### PR TITLE
Gérer les espaces (Spaces) dans les paramètres — CRUD admin

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -1,0 +1,73 @@
+class SpacesController < BaseController
+  before_action :get_space, only: [:show, :edit, :update, :destroy]
+
+  breadcrumb "Espaces", :spaces_path, match: :exact
+
+  def index
+    @spaces = SpaceDecorator
+      .decorate_collection(Space.all.order(position: :asc))
+  end
+
+  def show
+    @space = SpaceDecorator.new(@space)
+  end
+
+  def new
+    @space = Space.new
+  end
+
+  def create
+    service = Spaces::CreateService.new
+    if service.run(params)
+      redirect_to space_path(service.space),
+                  notice: "Super! L'espace '#{service.space.name}' a été ajouté."
+    else
+      @space = service.space
+      set_error_flash(service.space, service.error_message)
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    service = Spaces::UpdateService.new(
+      space: Space.find(params[:id])
+    )
+    if service.run(params)
+      redirect_to space_path(service.space),
+                  notice: "L'espace a été mis à jour."
+    else
+      @space = service.space
+      set_error_flash(service.space, service.error_message)
+      render :edit,
+             status: :unprocessable_entity,
+             alert: service.error_message
+    end
+  end
+
+  def destroy
+    if @space.soft_delete!(validate: false)
+      redirect_to spaces_path,
+                  notice: "L'espace '#{@space.name}' a été supprimé."
+    else
+      flash.now[:alert] = "Une erreur est survenue."
+      render :show
+    end
+  end
+
+  private
+
+  def get_space
+    @space = Space.find(params[:id])
+  end
+
+  def set_presenters
+    @menu_presenter = Components::MenuPresenter.new(
+      active_primary: "settings",
+      active_secondary: "spaces"
+    )
+    @settings_view = true
+  end
+end

--- a/app/decorators/space_decorator.rb
+++ b/app/decorators/space_decorator.rb
@@ -2,8 +2,21 @@ class SpaceDecorator < ApplicationDecorator
   delegate_all
 
   def name_and_description
-    h.content_tag(:div, name, class: "font-medium text-gray-900") + 
+    h.content_tag(:div, name, class: "font-medium text-gray-900") +
     h.content_tag(:span, description, class: "text-xs text-gray-700")
+  end
+
+  # Badge « multi-groupe » affiché pour les espaces partagés (capacity > 1,
+  # ex. Bois, Pâture est/ouest). Un espace exclusif (salle, capacity 1)
+  # n'affiche aucun badge.
+  def capacity_badge
+    return unless object.shared?
+
+    h.content_tag(
+      :span,
+      "multi-groupe · #{object.capacity} groupes",
+      class: "inline-flex items-center rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-800"
+    )
   end
 
   def monthly_reports_bar(date)

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -10,6 +10,7 @@
 #  code        :string
 #  deleted_at  :datetime
 #  position    :integer          default(999)
+#  capacity    :integer          default(1), not null
 #
 class Space < ApplicationRecord
   has_many :space_reservations
@@ -17,6 +18,10 @@ class Space < ApplicationRecord
   has_soft_deletion default_scope: true
 
   default_scope -> { order(:position) }
+
+  validates :name, presence: true
+  validates :capacity,
+            numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 
   def available_on?(date)
     !booked_on?(date)

--- a/app/services/spaces/create_service.rb
+++ b/app/services/spaces/create_service.rb
@@ -1,0 +1,40 @@
+module Spaces
+  class CreateService < ServiceBase
+    attr_reader :space
+
+    def initialize
+      @space = Space.new
+      @report_errors = true
+    end
+
+    def run(params = {})
+      context = {
+        params: params,
+      }
+
+      catch_error(context: context) do
+        run!(params)
+      end
+    end
+
+    def run!(params = {})
+      space.attributes = space_params(params)
+      space.save!
+      true
+    end
+
+    private
+
+    def space_params(params)
+      params
+        .require(:space)
+        .permit(
+          :name,
+          :description,
+          :code,
+          :position,
+          :capacity
+        )
+    end
+  end
+end

--- a/app/services/spaces/update_service.rb
+++ b/app/services/spaces/update_service.rb
@@ -1,0 +1,42 @@
+module Spaces
+  class UpdateService < ServiceBase
+    PreconditionFailedError = Class.new(StandardError)
+
+    attr_reader :space
+
+    def initialize(space:)
+      @space = space
+      @report_errors = true
+    end
+
+    def run(params = {})
+      context = {
+        params: params
+      }
+
+      catch_error(context: context) do
+        run!(params)
+      end
+    end
+
+    def run!(params = {})
+      space.attributes = space_params(params)
+      space.save!
+      true
+    end
+
+    private
+
+    def space_params(params)
+      params
+        .require(:space)
+        .permit(
+          :name,
+          :description,
+          :code,
+          :position,
+          :capacity
+        )
+    end
+  end
+end

--- a/app/views/layouts/components/_navbar.html.slim
+++ b/app/views/layouts/components/_navbar.html.slim
@@ -197,6 +197,10 @@ nav.bg-white.shadow-sm.lg:px-6
                       services_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'services' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
           li
+            = link_to "Espaces",
+                      spaces_path,
+                      class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'spaces' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
+          li
             = link_to "Objets à louer",
                       rental_items_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'rental_items' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"

--- a/app/views/spaces/_form.html.slim
+++ b/app/views/spaces/_form.html.slim
@@ -1,0 +1,36 @@
+.border-l-8.border-indigo-700.-ml-4.pl-4.md:p-0.md:m-0.md:border-0.grid.grid-cols-1.md:grid-cols-3.md:gap-4
+  .md:border-r-8.md:border-indigo-700.md:pr-4.md:text-right
+    = section_heading_tw heading: "Informations"
+
+  .col-span-2.mb-4.space-y-6.sm:space-y-5
+    = f.text_field :name,
+                   label: "Nom *",
+                   required: true,
+                   class: "md:w-1/2 lg:w-2/3"
+
+    = f.text_field :code,
+                   label: "Code",
+                   hint: "Abréviation affichée sur le calendrier (ex. « BOIS »)",
+                   class: "md:w-1/2 lg:w-1/3"
+
+    = f.label :description, "Description"
+    = f.text_area :description, rows: 3
+
+    = f.number_field :capacity,
+                     label: "Capacité (nombre de groupes) *",
+                     min: 1,
+                     step: 1,
+                     required: true,
+                     hint: "1 = espace exclusif (salle) ; >1 = plusieurs groupes simultanés (camping)",
+                     remove_default_class: "sm:text-sm",
+                     class: "w-24 text-lg"
+
+    = f.number_field :position,
+                     label: "Position",
+                     min: 0,
+                     step: 1,
+                     hint: "Ordre d'affichage (plus petit = affiché en premier)",
+                     remove_default_class: "sm:text-sm",
+                     class: "w-24 text-lg"
+
+hr

--- a/app/views/spaces/edit.html.slim
+++ b/app/views/spaces/edit.html.slim
@@ -1,0 +1,12 @@
+- content_for :page_header do
+  = render 'layouts/components/page_header',
+           title: "Mettre à jour l'espace"
+
+= form_with model: @space,
+            url: space_path(@space) do |f|
+  .space-y-8.divide-y.divide-gray-200.sm:space-y-5
+    .space-y-6.sm:space-y-5
+      = render "form", f: f
+
+  = f.actions do
+    = f.submit "Mettre à jour"

--- a/app/views/spaces/index.html.slim
+++ b/app/views/spaces/index.html.slim
@@ -1,0 +1,34 @@
+- content_for :page_header do
+  = render "layouts/components/page_header",
+           title: "Espaces",
+           links: [ \
+             link_to("➕ Nouvel espace", new_space_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2") \
+           ]
+
+.overflow-x-auto.relative
+  table.w-full.text-sm.text-left.text-gray-500
+    thead.text-xs.text-gray-700.uppercase.bg-gray-50
+      tr
+        th.py-3.px-6.w-16[scope="col"]
+          | Position
+        th.py-3.px-6[scope="col"]
+          | Nom
+        th.py-3.px-6[scope="col"]
+          | Description
+        th.py-3.px-6.w-48[scope="col"]
+          | Capacité
+    tbody
+      - @spaces.each do |space|
+        tr.border-b.bg-white
+          td.py-4.px-6.text-gray-900.whitespace-nowrap[scope="row"]
+            = space.position
+          td.py-4.px-6.font-medium.text-gray-900.whitespace-nowrap[scope="row"]
+            = link_to space.name,
+                      space_path(space),
+                      class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700 focus:text-blue-700"
+          td.py-4.px-6.text-gray-500
+            = space.description
+          td.py-4.px-6.text-gray-900.whitespace-nowrap[scope="row"]
+            .flex.items-center.gap-2
+              span= space.capacity
+              = space.capacity_badge

--- a/app/views/spaces/new.html.slim
+++ b/app/views/spaces/new.html.slim
@@ -1,0 +1,12 @@
+- content_for :page_header do
+  = render 'layouts/components/page_header',
+           title: "Nouvel espace"
+
+= form_with model: @space,
+            url: spaces_path do |f|
+  .space-y-8.divide-y.divide-gray-200.sm:space-y-5
+    .space-y-6.sm:space-y-5
+      = render "form", f: f
+
+  = f.actions do
+    = f.submit "Enregistrer"

--- a/app/views/spaces/show.html.slim
+++ b/app/views/spaces/show.html.slim
@@ -1,0 +1,47 @@
+- content_for :page_header do
+  = render 'layouts/components/page_header',
+           title: @space.name,
+           links: [ \
+             delete_link(@space.object),
+             link_to( \
+               "Mettre à jour",
+               edit_space_path(@space),
+               class: "btn-page-header" \
+             ) \
+           ].compact
+
+.space-y-4
+  .grid.grid-cols-3.gap-4
+    .col-span-2.space-y-4
+      .overflow-hidden.bg-white.shadow.sm:rounded-lg
+        .px-4.py-5.sm:px-6
+          h3.text-lg.font-medium.leading-6.text-gray-900
+            | Informations
+        .border-t.border-gray-200
+          dl
+            .px-4.py-5.sm:grid.sm:grid-cols-3.sm:gap-4.sm:px-6
+              dt.text-sm.font-medium.text-gray-500
+                | Code
+              dd.mt-1.text-sm.text-gray-900.sm:col-span-2.sm:mt-0
+                = @space.code
+              dt.text-sm.font-medium.text-gray-500
+                | Capacité
+              dd.mt-1.text-sm.text-gray-900.sm:col-span-2.sm:mt-0
+                .flex.items-center.gap-2
+                  span= @space.capacity
+                  = @space.capacity_badge
+              dt.text-sm.font-medium.text-gray-500
+                | Position
+              dd.mt-1.text-sm.text-gray-900.sm:col-span-2.sm:mt-0
+                = @space.position
+
+  - if @space.description.present?
+    .grid.grid-cols-3.gap-4
+      .col-span-2.space-y-4
+        .overflow-hidden.bg-white.shadow.sm:rounded-lg
+          .px-4.py-5.sm:px-6
+            h3.text-lg.font-medium.leading-6.text-gray-900
+              | Description
+          .border-t.border-gray-200
+            .p-6
+              = @space.description

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
   resources :roles
   resources :rooms
   resources :services
+  resources :spaces
   resources :tasks
   resources :teams
   resources :watchman_notes

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -23,6 +23,31 @@ RSpec.describe Space, type: :model do
     SpaceReservation.create!(space: space, space_booking: booking, date: on)
   end
 
+  describe "validations" do
+    it "exige un nom" do
+      space = Space.new(name: nil, capacity: 1)
+      expect(space).not_to be_valid
+      expect(space.errors[:name]).to be_present
+    end
+
+    it "refuse une capacité nulle" do
+      space = Space.new(name: "Sans capacité", capacity: nil)
+      expect(space).not_to be_valid
+      expect(space.errors[:capacity]).to be_present
+    end
+
+    it "refuse une capacité inférieure à 1" do
+      space = Space.new(name: "Zéro", capacity: 0)
+      expect(space).not_to be_valid
+      expect(space.errors[:capacity]).to be_present
+    end
+
+    it "accepte une capacité entière ≥ 1" do
+      expect(Space.new(name: "Salle", capacity: 1)).to be_valid
+      expect(Space.new(name: "Bois", capacity: 5)).to be_valid
+    end
+  end
+
   describe "capacity" do
     it "defaults to 1 (espace exclusif — comportement historique)" do
       expect(Space.new.capacity).to eq(1)

--- a/spec/requests/spaces_spec.rb
+++ b/spec/requests/spaces_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+# Issue #37 — CRUD admin des espaces dans les paramètres.
+RSpec.describe "Spaces (CRUD admin)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  describe "GET /spaces" do
+    it "liste les espaces triés par position avec le menu paramètres" do
+      Space.create!(name: "Grande Salle", capacity: 1, position: 2)
+      Space.create!(name: "Bois", capacity: 5, position: 1)
+
+      get spaces_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Espaces")
+      expect(response.body).to include("Grande Salle")
+      expect(response.body).to include("Bois")
+      # tri par position : Bois (1) avant Grande Salle (2)
+      expect(response.body.index("Bois")).to be < response.body.index("Grande Salle")
+      # badge multi-groupe pour l'espace partagé
+      expect(response.body).to include("multi-groupe")
+      # menu secondaire paramètres présent (lien Produits voisin)
+      expect(response.body).to include("Produits")
+    end
+  end
+
+  describe "GET /spaces/new" do
+    it "affiche le formulaire de création" do
+      get new_space_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Nouvel espace")
+      expect(response.body).to include("Capacité")
+    end
+  end
+
+  describe "POST /spaces" do
+    it "crée un espace et redirige vers sa page" do
+      expect {
+        post spaces_path, params: {
+          space: { name: "Pâture est", description: "Tente", code: "PAT-E", capacity: 5, position: 3 }
+        }
+      }.to change(Space, :count).by(1)
+
+      space = Space.order(:created_at).last
+      expect(space.name).to eq("Pâture est")
+      expect(space.capacity).to eq(5)
+      expect(response).to redirect_to(space_path(space))
+    end
+
+    it "refuse une capacité invalide et réaffiche le formulaire" do
+      expect {
+        post spaces_path, params: { space: { name: "Cassé", capacity: 0 } }
+      }.not_to change(Space, :count)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /spaces/:id" do
+    it "met à jour la capacité" do
+      space = Space.create!(name: "Bois", capacity: 3)
+      patch space_path(space), params: { space: { name: "Bois", capacity: 8 } }
+      expect(response).to redirect_to(space_path(space))
+      expect(space.reload.capacity).to eq(8)
+    end
+  end
+
+  describe "DELETE /spaces/:id" do
+    it "supprime en soft-delete (retiré de l'index, retrouvable via unscoped)" do
+      space = Space.create!(name: "À supprimer", capacity: 1)
+
+      delete space_path(space)
+
+      expect(response).to redirect_to(spaces_path)
+      expect(Space.where(id: space.id)).to be_empty
+      deleted = Space.unscoped.find(space.id)
+      expect(deleted.deleted_at).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Closes #37

## Résumé
Ajoute un **CRUD admin complet des espaces** (`Space`) dans la vue « Paramètres », au même niveau qu'Événements, Activités, Services, Produits, etc. Jusqu'ici les espaces n'étaient gérables que par seeds/console — notamment leur `capacity` (multi-groupe).

## Changements
- **Route** : `resources :spaces` top-level (distincte de l'`api/v1` existante) — `spaces_path` pointe vers l'index HTML admin.
- **`SpacesController < BaseController`** : `index`, `show`, `new`, `create`, `edit`, `update`, `destroy`, calqué sur `ProductsController` (services dédiés, `SpaceDecorator`, `breadcrumb "Espaces"`, flash succès/erreur, `@settings_view = true`).
- **Services** : `Spaces::CreateService` + `Spaces::UpdateService` (params permis : `name`, `description`, `code`, `position`, `capacity`).
- **Vues Slim** : `index` (tri par `position`, badge « multi-groupe » via `Space#shared?`), `new`, `edit`, `show`, `_form`. Le champ `capacity` porte l'aide « 1 = espace exclusif (salle) ; >1 = plusieurs groupes simultanés (camping) ».
- **Modèle** : validation `capacity` entier ≥ 1 (rejet de `0`/`nil`) + `name` présent. **Aucune** modification de la logique de disponibilité (`booked_on?`/`available_on?`/`remaining_capacity_on`/`shared?`).
- **Decorator** : `SpaceDecorator#capacity_badge` (badge orange « multi-groupe · N groupes » quand `capacity > 1`).
- **Navbar** : lien « Espaces » dans le menu secondaire des paramètres, état actif quand `controller_name == 'spaces'`.
- **Suppression** : `soft_delete!` (cohérent avec `has_soft_deletion default_scope: true`) — l'espace disparaît de l'index, les `SpaceReservation` historiques sont préservées.

## Tests
- `spec/models/space_spec.rb` : validations `capacity` (0/nil rejetés, ≥1 accepté) + `name`. Les 7 exemples de capacité existants restent verts.
- `spec/requests/spaces_spec.rb` (nouveau) : `index` (200 + tri par position + badge + menu paramètres), `new`, `create` (persistance + redirection + capacité invalide réaffichée), `update` (capacité modifiée), `destroy` (soft-delete : retiré de l'index, retrouvable via `Space.unscoped`).
- **Suite complète exécutée localement** : `244 exemples, 1 échec, 18 pending`.

### ⚠️ À noter — 1 échec **préexistant et indépendant**
`spec/requests/experiences_carriers_spec.rb:12` échoue **aussi sur `main`** (vérifié par rejeu sur `main` propre). C'est l'assertion trop large documentée dans la PR #32 (elle matche un nom dans un tooltip de la navbar, hors périmètre porteur). Cette PR ne touche ni les experiences, ni le tooltip navbar. Non corrigé ici pour rester dans le périmètre #37.

## 📸 Aperçu
![Paramètres → Espaces — index (badges multi-groupe)](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260703-032457-paramtres--espaces--index-badges-multi-groupe.png)

![Paramètres → Espaces — formulaire (capacité + aide)](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260703-032459-paramtres--espaces--formulaire-capacit--aide.png)

Captures prises sur le serveur de dev réel (Chrome headless, login Devise, assets Vite buildés). Index : onglet « Espaces » actif, colonnes position/nom/description/capacité, badges « multi-groupe » sur les espaces de capacité 5. Formulaire : champs Nom/Code/Description/Capacité (avec aide)/Position.

## Vérifié / non vérifié
- ✅ RSpec vert (hors échec préexistant ci-dessus) ; captures réelles des écrans index + formulaire.
- ✅ Diff limité au CRUD + menu + validation + decorator ; aucune migration (la colonne `capacity` existait déjà).
- ⚠️ Non vérifiés en navigateur : le parcours `show`, l'`update` et le `destroy` via l'UI (couverts par les request specs, mais pas cliqués à la main). Pas de lint configuré dans le repo (ni RuboCop, ni script JS) — rien à linter.
