### PR TITLE
Refs #25 — Phase 1 : renommage UI « Expérience » → « Activité »

### DIFF
--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -1,7 +1,7 @@
 class ExperiencesController < BaseController
   before_action :get_experience, only: [:show, :edit, :update, :destroy]
 
-  breadcrumb "Expériences", :experiences_path, match: :exact
+  breadcrumb "Activités", :experiences_path, match: :exact
 
   def index
     @experiences = ExperienceDecorator
@@ -20,7 +20,7 @@ class ExperiencesController < BaseController
     service = Experiences::CreateService.new
     if service.run(params)
       redirect_to experience_path(service.experience),
-                  notice: "Super! L'expérience '#{service.experience.name}' a été ajoutée."
+                  notice: "Super! L'activité '#{service.experience.name}' a été ajoutée."
     else
       @experience = service.experience
       set_error_flash(service.experience, service.error_message)
@@ -37,7 +37,7 @@ class ExperiencesController < BaseController
     )
     if service.run(params)
       redirect_to experience_path(service.experience),
-                  notice: "L'expérience a été mise à jour."
+                  notice: "L'activité a été mise à jour."
     else
       @experience = service.experience
       set_error_flash(service.experience, service.error_message)
@@ -50,7 +50,7 @@ class ExperiencesController < BaseController
   def destroy
     if @experience.soft_delete!(validate: false)
       redirect_to experiences_path,
-                  notice: "L'expérience '#{@experience.name}' a été supprimée."
+                  notice: "L'activité '#{@experience.name}' a été supprimée."
     else
       flash.now[:alert] = "Une erreur est survenue."
       render :show

--- a/app/views/experiences/_form.html.slim
+++ b/app/views/experiences/_form.html.slim
@@ -4,7 +4,7 @@
 
   .col-span-2.mb-4.space-y-6.sm:space-y-5
     = f.text_field :name,
-                   label: "Libellé de l'expérience *",
+                   label: "Libellé de l'activité *",
                    required: true,
                    class: "md:w-1/2 lg:w-2/3"
 
@@ -53,10 +53,10 @@
 
     .sm:space-y-1
       = f.label :description, 
-                "Présentation de l'expérience"
+                "Présentation de l'activité"
       = f.rich_text_area :description
 
-    = f.label :human_id, "Porteur·euse d'expérience"
+    = f.label :human_id, "Porteur·euse d'activité"
     = f.collection_radio_buttons :human_id, Human.all.order(:name), :id, :name, required: true do |radio_button|
       .flex.items-center
         = radio_button.radio_button

--- a/app/views/experiences/edit.html.slim
+++ b/app/views/experiences/edit.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_header do
   = render 'layouts/components/page_header',
-           title: "Mettre à jour l'expérience"
+           title: "Mettre à jour l'activité"
 
 = form_with model: @experience,
             url: experience_path(@experience),

--- a/app/views/experiences/index.html.slim
+++ b/app/views/experiences/index.html.slim
@@ -1,8 +1,8 @@
 - content_for :page_header do
   = render "layouts/components/page_header",
-           title: "Expériences",
+           title: "Activités",
            links: [ \
-             link_to("➕ Nouvelle expérience", new_experience_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2") \
+             link_to("➕ Nouvelle activité", new_experience_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2") \
            ]
 
 .overflow-x-auto.relative
@@ -11,7 +11,7 @@
       tr
         th.py-3.px-6[scope="col"]
         th.w-full.py-3.px-6[scope="col"]
-          | Expérience
+          | Activité
         th.py-3.px-6[scope="col"]
           | Porteur·euse
         th.w-36.py-3.px-6[scope="col"]

--- a/app/views/experiences/new.html.slim
+++ b/app/views/experiences/new.html.slim
@@ -1,6 +1,6 @@
 - content_for :page_header do
   = render 'layouts/components/page_header',
-           title: "Nouvelle expérience"
+           title: "Nouvelle activité"
 
 = form_with model: @experience,
             url: experiences_path,

--- a/app/views/experiences/show.html.slim
+++ b/app/views/experiences/show.html.slim
@@ -123,5 +123,5 @@
                 | Rôle
               dd.mt-3
                 span.inline-flex.items-center.rounded-full.bg-green-50.px-2.py-1.text-xs.font-medium.text-green-700.ring-1.ring-inset.ring-green-600/20
-                  | Porteur·euse d'expérience
+                  | Porteur·euse d'activité
                   

--- a/app/views/layouts/components/_navbar.html.slim
+++ b/app/views/layouts/components/_navbar.html.slim
@@ -189,7 +189,7 @@ nav.bg-white.shadow-sm.lg:px-6
                       events_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{(controller_name == 'events' || controller_name == 'events_categories') ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
           li
-            = link_to "Expériences",
+            = link_to "Activités",
                       experiences_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'experiences' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
           li

--- a/spec/requests/experiences_spec.rb
+++ b/spec/requests/experiences_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+# Phase 1 de l'epic #25 — renommage UI « Expérience » → « Activité »
+# (le modèle et les routes restent `Experience*` ; seuls les libellés changent)
+RSpec.describe "Experiences (UI « Activités »)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  describe "GET /experiences" do
+    it "affiche le libellé « Activités » et plus « Expériences »" do
+      get experiences_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Activités")
+      expect(response.body).not_to include("Expériences")
+      expect(response.body).to include("Nouvelle activité")
+    end
+  end
+
+  describe "GET /experiences/new" do
+    it "intitule la page « Nouvelle activité »" do
+      get new_experience_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Nouvelle activité")
+      # l'apostrophe est échappée en HTML (&#39;)
+      expect(response.body).to include("Libellé de l&#39;activité")
+      expect(response.body).to include("Porteur·euse d&#39;activité")
+      expect(response.body).not_to include("xpérience")
+    end
+  end
+end


### PR DESCRIPTION
Phase 1 de l'epic #25.

## Résumé
Renommage **cosmétique** des libellés affichés « Expérience » → « Activité ». Le modèle `Experience`, les tables, les routes et tous les identifiants de code (`experiences_path`, `@experience`, `reservation[experiences]`, etc.) restent **inchangés** — décision produit de l'epic pour éviter une migration risquée.

## Changements
- **Navbar** (`_navbar.html.slim`) : lien « Expériences » → « Activités ».
- **Vues admin `experiences/*`** : titres (index/new/edit), bouton « Nouvelle activité », en-tête de tableau « Activité », labels du formulaire (« Libellé de l'activité », « Présentation de l'activité », « Porteur·euse d'activité »), badge « Porteur·euse d'activité » sur la fiche.
- **`ExperiencesController`** : breadcrumb « Activités » + 3 messages flash (création / mise à jour / suppression).
- Ajout de `spec/requests/experiences_spec.rb` (vérifie que l'UI affiche « Activités » et ne contient plus « Expérience »).

## Périmètre / notes
- Les vues client (`public/activity_selections`, `public/reservations/activities`) et les mailers (`activity_selection_mailer`) **utilisaient déjà** « activité » — aucun changement nécessaire de ce côté (vérifié).
- Aucun changement de modèle/route/migration.

## Tests
- `bundle exec rspec` exécuté en local : **180 exemples, 0 échec, 21 pending** (baseline 178 + 2 nouvelles specs).
- Environnement de test monté dans le conteneur (Ruby 3.1.6 au lieu de 3.1.2 épinglé — le pin du `Gemfile` n'est pas modifié dans cette PR).

## Suite de l'epic
Phase 2 (comptes porteurs) et suivantes restent à faire lors des prochaines itérations. À cocher dans l'epic #25 une fois cette PR mergée.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD7tf4SbV2GaqQTRC5qRij)_