### PR TITLE
Fondation lien direct Payment → Stay (refs #26)

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -18,6 +18,9 @@ class Payment < ApplicationRecord
   self.implicit_order_column = :created_at
 
   belongs_to :booking
+  # Lien direct vers le séjour (issue #26, fondation). Optionnel le temps de la
+  # transition : `booking` reste l'ancre obligatoire, `stay` est dénormalisé.
+  belongs_to :stay, optional: true
 
   monetize :amount_cents, allow_nil: false
 

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -47,13 +47,16 @@ class Stay < ApplicationRecord
     stay_items.includes(:bookable).map(&:bookable).compact
   end
 
-  # Read-derived payments: walk through the Booking items only (SpaceBooking has
-  # no Payment association — its money lives in *_amount_cents columns). Schema
-  # of `payments` is untouched (decision §11.6).
+  # Paiements du séjour. Pendant la transition (issue #26), on unit deux sources :
+  #   - le lien direct dénormalisé `payments.stay_id` (nouveau, posé par le
+  #     Reservations::Builder et par le backfill de migration) ;
+  #   - le lien historique via les items Booking (SpaceBooking n'a pas de Payment
+  #     direct — son montant vit dans les colonnes *_amount_cents).
+  # L'union garantit l'absence de régression tant que tous les Payment ne sont
+  # pas encore reliés directement au Stay.
   def payments
     booking_ids = stay_items.where(bookable_type: "Booking").pluck(:bookable_id)
-    return Payment.none if booking_ids.empty?
-    Payment.where(booking_id: booking_ids)
+    Payment.where(stay_id: id).or(Payment.where(booking_id: booking_ids))
   end
 
   # Recompute aggregate dates / amount from the attached items (min arrival,

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -55,6 +55,7 @@ module Reservations
         @stay.stay_items.create!(bookable: @booking)
         @payment = Payment.create!(
           booking: @booking,
+          stay: @stay,
           amount_cents: quote.deposit_cents,
           status: "pending",
           payment_method: "card"

--- a/db/migrate/20260603130000_add_stay_to_payments.rb
+++ b/db/migrate/20260603130000_add_stay_to_payments.rb
@@ -1,0 +1,29 @@
+class AddStayToPayments < ActiveRecord::Migration[7.0]
+  # Étape additive et réversible (issue #26, fondation) : on dénormalise un lien
+  # direct Payment -> Stay, sans toucher à `booking_id` (qui reste NOT NULL) ni
+  # supprimer le Booking « ancre ». Le retrait du Booking fantôme et le passage
+  # de `booking_id` en nullable feront l'objet d'un travail ultérieur (cf. issue).
+  def up
+    add_column :payments, :stay_id, :bigint
+    add_index :payments, :stay_id
+    add_foreign_key :payments, :stays, column: :stay_id
+
+    # Backfill : chaque Payment hérite du Stay de son Booking via stay_items
+    # (item vivant uniquement). Robuste, indépendant des scopes applicatifs.
+    execute(<<~SQL)
+      UPDATE payments
+         SET stay_id = si.stay_id
+        FROM stay_items si
+       WHERE si.bookable_type = 'Booking'
+         AND si.bookable_id   = payments.booking_id
+         AND si.deleted_at IS NULL
+         AND payments.stay_id IS NULL
+    SQL
+  end
+
+  def down
+    remove_foreign_key :payments, column: :stay_id
+    remove_index :payments, :stay_id
+    remove_column :payments, :stay_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_03_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -85,6 +85,15 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
     t.index ["author_id"], name: "index_agenda_items_on_author_id"
     t.index ["gathering_id", "position"], name: "index_agenda_items_on_gathering_id_and_position"
     t.index ["gathering_id"], name: "index_agenda_items_on_gathering_id"
+  end
+
+  create_table "booking_page_views", force: :cascade do |t|
+    t.bigint "booking_id", null: false
+    t.string "ip_address"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["booking_id"], name: "index_booking_page_views_on_booking_id"
   end
 
   create_table "bookings", force: :cascade do |t|
@@ -383,8 +392,10 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
     t.integer "amount_cents", default: 0, null: false
     t.string "stripe_checkout_session_id"
     t.string "stripe_payment_intent_id"
+    t.bigint "stay_id"
     t.index ["booking_id"], name: "index_payments_on_booking_id"
     t.index ["id"], name: "index_payments_on_id", unique: true
+    t.index ["stay_id"], name: "index_payments_on_stay_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -634,6 +645,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "agenda_items", "gatherings"
   add_foreign_key "agenda_items", "humans", column: "author_id"
+  add_foreign_key "booking_page_views", "bookings"
   add_foreign_key "bookings", "lodgings"
   add_foreign_key "bundles", "projects"
   add_foreign_key "bundles", "teams"
@@ -656,6 +668,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_31_205355) do
   add_foreign_key "lodging_rooms", "lodgings"
   add_foreign_key "lodging_rooms", "rooms"
   add_foreign_key "payments", "bookings"
+  add_foreign_key "payments", "stays"
   add_foreign_key "projects", "humans"
   add_foreign_key "reservations", "bookings"
   add_foreign_key "reservations", "rooms"

--- a/lib/tasks/payments.rake
+++ b/lib/tasks/payments.rake
@@ -19,4 +19,32 @@ namespace :payments do
     end
     puts "Done!"
   end
+
+  desc "Vérifie/répare le lien direct Payment -> Stay (issue #26)"
+  task verify_stay_links: :environment do
+    scope         = Payment.unscoped
+    total         = scope.count
+    with_stay     = scope.where.not(stay_id: nil).count
+    without_stay  = scope.where(stay_id: nil)
+
+    # Parmi ceux sans stay_id, lesquels POURRAIENT être reliés via leur Booking ?
+    linkable = without_stay.to_a.select do |payment|
+      payment.booking&.stay&.id.present?
+    end
+
+    puts "Payments (deleted inclus) : #{total}"
+    puts "  avec stay_id            : #{with_stay}"
+    puts "  sans stay_id            : #{without_stay.count}"
+    puts "  dont reliables via Booking (backfill possible) : #{linkable.size}"
+
+    if ENV["FIX"] == "1" && linkable.any?
+      linkable.each { |p| p.update_column(:stay_id, p.booking.stay.id) }
+      puts "→ #{linkable.size} payment(s) reliés (FIX=1)."
+    elsif linkable.any?
+      puts "→ Relancez avec FIX=1 pour backfiller ces #{linkable.size} payment(s)."
+    end
+
+    orphans = without_stay.count - linkable.size
+    puts "Payments sans stay_id ni Booking->Stay (legacy sans séjour) : #{orphans}"
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -16,5 +16,25 @@
 require 'rails_helper'
 
 RSpec.describe Payment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:customer) { Customer.create!(email: "pay@example.com", customer_type: "individual") }
+  let(:booking) do
+    Booking.create!(firstname: "Pay", from_date: Date.today, to_date: Date.today + 2,
+                    adults: 1, status: "pending", price_cents: 10_000)
+  end
+
+  it "exige un booking (ancre obligatoire)" do
+    payment = Payment.new(amount_cents: 5_000, payment_method: "card")
+    expect(payment).not_to be_valid
+    expect(payment.errors[:booking]).to be_present
+  end
+
+  it "accepte un stay optionnel (issue #26)" do
+    payment = Payment.create!(booking: booking, amount_cents: 5_000, status: "pending",
+                              payment_method: "card")
+    expect(payment.stay).to be_nil
+
+    stay = Stay.create!(customer: customer)
+    payment.update!(stay: stay)
+    expect(payment.reload.stay).to eq(stay)
+  end
 end

--- a/spec/models/stay_spec.rb
+++ b/spec/models/stay_spec.rb
@@ -36,6 +36,26 @@ RSpec.describe Stay, type: :model do
 
       expect(stay.payments).to be_empty
     end
+
+    # issue #26 — lien direct dénormalisé Payment -> Stay
+    it "returns payments linked directly via stay_id" do
+      stay = Stay.create!(customer: customer)
+      b = booking(from: Date.new(2026, 7, 1), to: Date.new(2026, 7, 3))
+      payment = Payment.create!(booking: b, stay: stay, amount_cents: 5_000,
+                                status: "pending", payment_method: "card")
+
+      expect(stay.payments).to contain_exactly(payment)
+    end
+
+    it "n'duplique pas un paiement relié à la fois via stay_id et via son Booking" do
+      stay = Stay.create!(customer: customer)
+      b = booking(from: Date.new(2026, 7, 1), to: Date.new(2026, 7, 3))
+      stay.stay_items.create!(bookable: b)
+      payment = Payment.create!(booking: b, stay: stay, amount_cents: 5_000,
+                                status: "paid", payment_method: "card")
+
+      expect(stay.payments).to contain_exactly(payment)
+    end
   end
 
   describe "#recompute_aggregates!" do

--- a/spec/services/reservations/builder_spec.rb
+++ b/spec/services/reservations/builder_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe Reservations::Builder do
       expect(builder.payment.status).to eq("pending")
       # Hulotte 2 nuits = 485 + 260 = 745 € ; acompte 50 % = 372,50 €.
       expect(builder.payment.amount_cents).to eq(37_250)
+      # issue #26 : le Payment porte aussi le lien direct vers le Stay.
+      expect(builder.payment.stay).to eq(builder.stay)
+      expect(builder.stay.payments).to include(builder.payment)
     end
   end
 


### PR DESCRIPTION
Refs #26 — **première étape, additive et réversible** (ne ferme pas l'issue).

## Pourquoi pas tout l'epic d'un coup
Le `Reservations::Builder` crée aujourd'hui un `Booking` « ancre » **précisément** pour réutiliser toute l'infra Stripe/webhook (URLs `success/cancel`, `payment.booking.set_payment_status`, redirections client). Retirer ce Booking et passer `booking_id` en nullable casserait le flux Checkout tant que le paiement n'est pas rendu « Stay-aware » — ce qui demande des décisions produit (cf. commentaire posté sur #26). Cette PR pose donc **uniquement la fondation sûre**, sans aucun changement de comportement Stripe.

## Changements
- **Migration `add_stay_to_payments`** : `payments.stay_id` (nullable) + index + FK vers `stays`, puis **backfill** SQL via `stay_items` (items `Booking` vivants). `booking_id` reste `NOT NULL`.
- **`Payment`** : `belongs_to :stay, optional: true` (l'ancre `booking` reste obligatoire).
- **`Reservations::Builder`** : renseigne `stay:` sur le `Payment` créé (additif).
- **`Stay#payments`** : unit désormais le lien direct (`stay_id`) **et** le lien historique via `Booking`, garantissant zéro régression pendant la transition (les paiements legacy non encore backfillés restent trouvés).
- **Rake `payments:verify_stay_links`** : audite le taux de liaison ; `FIX=1` backfille les paiements reliables via leur Booking.

## Reste à faire (suivi #26, hors de cette PR)
1. Rendre le flux paiement « Stay-aware » (URLs success/cancel, statut de paiement, redirections) pour les séjours B2C.
2. Supprimer la création du `Booking` fantôme dans le `Builder`.
3. `change_column_null :payments, :booking_id, true`.

## Tests
- Specs ajoutées/étendues : `payment_spec` (stay optionnel), `stay_spec` (lien direct + union sans doublon), `builder_spec` (le Payment porte le Stay).
- `bundle exec rspec` en local : **181 exemples, 0 échec**.
- Backfill : exécuté sur la DB de test (vide) ; **non testé sur données de prod** — à valider via `rake payments:verify_stay_links` après déploiement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD7tf4SbV2GaqQTRC5qRij)_