### PR TITLE
Suivi des consultations de la page de réservation client (#16)

### DIFF
--- a/app/controllers/public/bookings_controller.rb
+++ b/app/controllers/public/bookings_controller.rb
@@ -27,6 +27,7 @@ class Public::BookingsController < Public::BaseController
   def show
     @booking = Booking.find_by!(token: params[:token]).decorate
     @reservations_by_date = @booking.reservations.decorate.to_a.group_by { |r| r.date }
+    record_page_view(@booking) unless params[:donottrack].present?
   rescue ActiveRecord::RecordNotFound
     raise ActionController::RoutingError.new('Not Found')
   end
@@ -51,6 +52,18 @@ class Public::BookingsController < Public::BaseController
   end
 
   private
+
+  # Enregistre une consultation de la page web privée du client (issue #16).
+  # Le tracking ne doit jamais faire échouer l'affichage de la page.
+  def record_page_view(booking)
+    booking.object.page_views.create(
+      ip_address: request.remote_ip,
+      user_agent: request.user_agent
+    )
+  rescue StandardError => e
+    Sentry.capture_exception(e) if defined?(Sentry)
+    nil
+  end
 
   def booking_params
     params

--- a/app/decorators/booking_decorator.rb
+++ b/app/decorators/booking_decorator.rb
@@ -416,6 +416,31 @@ class BookingDecorator < ApplicationDecorator
   end
 
   def wifi_emoji
-    object.wifi? ? h.content_tag(:span, h.raw("👩‍💻 <a href='https://les4sources.notion.site/Appareils-WiFi-febf850431bc42b68e455574cc32e951?pvs=4' target='_blank' class='claudy-link'>Installer le WiFi</a>"), class: "text-sm") : nil 
+    object.wifi? ? h.content_tag(:span, h.raw("👩‍💻 <a href='https://les4sources.notion.site/Appareils-WiFi-febf850431bc42b68e455574cc32e951?pvs=4' target='_blank' class='claudy-link'>Installer le WiFi</a>"), class: "text-sm") : nil
+  end
+
+  # --- Statistiques de consultation de la page web client (issue #16) ---
+
+  def page_views_count
+    object.page_views.count
+  end
+
+  def page_viewed?
+    page_views_count.positive?
+  end
+
+  # Nombre de jours distincts où la page a été consultée.
+  def page_views_distinct_days
+    object.page_views.pluck(:created_at).map(&:to_date).uniq.count
+  end
+
+  def page_views_first_at
+    view = object.page_views.order(:created_at).first
+    view && l(view.created_at, format: :short)
+  end
+
+  def page_views_last_at
+    view = object.page_views.order(:created_at).last
+    view && l(view.created_at, format: :short)
   end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -57,6 +57,9 @@ class Booking < ApplicationRecord
 
   belongs_to :lodging, optional: true
 
+  # Consultations de la page web privée du client (issue #16).
+  has_many :page_views, class_name: "BookingPageView", dependent: :destroy
+
   # Read-side inverse of the Stay graph (tranche 1, strangler pattern). No FK on
   # bookings — the join lives in stay_items, preserving coexistence.
   has_one :stay_item, as: :bookable

--- a/app/models/booking_page_view.rb
+++ b/app/models/booking_page_view.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: booking_page_views
+#
+#  id         :bigint           not null, primary key
+#  booking_id :bigint           not null
+#  ip_address :string
+#  user_agent :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Une consultation de la page web privée (à jeton) d'une réservation par un·e
+# client·e. Sert à savoir si les client·es consultent leur page de réservation.
+# Voir issue #16.
+class BookingPageView < ApplicationRecord
+  belongs_to :booking
+end

--- a/app/views/bookings/show.html.slim
+++ b/app/views/bookings/show.html.slim
@@ -197,6 +197,8 @@ ul.mt-2.mb-4.grid.grid-cols-1.gap-5.sm:grid-cols-2.sm:gap-6.lg:grid-cols-4[role=
   .space-y-4
     = render partial: "bookings/show/details", locals: { booking: @booking }
 
+    = render partial: "bookings/show/page_views", locals: { booking: @booking }
+
     - if @booking.object.estimated_arrival.presence || @booking.object.departure_time.presence
       div
         dl.grid.grid-cols-2.gap-5

--- a/app/views/bookings/show/_page_views.html.slim
+++ b/app/views/bookings/show/_page_views.html.slim
@@ -1,0 +1,37 @@
+/ issue #16 — statistiques de consultation de la page web privée du client
+.overflow-hidden.bg-white.shadow.sm:rounded-lg
+  .px-4.py-5.sm:px-6
+    h3.text-lg.font-medium.leading-6.text-gray-900
+      | Consultations de la page client
+    p.mt-1.text-sm.text-gray-500
+      | Le client a-t-il ouvert sa page web ?
+  .border-t.border-gray-200.px-4.py-5.sm:px-6
+    - if booking.page_viewed?
+      dl.grid.grid-cols-2.gap-4
+        div
+          dt.text-sm.font-medium.text-gray-500
+            | Vues
+          dd.mt-1.text-3xl.font-semibold.tracking-tight.text-gray-900
+            = booking.page_views_count
+        div
+          dt.text-sm.font-medium.text-gray-500
+            | Jours distincts
+          dd.mt-1.text-3xl.font-semibold.tracking-tight.text-gray-900
+            = booking.page_views_distinct_days
+        div
+          dt.text-sm.font-medium.text-gray-500
+            | Première vue
+          dd.mt-1.text-sm.text-gray-900
+            = booking.page_views_first_at
+        div
+          dt.text-sm.font-medium.text-gray-500
+            | Dernière vue
+          dd.mt-1.text-sm.text-gray-900
+            = booking.page_views_last_at
+    - else
+      p.text-sm.text-gray-400.italic
+        | Aucune consultation enregistrée pour l'instant.
+    p.mt-4.text-xs.text-gray-400
+      | Astuce : ajoutez
+      code.mx-1.rounded.bg-gray-100.px-1.py-0.5 ?donottrack
+      | à l'URL pour consulter la page sans être comptabilisé.

--- a/app/views/public/bookings/show.html.slim
+++ b/app/views/public/bookings/show.html.slim
@@ -1,5 +1,18 @@
 - content_for :meta_title, "Ma réservation aux 4 Sources"
 
+/ issue #16 — quand l'équipe consulte la page avec ?donottrack (pour ne pas
+/ fausser les stats), on retire le paramètre de l'URL côté client (sans recharger)
+/ afin qu'il ne soit pas copié-collé et partagé par erreur.
+- if params[:donottrack].present?
+  javascript:
+    (function () {
+      try {
+        var url = new URL(window.location.href);
+        url.searchParams.delete("donottrack");
+        window.history.replaceState({}, document.title, url.toString());
+      } catch (e) {}
+    })();
+
 - content_for :page_header do
   = render 'layouts/public/components/page_header',
            title: @booking.confirmed? ? "Votre séjour aux 4 Sources" : "Votre demande de réservation"

--- a/db/migrate/20260603120000_create_booking_page_views.rb
+++ b/db/migrate/20260603120000_create_booking_page_views.rb
@@ -1,0 +1,11 @@
+class CreateBookingPageViews < ActiveRecord::Migration[7.0]
+  def change
+    create_table :booking_page_views do |t|
+      t.references :booking, null: false, foreign_key: true, index: true
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_03_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -85,6 +85,15 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
     t.index ["author_id"], name: "index_agenda_items_on_author_id"
     t.index ["gathering_id", "position"], name: "index_agenda_items_on_gathering_id_and_position"
     t.index ["gathering_id"], name: "index_agenda_items_on_gathering_id"
+  end
+
+  create_table "booking_page_views", force: :cascade do |t|
+    t.bigint "booking_id", null: false
+    t.string "ip_address"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["booking_id"], name: "index_booking_page_views_on_booking_id"
   end
 
   create_table "bookings", force: :cascade do |t|
@@ -634,6 +643,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "agenda_items", "gatherings"
   add_foreign_key "agenda_items", "humans", column: "author_id"
+  add_foreign_key "booking_page_views", "bookings"
   add_foreign_key "bookings", "lodgings"
   add_foreign_key "bundles", "projects"
   add_foreign_key "bundles", "teams"

--- a/spec/models/booking_page_view_spec.rb
+++ b/spec/models/booking_page_view_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe BookingPageView, type: :model do
+  let(:booking) do
+    Booking.create!(firstname: "Test", lastname: "Client", from_date: Date.today,
+                    to_date: Date.today + 2, adults: 2, token: "tok-model")
+  end
+
+  it "appartient à une réservation" do
+    view = booking.page_views.create!(ip_address: "1.2.3.4", user_agent: "RSpec")
+    expect(view.booking).to eq(booking)
+    expect(booking.page_views).to include(view)
+  end
+
+  it "est supprimée avec sa réservation (dependent: :destroy)" do
+    booking.page_views.create!
+    expect { booking.destroy }.to change(BookingPageView, :count).by(-1)
+  end
+end

--- a/spec/requests/public/booking_page_views_spec.rb
+++ b/spec/requests/public/booking_page_views_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+# issue #16 — suivi des consultations de la page web privée du client.
+RSpec.describe "Suivi des consultations de la page de réservation", type: :request do
+  let!(:booking) do
+    Booking.create!(firstname: "Vue", lastname: "Client", from_date: Date.today,
+                    to_date: Date.today + 2, adults: 2, children: 0, babies: 0,
+                    status: "confirmed", price_cents: 0, token: "tok-views-123")
+  end
+
+  describe "GET /public/reservation/:token" do
+    it "enregistre une consultation" do
+      expect {
+        get public_booking_path(booking.token)
+      }.to change { booking.page_views.count }.by(1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "n'enregistre rien avec ?donottrack et nettoie l'URL côté client" do
+      expect {
+        get public_booking_path(booking.token), params: { donottrack: "1" }
+      }.not_to change { booking.page_views.count }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("history.replaceState")
+    end
+
+    it "renvoie 404 pour un jeton inconnu sans rien enregistrer" do
+      expect {
+        get public_booking_path("jeton-inexistant")
+      }.not_to change(BookingPageView, :count)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /bookings/:id (admin)" do
+    include Devise::Test::IntegrationHelpers
+    let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+    before { sign_in user }
+
+    it "affiche la carte des statistiques de consultation" do
+      booking.page_views.create!(ip_address: "1.1.1.1", user_agent: "RSpec")
+      get booking_path(booking)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Consultations de la page client")
+    end
+  end
+end


### PR DESCRIPTION
Closes #16

## Résumé
Permet de savoir si un·e client·e consulte sa **page web privée de réservation** (`/public/reservation/:token`) et affiche des statistiques simples sur la page admin de la réservation.

## Changements
- **Modèle `BookingPageView`** (`booking`, `ip_address`, `user_agent`, timestamps) + migration `create_booking_page_views`.
- **`Booking`** : `has_many :page_views, dependent: :destroy`.
- **`Public::BookingsController#show`** : enregistre une consultation à chaque affichage, **sauf si `?donottrack`** est présent. L'enregistrement est encapsulé dans un `rescue` (capture Sentry) pour ne **jamais** faire échouer l'affichage de la page.
- **Anti-pollution `?donottrack`** : quand le paramètre est présent (l'équipe consulte sans être comptée), un petit script retire `donottrack` de l'URL via `history.replaceState` (sans rechargement), pour éviter qu'une URL avec le paramètre soit copiée-collée et partagée — conformément à la demande de l'issue.
- **Stats admin** : nouvelle carte « Consultations de la page client » dans le sidebar de `bookings#show` (nombre de vues, jours distincts, première / dernière vue), alimentée par des méthodes ajoutées à `BookingDecorator`.

## Périmètre / choix
- Cible la page de réservation hébergement (`public/bookings#show`), qui correspond à la « booking page » de l'issue. Les pages **espaces** (`public/space_bookings#show`) et **séjours** (`mon-sejour/:token`) ne sont pas trackées ici — à faire en suivi si souhaité (le modèle est volontairement spécifique à `Booking` ; on pourra le généraliser).
- Une vue = une requête `GET` (pas de dédoublonnage des rechargements rapides), conforme au « basic stats » demandé.

## Tests
- Nouvelles specs : `spec/models/booking_page_view_spec.rb`, `spec/requests/public/booking_page_views_spec.rb` (enregistrement, `?donottrack`, 404 jeton inconnu, carte admin).
- `bundle exec rspec` en local : **184 exemples, 0 échec, 21 pending** (baseline 178 + 6).

## À valider / notes
- La vue publique `public/bookings/show` exige `ENV['PHONE_NUMBER']` (déjà le cas en prod) ; pensez à l'avoir en environnement de test local.
- Pas d'anonymisation/rétention des `ip_address` / `user_agent` mise en place (RGPD) — à décider si nécessaire.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD7tf4SbV2GaqQTRC5qRij)_