### PR TITLE
Fix : formulaire d'édition d'un point cassé quand la description contient des guillemets

### DIFF
--- a/app/frontend/controllers/tiptap_controller.js
+++ b/app/frontend/controllers/tiptap_controller.js
@@ -16,18 +16,20 @@ import Placeholder from "@tiptap/extension-placeholder"
 export default class extends Controller {
   static targets = ["editor", "input"]
   static values = {
-    content: String,
     placeholder: { type: String, default: "Contexte, questions à trancher, documents utiles…" },
   }
 
   connect() {
+    // Initial content comes from the hidden ActionText field (correctly escaped
+    // by Rails), never from a data attribute — rich-text HTML contains quotes
+    // that would break an HTML attribute value.
     this.editor = new Editor({
       element: this.editorTarget,
       extensions: [
         StarterKit.configure({ link: { openOnClick: false, autolink: true } }),
         Placeholder.configure({ placeholder: this.placeholderValue }),
       ],
-      content: this.contentValue || "",
+      content: this.inputTarget.value || "",
       editorProps: {
         attributes: { class: "prose max-w-none focus:outline-none min-h-[10rem]" },
       },

--- a/app/views/agenda_items/_form.html.slim
+++ b/app/views/agenda_items/_form.html.slim
@@ -29,7 +29,7 @@
 
   .space-y-2
     = f.label :description, "Fiche de préparation", class: "block text-sm font-medium text-gray-700"
-    div.rounded-md.border.border-gray-300.shadow-sm.focus-within:border-emerald-500(data-controller="tiptap" data-tiptap-content-value=item.description.to_s)
+    div.rounded-md.border.border-gray-300.shadow-sm.focus-within:border-emerald-500(data-controller="tiptap")
       .flex.flex-wrap.items-center.gap-1.border-b.border-gray-200.bg-gray-50.px-2.py-1.5
         - tb = "px-2 py-1 rounded text-sm text-gray-600 hover:bg-gray-200"
         button type="button" class=tb data-action="tiptap#toggleBold" title="Gras"


### PR DESCRIPTION
## Problème
Pour certains points de l'ODJ, la modale d'édition était cassée : le bouton **Enregistrer** s'affichait **en dehors** du formulaire (à droite, hors modale), et cliquer dessus fermait la modale sans rien enregistrer. Reproduction : uniquement les points dont la *Fiche de préparation* contient des guillemets dans son HTML (anciens points créés sous Trix, qui sont enveloppés dans `<div class="trix-content prose">`, ou contenant des liens).

## Cause
Dans `agenda_items/_form.html.slim`, le HTML de la description (`item.description.to_s`, qui est `html_safe`) était injecté dans l'attribut `data-tiptap-content-value`. **Slim n'échappe pas une valeur `html_safe`** → le premier `"` du HTML refermait l'attribut puis la balise `<div>`, mal-imbriquant tout le reste du formulaire et éjectant le bouton submit hors du `<form>`.

## Correctif
TipTap lit désormais le contenu initial depuis le **champ caché** `hidden_field_tag "agenda_item[description]"` — dont la valeur est correctement échappée par Rails (`&quot;`, `&lt;`…) — au lieu d'un attribut data. Plus de duplication, plus d'attribut cassable.

- `_form.html.slim` : retrait de `data-tiptap-content-value`.
- `tiptap_controller.js` : `content: this.inputTarget.value` au lieu de `this.contentValue`.

## Vérifié
- Rendu serveur du formulaire d'édition pour un point dont la description contient `"` : structure saine, bouton Enregistrer **dans** le `<form>`, plus de fuite `">`.
- En navigateur : TipTap monte et charge le contenu initial avec guillemets (`Texte avec "guillemets" et lien`), synchronise au retour, zéro erreur console.