### PR TITLE
feat(api): endpoint read-only human_roles (gardes / veilleur·euse)

### DIFF
--- a/app/controllers/api/v1/human_roles_controller.rb
+++ b/app/controllers/api/v1/human_roles_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    # Rôles datés assignés aux membres — notamment les gardes (role "Veilleur·euse").
+    # Un HumanRole = un membre tient un rôle un jour donné, avec un statut
+    # (selected = confirmé, backup = suppléant). Read-only : la planification des
+    # gardes se gère ailleurs ; l'API ne fait que l'exposer.
+    class HumanRolesController < BaseController
+      def index
+        scope = HumanRole.all
+        scope = scope.where(human_id: params[:human_id]) if params[:human_id].present?
+        scope = scope.where(role_id: params[:role_id]) if params[:role_id].present?
+        scope = scope.where(status: params[:status]) if HumanRole.statuses.key?(params[:status])
+        scope = scope.where("date >= ?", params[:from]) if params[:from].present?
+        scope = scope.where("date <= ?", params[:to]) if params[:to].present?
+        @human_roles = paginate(scope.includes(:human, :role).order(:date))
+      end
+
+      def show
+        @human_role = HumanRole.includes(:human, :role).find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/index_controller.rb
+++ b/app/controllers/api/v1/index_controller.rb
@@ -41,6 +41,7 @@ module Api
             { name: "humans", path: api_v1_humans_path, description: "Membres du collectif." },
             { name: "cycles", path: api_v1_cycles_path, description: "Cycles de l'organisation (périodes datées)." },
             { name: "cycle_actions", path: api_v1_cycle_actions_path, description: "Actions de cycle par membre. Filtres: human_id, category, completed." },
+            { name: "human_roles", path: api_v1_human_roles_path, description: "Rôles datés par membre (ex. gardes / Veilleur·euse). Filtres: human_id, role_id, status (selected|backup), from, to." },
             { name: "tasks", path: api_v1_tasks_path, description: "Tâches de l'organisation. Filtres: status, project_id." },
             { name: "payments", path: api_v1_payments_path, description: "Paiements liés aux réservations (identifiants Stripe non exposés)." }
           ],

--- a/app/views/api/v1/human_roles/_human_role.json.jbuilder
+++ b/app/views/api/v1/human_roles/_human_role.json.jbuilder
@@ -1,0 +1,10 @@
+json.id human_role.id
+json.type "human_role"
+json.date human_role.date
+json.status human_role.status
+json.human { json.partial! "api/v1/shared/ref", record: human_role.human }
+json.role { json.partial! "api/v1/shared/ref", record: human_role.role }
+json.has_watchman_note human_role.has_watchman_note?
+json.created_at human_role.created_at
+json.updated_at human_role.updated_at
+json.url api_v1_human_role_url(human_role)

--- a/app/views/api/v1/human_roles/index.json.jbuilder
+++ b/app/views/api/v1/human_roles/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.data @human_roles do |human_role|
+  json.partial! "api/v1/human_roles/human_role", human_role: human_role
+end
+json.meta { json.partial! "api/v1/shared/pagination", collection: @human_roles }

--- a/app/views/api/v1/human_roles/show.json.jbuilder
+++ b/app/views/api/v1/human_roles/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.data { json.partial! "api/v1/human_roles/human_role", human_role: @human_role }

--- a/config/openapi/v1.yaml
+++ b/config/openapi/v1.yaml
@@ -665,6 +665,50 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /human_roles:
+    get:
+      tags: [Collectif]
+      summary: Lister les rôles datés (gardes / Veilleur·euse)
+      description: >
+        Rôles assignés à un membre pour un jour donné. Le rôle "Veilleur·euse"
+        (role_id 1) correspond à la garde. status=selected confirme l'assignation
+        (backup = suppléant). Pour savoir quels jours un membre est de garde :
+        ?human_id=<id>&role_id=1&status=selected&from=<date>&to=<date>.
+      parameters:
+        - { name: human_id, in: query, schema: { type: integer }, description: "Filtre par membre." }
+        - { name: role_id, in: query, schema: { type: integer }, description: "Filtre par rôle (1 = Veilleur·euse / garde)." }
+        - { name: status, in: query, schema: { type: string, enum: [selected, backup] }, description: "selected = confirmé, backup = suppléant." }
+        - { name: from, in: query, schema: { type: string, format: date }, description: "Borne basse de date (incluse)." }
+        - { name: to, in: query, schema: { type: string, format: date }, description: "Borne haute de date (incluse)." }
+        - { $ref: "#/components/parameters/Page" }
+        - { $ref: "#/components/parameters/PerPage" }
+      responses:
+        "200":
+          description: Liste paginée de rôles datés (triés par date croissante).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data: { type: array, items: { $ref: "#/components/schemas/HumanRole" } }
+                  meta: { $ref: "#/components/schemas/PaginationMeta" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+  /human_roles/{id}:
+    get:
+      tags: [Collectif]
+      summary: Détail d'un rôle daté
+      parameters: [{ $ref: "#/components/parameters/Id" }]
+      responses:
+        "200":
+          description: Rôle daté.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { data: { $ref: "#/components/schemas/HumanRole" } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /tasks:
     get:
       tags: [Collectif]
@@ -1122,6 +1166,19 @@ components:
         archived_at: { type: string, format: date-time, nullable: true }
         human: { $ref: "#/components/schemas/Ref" }
         delegate_to_human: { allOf: [{ $ref: "#/components/schemas/Ref" }], nullable: true }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        url: { type: string }
+    HumanRole:
+      type: object
+      properties:
+        id: { type: integer }
+        type: { type: string, example: "human_role" }
+        date: { type: string, format: date }
+        status: { type: string, enum: [selected, backup] }
+        human: { $ref: "#/components/schemas/Ref" }
+        role: { $ref: "#/components/schemas/Ref" }
+        has_watchman_note: { type: boolean, description: "Vrai si une note de veilleur existe pour cette date." }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         url: { type: string }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,7 @@ Rails.application.routes.draw do
       resources :humans, only: [:index, :show, :update, :destroy]
       resources :cycles, only: [:index, :show, :update, :destroy]
       resources :cycle_actions, only: [:index, :show, :update, :destroy]
+      resources :human_roles, only: [:index, :show]
       resources :tasks, only: [:index, :show, :update, :destroy]
       resources :payments, only: [:index, :show, :update, :destroy]
     end

--- a/spec/requests/api/v1/human_roles_spec.rb
+++ b/spec/requests/api/v1/human_roles_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::HumanRoles", type: :request do
+  let(:token) { "test-token-123" }
+  let(:auth) { { "Authorization" => "Bearer #{token}" } }
+
+  around do |example|
+    previous = ENV["AGENT_API_TOKEN"]
+    ENV["AGENT_API_TOKEN"] = token
+    example.run
+    ENV["AGENT_API_TOKEN"] = previous
+  end
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  let!(:michael) { Human.create!(name: "Michael", email: "michael@example.com") }
+  let!(:other) { Human.create!(name: "Autre", email: "autre@example.com") }
+  let!(:watch_role) { Role.create!(name: "Veilleur·euse") }
+  let!(:misc_role) { Role.create!(name: "Cuisine") }
+
+  let!(:michael_mon) do
+    HumanRole.create!(human: michael, role: watch_role, date: Date.new(2026, 6, 15), status: :selected)
+  end
+  let!(:michael_thu) do
+    HumanRole.create!(human: michael, role: watch_role, date: Date.new(2026, 6, 18), status: :backup)
+  end
+  let!(:other_tue) do
+    HumanRole.create!(human: other, role: watch_role, date: Date.new(2026, 6, 16), status: :selected)
+  end
+  let!(:michael_kitchen) do
+    HumanRole.create!(human: michael, role: misc_role, date: Date.new(2026, 6, 17), status: :selected)
+  end
+
+  describe "GET /api/v1/human_roles" do
+    it "lists roles with pagination meta, ordered by date" do
+      get "/api/v1/human_roles", headers: auth
+      expect(response).to have_http_status(:ok)
+      expect(json["data"]).to be_an(Array)
+      expect(json["meta"]).to include("page", "per_page", "total")
+      dates = json["data"].map { |r| r["date"] }
+      expect(dates).to eq(dates.sort)
+    end
+
+    it "filters by human_id" do
+      get "/api/v1/human_roles", params: { human_id: michael.id }, headers: auth
+      human_ids = json["data"].map { |r| r["human"]["id"] }
+      expect(human_ids).to all(eq(michael.id))
+    end
+
+    it "filters by role_id and status to isolate confirmed watch shifts" do
+      get "/api/v1/human_roles",
+          params: { human_id: michael.id, role_id: watch_role.id, status: "selected" }, headers: auth
+      expect(json["data"].length).to eq(1)
+      shift = json["data"].first
+      expect(shift["date"]).to eq("2026-06-15")
+      expect(shift["status"]).to eq("selected")
+      expect(shift["role"]["name"]).to eq("Veilleur·euse")
+    end
+
+    it "filters by date range with from/to" do
+      get "/api/v1/human_roles",
+          params: { from: "2026-06-16", to: "2026-06-17" }, headers: auth
+      dates = json["data"].map { |r| r["date"] }
+      expect(dates).to match_array(%w[2026-06-16 2026-06-17])
+    end
+
+    it "exposes status, role and has_watchman_note in the payload" do
+      get "/api/v1/human_roles", params: { human_id: michael.id, role_id: watch_role.id }, headers: auth
+      record = json["data"].first
+      expect(record).to include("date", "status", "role", "has_watchman_note")
+      expect(record["type"]).to eq("human_role")
+    end
+
+    it "requires authentication" do
+      get "/api/v1/human_roles"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /api/v1/human_roles/:id" do
+    it "returns a single dated role" do
+      get "/api/v1/human_roles/#{michael_mon.id}", headers: auth
+      expect(response).to have_http_status(:ok)
+      expect(json["data"]["id"]).to eq(michael_mon.id)
+      expect(json["data"]["date"]).to eq("2026-06-15")
+    end
+  end
+end


### PR DESCRIPTION
Expose `GET /api/v1/human_roles` en lecture seule pour qu'un agent puisse savoir quels jours un membre est de garde.

**Pourquoi** : la planification des gardes vit dans le modèle `HumanRole` (human × role daté + status), mais aucun endpoint ne l'exposait. Le rôle « Veilleur·euse » = `role_id 1`, `status=selected` = garde confirmée.

**Usage** : `GET /api/v1/human_roles?human_id=1&role_id=1&status=selected&from=2026-06-15&to=2026-06-22`

**Contenu** : controller (index + show, read-only), vues jbuilder, entrée discovery index, OpenAPI hand-authored (path + schéma `HumanRole`), request spec.

**Tests** : 7/7 verts (`spec/requests/api/v1/human_roles_spec.rb`).
Aucune route existante modifiée ; additif et read-only.