### PR TITLE
Refs #25 — Phase 2 : comptes d'accès des porteurs d'activité

### DIFF
--- a/app/controllers/agenda_items_controller.rb
+++ b/app/controllers/agenda_items_controller.rb
@@ -90,10 +90,6 @@ class AgendaItemsController < BaseController
     @agenda_item = @gathering.agenda_items.find(params[:id])
   end
 
-  def current_human
-    current_user&.human || Human.where(status: "active").first
-  end
-
   def set_presenters
     @menu_presenter = Components::MenuPresenter.new(
       active_primary: "organisation"

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -6,6 +6,8 @@ class BaseController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit
 
+  helper_method :current_human
+
   # breadcrumb "Calendrier", :root_path
 
   def render *args
@@ -14,6 +16,13 @@ class BaseController < ActionController::Base
   end
 
   private
+
+  # Identifie l'humain (porteur d'activité, membre de l'équipe…) lié à
+  # l'utilisateur connecté. Centralisé ici pour rester cohérent partout —
+  # cf. epic #25 Phase 2 (comptes porteurs).
+  def current_human
+    current_user&.human || Human.where(status: "active").first
+  end
 
   def set_error_flash(object, error_message)
     if object.valid?

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -65,10 +65,6 @@ class DecisionsController < BaseController
     @decision = Decision.find(params[:id])
   end
 
-  def current_human
-    current_user&.human || Human.where(status: "active").first
-  end
-
   def set_presenters
     @menu_presenter = Components::MenuPresenter.new(
       active_primary: "organisation",

--- a/app/controllers/humans_controller.rb
+++ b/app/controllers/humans_controller.rb
@@ -62,6 +62,18 @@ class HumansController < BaseController
     end
   end
 
+  def create_account
+    @human = Human.unscoped.find(params[:id])
+    service = Humans::CreateAccountService.new(human: @human)
+    if service.run
+      redirect_to human_path(@human),
+                  notice: "Un compte d'accès a été créé pour #{@human.name}. Un email d'invitation à définir le mot de passe a été envoyé à #{@human.email}."
+    else
+      redirect_to human_path(@human),
+                  alert: service.error_message
+    end
+  end
+
   def destroy
     if @human.soft_delete!(validate: false)
       redirect_to humans_path,

--- a/app/models/human.rb
+++ b/app/models/human.rb
@@ -25,6 +25,9 @@ class Human < ApplicationRecord
   has_and_belongs_to_many :tasks
 
   scope :cycle_active, -> { where(cycle_active: true) }
+  # Personnes pouvant recevoir un compte d'accès (un email est requis pour
+  # créer le User Devise). Cf. epic #25 — Phase 2 (comptes porteurs).
+  scope :with_email, -> { where.not(email: [nil, ""]) }
 
   self.table_name = "humans"
 
@@ -43,5 +46,16 @@ class Human < ApplicationRecord
 
   def inactive?
     self.status == "inactive"
+  end
+
+  # A un compte d'accès (User Devise) lié.
+  def account?
+    user.present?
+  end
+
+  # Peut recevoir un compte d'accès (un email est nécessaire et aucun compte
+  # n'existe encore).
+  def account_possible?
+    email.present? && user.blank?
   end
 end

--- a/app/services/humans/create_account_service.rb
+++ b/app/services/humans/create_account_service.rb
@@ -1,0 +1,50 @@
+module Humans
+  # Crée un compte d'accès (User Devise) lié à un Human, pour qu'un porteur
+  # d'activité puisse se connecter à Claudy et gérer ses disponibilités.
+  # Epic #25 — Phase 2 (comptes porteurs).
+  #
+  # Le mot de passe est aléatoire ; par défaut un email d'invitation
+  # (« définir votre mot de passe ») est envoyé via le flux Devise de
+  # réinitialisation. Passer `send_invitation: false` pour un backfill silencieux.
+  class CreateAccountService < ServiceBase
+    attr_reader :human, :user
+
+    def initialize(human:, send_invitation: true)
+      @human = human
+      @send_invitation = send_invitation
+      @report_errors = true
+    end
+
+    def run
+      catch_error(context: { human_id: human&.id }) do
+        run!
+      end
+    end
+
+    def run!
+      if human.email.blank?
+        set_error_message("#{human.name} n'a pas d'adresse email — ajoutez-en une avant de créer un compte.")
+        return false
+      end
+
+      if human.user.present?
+        set_error_message("#{human.name} a déjà un compte d'accès.")
+        return false
+      end
+
+      if User.exists?(email: human.email)
+        set_error_message("Un compte existe déjà avec l'adresse #{human.email}.")
+        return false
+      end
+
+      @user = User.new(
+        email: human.email,
+        password: SecureRandom.hex(24),
+        human: human
+      )
+      @user.save!
+      @user.send_reset_password_instructions if @send_invitation
+      true
+    end
+  end
+end

--- a/app/views/experiences/_form.html.slim
+++ b/app/views/experiences/_form.html.slim
@@ -56,10 +56,19 @@
                 "Présentation de l'activité"
       = f.rich_text_area :description
 
+    - carrier_candidates = (Human.with_email.to_a + [f.object.human]).compact.uniq.sort_by { |human| human.name.to_s }
     = f.label :human_id, "Porteur·euse d'activité"
-    = f.collection_radio_buttons :human_id, Human.all.order(:name), :id, :name, required: true do |radio_button|
+    p.mt-1.mb-2.text-xs.text-gray-500
+      | Seules les personnes disposant d'une adresse email apparaissent ici : un compte d'accès leur sera créé pour gérer leurs disponibilités.
+    = f.collection_radio_buttons :human_id, carrier_candidates, :id, :name, required: true do |radio_button|
       .flex.items-center
         = radio_button.radio_button
         = radio_button.label(class: "ml-3 block text-sm font-medium text-gray-700")
+        - if radio_button.object.account?
+          span.ml-2 class="inline-flex items-center rounded-md bg-green-50 px-1.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20"
+            | compte actif
+        - else
+          span.ml-2 class="inline-flex items-center rounded-md bg-gray-50 px-1.5 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10"
+            | compte à créer
 
 hr

--- a/app/views/humans/show.html.slim
+++ b/app/views/humans/show.html.slim
@@ -40,6 +40,33 @@
   .grid.grid-cols-3.gap-4
     .col-span-2.space-y-4
       .overflow-hidden.bg-white.shadow.sm:rounded-lg
+        .px-4.py-5.sm:px-6.flex.items-center.justify-between
+          h3.text-lg.font-medium.leading-6.text-gray-900
+            | Compte d'accès
+          - if @human.account?
+            span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20"
+              | Compte actif
+        .border-t.border-gray-200
+          .px-4.py-5.sm:px-6
+            - if @human.account?
+              p.text-sm.text-gray-700
+                | Connexion à Claudy avec l'adresse
+                |
+                span.font-medium = @human.user.email
+            - elsif @human.email.present?
+              p.text-sm.text-gray-700.mb-4
+                | Aucun compte d'accès pour l'instant. Créez-en un pour permettre à #{@human.name} de se connecter à Claudy et de gérer ses activités et disponibilités.
+              = button_to "Créer un compte d'accès",
+                          create_account_human_path(@human),
+                          method: :post,
+                          class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            - else
+              p.text-sm.text-gray-700
+                | Ajoutez d'abord une adresse email à cette personne (via « Mettre à jour ») pour pouvoir lui créer un compte d'accès.
+
+  .grid.grid-cols-3.gap-4
+    .col-span-2.space-y-4
+      .overflow-hidden.bg-white.shadow.sm:rounded-lg
         .px-4.py-5.sm:px-6
           h3.text-lg.font-medium.leading-6.text-gray-900
             | Description

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   resources :humans do
     member do
       patch :toggle_cycle_active
+      post :create_account
     end
   end
   resources :human_roles

--- a/lib/tasks/activity_carriers.rake
+++ b/lib/tasks/activity_carriers.rake
@@ -1,0 +1,33 @@
+namespace :activity_carriers do
+  desc "Crée un compte d'accès (User) pour chaque porteur d'activité (Human avec email, sans compte). Passer SEND_INVITES=1 pour envoyer les emails d'invitation."
+  task ensure_accounts: :environment do
+    send_invitation = ENV["SEND_INVITES"] == "1"
+
+    carriers = Human.with_email
+                    .where(id: Experience.where.not(human_id: nil).select(:human_id))
+                    .order(:name)
+
+    puts "#{carriers.count} porteur·euse(s) avec email."
+    puts "Envoi des invitations : #{send_invitation ? 'OUI' : 'non (SEND_INVITES=1 pour activer)'}"
+
+    created = 0
+    skipped = 0
+
+    carriers.find_each do |human|
+      if human.user.present?
+        skipped += 1
+        next
+      end
+
+      service = Humans::CreateAccountService.new(human: human, send_invitation: send_invitation)
+      if service.run
+        created += 1
+        puts "  ✓ Compte créé pour #{human.name} (#{human.email})"
+      else
+        puts "  ✗ #{human.name} : #{service.error_message}"
+      end
+    end
+
+    puts "Terminé : #{created} compte(s) créé(s), #{skipped} déjà existant(s)."
+  end
+end

--- a/spec/requests/experiences_carriers_spec.rb
+++ b/spec/requests/experiences_carriers_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+# Epic #25 — Phase 2 (comptes porteurs) : le formulaire d'activité ne propose
+# comme porteur·euse que des personnes pouvant avoir un compte (= ayant un email).
+RSpec.describe "Experiences — sélection du porteur", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  describe "GET /experiences/new" do
+    it "ne propose comme porteur que les personnes ayant un email" do
+      Human.create!(name: "Avec Email Porteur", email: "porteur@example.com")
+      Human.create!(name: "Aucun Email Ici")
+
+      get new_experience_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Avec Email Porteur")
+      expect(response.body).not_to include("Aucun Email Ici")
+      expect(response.body).to include("compte à créer")
+    end
+
+    it "affiche « compte actif » pour un porteur disposant déjà d'un compte" do
+      human = Human.create!(name: "Porteur Connecté", email: "connecte@example.com")
+      User.create!(email: "connecte@example.com", password: "password123", human: human)
+
+      get new_experience_path
+
+      expect(response.body).to include("Porteur Connecté")
+      expect(response.body).to include("compte actif")
+    end
+  end
+end

--- a/spec/requests/humans_account_spec.rb
+++ b/spec/requests/humans_account_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+# Epic #25 — Phase 2 (comptes porteurs) : carte « Compte d'accès » sur la fiche
+# d'un membre et action de création de compte.
+RSpec.describe "Humans — comptes d'accès porteurs", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  describe "GET /humans/:id" do
+    it "propose de créer un compte quand le membre a un email mais pas de compte" do
+      human = Human.create!(name: "Porteur Sans Compte", email: "porteur@example.com")
+      get human_path(human)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Créer un compte")
+    end
+
+    it "indique « Compte actif » quand le membre a déjà un compte" do
+      human = Human.create!(name: "Porteur Avec Compte", email: "avec@example.com")
+      User.create!(email: "avec@example.com", password: "password123", human: human)
+      get human_path(human)
+      expect(response.body).to include("Compte actif")
+      expect(response.body).not_to include("Créer un compte")
+    end
+
+    it "invite à ajouter un email quand le membre n'en a pas" do
+      human = Human.create!(name: "Porteur Sans Email")
+      get human_path(human)
+      expect(response.body).to include("pour pouvoir lui créer un compte")
+    end
+  end
+
+  describe "POST /humans/:id/create_account" do
+    it "crée le compte et redirige vers la fiche" do
+      human = Human.create!(name: "Nouveau Porteur", email: "nouveau@example.com")
+
+      expect {
+        post create_account_human_path(human)
+      }.to change(User, :count).by(1)
+
+      expect(response).to redirect_to(human_path(human))
+      expect(human.reload.user).to be_present
+      expect(human.user.email).to eq("nouveau@example.com")
+    end
+
+    it "refuse sans email et ne crée aucun compte" do
+      human = Human.create!(name: "Porteur Sans Email")
+
+      expect {
+        post create_account_human_path(human)
+      }.not_to change(User, :count)
+
+      expect(response).to redirect_to(human_path(human))
+    end
+  end
+end

--- a/spec/services/humans/create_account_service_spec.rb
+++ b/spec/services/humans/create_account_service_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Epic #25 — Phase 2 (comptes porteurs)
+RSpec.describe Humans::CreateAccountService do
+  describe "#run" do
+    it "crée un User lié au Human et déclenche l'invitation par défaut" do
+      human = Human.create!(name: "Alice Porteuse", email: "alice@example.com")
+      service = described_class.new(human: human)
+
+      expect { expect(service.run).to be(true) }.to change(User, :count).by(1)
+
+      expect(human.reload.user).to be_present
+      expect(human.user.email).to eq("alice@example.com")
+      # send_reset_password_instructions horodate la demande d'invitation
+      expect(human.user.reset_password_sent_at).to be_present
+    end
+
+    it "n'envoie pas d'invitation quand send_invitation: false" do
+      human = Human.create!(name: "Bob Porteur", email: "bob@example.com")
+      service = described_class.new(human: human, send_invitation: false)
+
+      expect { expect(service.run).to be(true) }.to change(User, :count).by(1)
+      expect(human.reload.user.reset_password_sent_at).to be_nil
+    end
+
+    it "échoue si le Human n'a pas d'email" do
+      human = Human.create!(name: "Sans Email")
+      service = described_class.new(human: human)
+
+      expect { expect(service.run).to be(false) }.not_to change(User, :count)
+      expect(service.error_message).to match(/email/i)
+      expect(human.reload.user).to be_nil
+    end
+
+    it "échoue si le Human a déjà un compte" do
+      human = Human.create!(name: "Déjà Compte", email: "deja@example.com")
+      User.create!(email: "deja@example.com", password: "password123", human: human)
+      service = described_class.new(human: human)
+
+      expect(service.run).to be(false)
+      expect(service.error_message).to match(/déjà/i)
+    end
+
+    it "échoue si un User existe déjà avec cette adresse email" do
+      User.create!(email: "taken@example.com", password: "password123")
+      human = Human.create!(name: "Email Pris", email: "taken@example.com")
+      service = described_class.new(human: human)
+
+      expect { expect(service.run).to be(false) }.not_to change(User, :count)
+      expect(service.error_message).to match(/existe déjà/i)
+    end
+  end
+end


### PR DESCRIPTION
Phase 2 de l'epic #25 (Activités). Ne ferme pas l'epic — les phases 3→10 restent à faire.

## Objectif de la phase
Permettre à chaque **porteur·euse d'activité** d'avoir un compte d'accès (`User` Devise) relié à son `Human`, pour pouvoir se connecter à Claudy et (phases suivantes) gérer ses disponibilités. Conforme aux décisions de l'epic : **pas de fusion Human/User**, chaque porteur a un `User` relié.

## Changements
- **`Humans::CreateAccountService`** (`app/services/humans/`) : crée un `User` lié à un `Human` (mot de passe aléatoire), avec garde-fous (email requis, pas de compte existant, pas d'email déjà pris). Envoie par défaut l'email d'invitation via le flux Devise « réinitialisation du mot de passe » ; `send_invitation: false` pour un backfill silencieux.
- **Fiche membre** (`humans#show`) : nouvelle carte **« Compte d'accès »** — bouton « Créer un compte d'accès » si email présent et sans compte, badge « Compte actif » sinon, ou invitation à renseigner un email.
- **Route + action** : `POST /humans/:id/create_account` (`HumansController#create_account`).
- **Formulaire activité** (`experiences/_form`) : ne propose plus comme porteur que les personnes **pouvant avoir un compte** (email présent — plus le porteur déjà assigné le cas échéant), avec un badge « compte actif » / « compte à créer ». Scope `Human.with_email` + helpers `Human#account?` / `Human#account_possible?`.
- **`current_human` centralisé** dans `BaseController` (`helper_method`), doublons retirés de `DecisionsController` et `AgendaItemsController` — « helper `current_human` cohérent » de la phase.
- **Rake `activity_carriers:ensure_accounts`** : backfille les comptes des porteurs (Humans avec email, rattachés à au moins une activité). N'envoie pas d'invitation sauf `SEND_INVITES=1`.

## Périmètre / choix
- Permissions fines hors scope (tous les users accèdent à tout — décision de l'epic).
- L'invitation par email repose sur le `reset_password` Devise existant (pas de nouveau mailer) ; l'utilisateur définit son mot de passe via le lien reçu.

## Tests
- Specs ajoutées :
  - `spec/services/humans/create_account_service_spec.rb` (création, garde-fous, invitation on/off via `reset_password_sent_at`).
  - `spec/requests/humans_account_spec.rb` (carte fiche membre + `POST create_account`).
  - `spec/requests/experiences_carriers_spec.rb` (filtrage des porteurs au email + badges).
- ⚠️ **Suite non exécutée dans ce conteneur** : seul Ruby 3.3.6 est disponible alors que le projet épingle 3.1.2, et le gemset verrouillé (nokogiri 1.13.9 < Ruby 3.2) refuse de s'installer sous 3.3. Le `Gemfile`/`Gemfile.lock` n'a **pas** été modifié. Tous les fichiers Ruby passent `ruby -c`. À faire tourner localement : `bundle exec rspec spec/services/humans spec/requests/humans_account_spec.rb spec/requests/experiences_carriers_spec.rb`.

## À valider manuellement
- Rendu Slim de la carte « Compte d'accès » (`humans#show`) et des badges du formulaire activité (non vérifié via Interceptor faute d'app lancée ici).
- Vérifier que le mailer Devise `reset_password` est bien configuré en prod (host/Postmark) pour que l'email d'invitation parte.
- Décider si l'on lance `rake activity_carriers:ensure_accounts` (avec ou sans `SEND_INVITES=1`) après merge.

## Suite de l'epic
À cocher la case **Phase 2** dans l'epic #25 une fois cette PR mergée. Prochaine phase éligible ensuite : **Phase 3 — Durée d'activité en heures**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsPhgLhz5wuxqkzkLzNV7v)_