### PR TITLE
Refs #25 — Phase 3 : durée d'activité en heures

### DIFF
--- a/app/decorators/experience_decorator.rb
+++ b/app/decorators/experience_decorator.rb
@@ -18,4 +18,12 @@ class ExperienceDecorator < ApplicationDecorator
   def price
     h.humanized_money_with_symbol(object.price)
   end
+
+  # Durée numérique formatée en français (ex. « 2 h », « 2,5 h »), ou nil.
+  def duration_hours
+    return nil if object.duration_hours.nil?
+
+    formatted = object.duration_hours.to_d.to_s("F").sub(/\.0+\z/, "").tr(".", ",")
+    "#{formatted} h"
+  end
 end

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -16,6 +16,7 @@
 #  min_participants  :integer
 #  max_participants  :integer
 #  duration          :string
+#  duration_hours    :decimal(, )
 #
 class Experience < ApplicationRecord
   belongs_to :human, optional: true
@@ -36,4 +37,16 @@ class Experience < ApplicationRecord
   validates :name,
             presence: true,
             uniqueness: true
+  validates :duration_hours,
+            numericality: { greater_than: 0 },
+            allow_nil: true
+
+  # Durée d'un bloc de disponibilité, en minutes, dérivée de la durée numérique
+  # en heures. Pilote la taille des créneaux (Phase 4 de l'épic #25). Renvoie
+  # nil tant qu'aucune durée numérique n'a été renseignée.
+  def block_duration_minutes
+    return nil if duration_hours.nil?
+
+    (duration_hours * 60).round
+  end
 end

--- a/app/services/experiences/create_service.rb
+++ b/app/services/experiences/create_service.rb
@@ -39,7 +39,8 @@ module Experiences
           :fixed_price,
           :min_participants,
           :max_participants,
-          :duration
+          :duration,
+          :duration_hours
         )
     end
   end

--- a/app/services/experiences/update_service.rb
+++ b/app/services/experiences/update_service.rb
@@ -41,7 +41,8 @@ module Experiences
           :fixed_price,
           :min_participants,
           :max_participants,
-          :duration
+          :duration,
+          :duration_hours
         )
     end
   end

--- a/app/views/experiences/_form.html.slim
+++ b/app/views/experiences/_form.html.slim
@@ -34,8 +34,16 @@
                      step: "1"
 
     = f.text_field :duration,
-                   label: "Durée",
+                   label: "Durée (libellé affiché)",
+                   hint: "Texte libre montré aux client·es, ex. « une demi-journée »",
                    class: "w-1/2 md:w-1/2 lg:w-1/4"
+
+    = f.number_field :duration_hours,
+                     label: "Durée en heures",
+                     hint: "Valeur numérique (ex. 1 · 2 · 2,5 · 3 · 4) — détermine la taille des créneaux de disponibilité.",
+                     min: "0.5",
+                     step: "0.5",
+                     class: "w-1/2 md:w-1/2 lg:w-1/4"
 
     .flex.space-x-4
       - if f.object.photo?

--- a/app/views/experiences/index.html.slim
+++ b/app/views/experiences/index.html.slim
@@ -44,3 +44,5 @@
             = experience.participants
           td.py-4.px-6.text-gray-900.whitespace-nowrap[scope="row"]
             = experience.duration
+            - if experience.duration_hours
+              .text-xs.text-gray-400 = experience.duration_hours

--- a/app/views/experiences/show.html.slim
+++ b/app/views/experiences/show.html.slim
@@ -36,6 +36,14 @@
             dd.mt-1.text-sm.text-gray-900.sm:col-span-2.sm:mt-0
               = @experience.participants
 
+            - if @experience.duration.present? || @experience.duration_hours
+              dt.text-sm.font-medium.text-gray-500
+                | Durée
+              dd.mt-1.text-sm.text-gray-900.sm:col-span-2.sm:mt-0
+                = @experience.duration
+                - if @experience.duration_hours
+                  span.text-gray-400 = " (#{@experience.duration_hours})"
+
             dt.text-sm.font-medium.text-gray-500
               | Résumé
             dd.mt-1.text-sm.text-gray-900.sm:col-span-2.sm:mt-0

--- a/db/migrate/20260603140000_add_duration_hours_to_experiences.rb
+++ b/db/migrate/20260603140000_add_duration_hours_to_experiences.rb
@@ -1,0 +1,8 @@
+class AddDurationHoursToExperiences < ActiveRecord::Migration[7.0]
+  def change
+    # Durée numérique en heures (ex. 1 / 2 / 2.5 / 3 / 4) qui pilotera la taille
+    # des blocs de disponibilité (Phase 4). Le champ texte `duration` existant
+    # reste un libellé libre (épic #25, décision produit).
+    add_column :experiences, :duration_hours, :decimal, precision: 4, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_06_03_130000) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_03_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -283,6 +283,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_03_130000) do
     t.integer "min_participants"
     t.integer "max_participants"
     t.string "duration"
+    t.decimal "duration_hours", precision: 4, scale: 2
     t.index ["human_id"], name: "index_experiences_on_human_id"
   end
 

--- a/spec/models/experience_spec.rb
+++ b/spec/models/experience_spec.rb
@@ -16,9 +16,37 @@
 #  min_participants  :integer
 #  max_participants  :integer
 #  duration          :string
+#  duration_hours    :decimal(, )
 #
 require 'rails_helper'
 
+# Phase 3 de l'épic #25 — durée numérique en heures sur Experience.
 RSpec.describe Experience, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "duration_hours" do
+    it "accepte une valeur décimale positive" do
+      experience = Experience.new(name: "Atelier vannerie", duration_hours: 2.5)
+      expect(experience).to be_valid
+    end
+
+    it "accepte l'absence de valeur (nil)" do
+      experience = Experience.new(name: "Balade contée")
+      expect(experience).to be_valid
+    end
+
+    it "rejette une valeur nulle ou négative" do
+      expect(Experience.new(name: "X", duration_hours: 0)).not_to be_valid
+      expect(Experience.new(name: "Y", duration_hours: -1)).not_to be_valid
+    end
+  end
+
+  describe "#block_duration_minutes" do
+    it "convertit les heures en minutes" do
+      expect(Experience.new(duration_hours: 2.5).block_duration_minutes).to eq(150)
+      expect(Experience.new(duration_hours: 1).block_duration_minutes).to eq(60)
+    end
+
+    it "renvoie nil sans durée numérique" do
+      expect(Experience.new.block_duration_minutes).to be_nil
+    end
+  end
 end

--- a/spec/requests/experiences_duration_spec.rb
+++ b/spec/requests/experiences_duration_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+# Phase 3 de l'épic #25 — durée numérique en heures (champ `duration_hours`).
+RSpec.describe "Experiences — durée en heures", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  describe "GET /experiences/new" do
+    it "affiche le champ « Durée en heures »" do
+      get new_experience_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Durée en heures")
+      expect(response.body).to include("experience[duration_hours]")
+    end
+  end
+
+  describe "POST /experiences" do
+    it "persiste la durée numérique en heures" do
+      post experiences_path, params: {
+        experience: {
+          name: "Atelier pain au four",
+          fixed_price: "0",
+          price: "15",
+          min_participants: "1",
+          duration: "une demi-journée",
+          duration_hours: "2.5"
+        }
+      }
+      experience = Experience.find_by(name: "Atelier pain au four")
+      expect(experience).to be_present
+      expect(experience.duration_hours).to eq(2.5)
+      expect(experience.duration).to eq("une demi-journée")
+      expect(experience.block_duration_minutes).to eq(150)
+    end
+  end
+
+  describe "PATCH /experiences/:id" do
+    it "met à jour la durée numérique" do
+      experience = Experience.create!(name: "Balade nature", fixed_price_cents: 0)
+      patch experience_path(experience), params: {
+        experience: { duration_hours: "3" }
+      }
+      expect(experience.reload.duration_hours).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
Phase 3 de l'épic #25 (Activités). **Ne ferme pas l'épic** — les phases 4→10 restent à faire.

## Objectif de la phase
Ajouter une **durée numérique en heures** sur les activités, distincte du libellé texte libre existant. Cette valeur numérique pilotera la taille des **blocs de disponibilité** (à exploiter en Phase 4). Conforme à la décision de l'épic : champ dédié `duration_hours` décimal, le champ `duration` (string) reste un libellé affiché.

## Changements
- **Migration `add_duration_hours_to_experiences`** : `experiences.duration_hours` décimal `precision: 4, scale: 2`, nullable.
- **`Experience`** : validation `numericality: { greater_than: 0 }, allow_nil: true` + méthode **`#block_duration_minutes`** (heures → minutes, ex. `2.5 → 150`) qui servira de taille de bloc en Phase 4. Renvoie `nil` tant qu'aucune durée numérique n'est saisie.
- **Formulaire activité** (`experiences/_form`) : nouveau champ **« Durée en heures »** (`number_field`, `step 0.5`, `min 0.5`) avec un hint expliquant son rôle. Le champ texte existant est relibellé « Durée (libellé affiché) ».
- **Services** (`Experiences::CreateService` / `UpdateService`) : `:duration_hours` ajouté aux params permis.
- **Affichage** : `ExperienceDecorator#duration_hours` (formaté FR, ex. « 2,5 h ») montré sur l'index (sous la durée texte) et ajout d'une ligne « Durée » sur la fiche `show` (qui n'en affichait aucune).

## Périmètre / choix
- Strictement la Phase 3 : on **stocke** la durée numérique et on expose la conversion en minutes. La **création effective des blocs** de disponibilité dimensionnés par cette durée est la **Phase 4** (non incluse).
- `duration` (string) volontairement conservé tel quel (décision produit de l'épic).

## Tests
- **Specs ajoutées** :
  - `spec/models/experience_spec.rb` (remplace le placeholder `pending`) : validation `duration_hours` (positif / nil / ≤ 0) et `#block_duration_minutes`.
  - `spec/requests/experiences_duration_spec.rb` : rendu du champ sur `new`, persistance via `POST` et `PATCH`.
- **Suite complète exécutée localement** (PostgreSQL, Ruby 3.1.2, assets Vite buildés en mode test) : **208 exemples, 19 pending, 1 échec** — voir ci-dessous.

## ⚠️ Échec préexistant, indépendant de cette phase
- `spec/requests/experiences_carriers_spec.rb:12` (Phase 2) échoue sur `expect(response.body).not_to include("Aucun Email Ici")`.
- **Cause** : l'assertion est trop large — le nom du `Human` sans email apparaît dans un **tooltip de la navbar** (`id="tooltip-human-2"`, qui liste tous les humains), **pas** dans le sélecteur de porteur du formulaire (qui filtre bien sur `Human.with_email`). Le comportement produit est correct ; c'est l'assertion du spec qui matche un élément hors formulaire.
- Ce spec a été **mergé sans être exécuté** (la PR #31 indiquait « Suite non exécutée dans ce conteneur »). Cette PR Phase 3 **ne touche ni la navbar ni la sélection de porteur** — l'échec est antérieur et indépendant. Laissé en l'état pour rester dans le périmètre de la Phase 3 ; à corriger dans un changement dédié (restreindre l'assertion à la section porteur du formulaire).

## À valider manuellement
- Rendu Slim du champ « Durée en heures » (formulaire) et de l'affichage formaté sur `index`/`show` — non vérifié via navigateur faute d'app lancée dans ce conteneur.

## Suite de l'épic
À cocher la case **Phase 3** dans l'épic #25 une fois cette PR mergée. Prochaine phase éligible : **Phase 4 — Calendrier de disponibilités du porteur** (qui consommera `block_duration_minutes`).

---
_Generated by [Claude Code](https://claude.com/claude-code)_
