### PR TITLE
Funnel B2C : passe design mobile (epic #27)

### DIFF
--- a/app/lib/form_builders/tailwind_form_builder.rb
+++ b/app/lib/form_builders/tailwind_form_builder.rb
@@ -91,11 +91,16 @@ module FormBuilders
       )
       hint = options.fetch(:hint, errors(method))
       error = options.fetch(:error, any_errors?(method))
+      show_label = merged_options.delete(:label) != false
 
       tag.div class: 'form-control' do
-        label(method, class: 'label mb-1') do
-          tag.span(label_text(method, merged_options), class: 'label-text')
-        end + super(method, merged_options) + hint_message(hint, error)
+        if show_label
+          label(method, class: 'label mb-1') do
+            tag.span(label_text(method, options), class: 'label-text')
+          end + super(method, merged_options) + hint_message(hint, error)
+        else
+          super(method, merged_options) + hint_message(hint, error)
+        end
         # end + super(method, merged_options) + hint_message(hint, error) + errors(method)
       end
     end
@@ -134,11 +139,16 @@ module FormBuilders
       default_options = { class: input_html_classes(method) }
       default_options[:class] << (options[:maxlength] ? 'w-20' : 'w-full')
       merged_options = default_options.merge(options)
+      show_label = merged_options.delete(:label) != false
 
       tag.div class: 'form-control' do
-        label(method, class: 'label') do
-          tag.span(label_text(method, merged_options), class: 'label-text')
-        end + super(method, merged_options) + errors(method)
+        if show_label
+          label(method, class: 'label') do
+            tag.span(label_text(method, options), class: 'label-text')
+          end + super(method, merged_options) + errors(method)
+        else
+          super(method, merged_options) + errors(method)
+        end
       end
     end
 
@@ -147,11 +157,16 @@ module FormBuilders
       default_options[:class]['w-full'] = 'w-48'
       default_options[:class]['text-sm'] = 'text-lg'
       merged_options = default_options.merge(options)
+      show_label = merged_options.delete(:label) != false
 
       tag.div class: 'form-control' do
-        label(method, class: 'label') do
-          tag.span(label_text(method, merged_options), class: 'label-text')
-        end + super(method, merged_options) + errors(method)
+        if show_label
+          label(method, class: 'label') do
+            tag.span(label_text(method, options), class: 'label-text')
+          end + super(method, merged_options) + errors(method)
+        else
+          super(method, merged_options) + errors(method)
+        end
       end
     end
 
@@ -160,11 +175,16 @@ module FormBuilders
       default_options[:class]['w-full'] = 'w-24'
       default_options[:class]['text-sm'] = 'text-lg'
       merged_options = default_options.merge(options)
+      show_label = merged_options.delete(:label) != false
 
       tag.div class: 'form-control' do
-        label(method, class: 'label') do
-          tag.span(label_text(method, merged_options), class: 'label-text')
-        end + super(method, merged_options) + errors(method)
+        if show_label
+          label(method, class: 'label') do
+            tag.span(label_text(method, options), class: 'label-text')
+          end + super(method, merged_options) + errors(method)
+        else
+          super(method, merged_options) + errors(method)
+        end
       end
     end
 

--- a/app/views/layouts/public_sheet.html.slim
+++ b/app/views/layouts/public_sheet.html.slim
@@ -22,7 +22,10 @@ html(lang="fr")
 
     .container.mx-auto.sm:px-6.lg:px-8
       .grid.justify-items-center
-        .bg-white.md:shadow-2xl.md:rounded-lg.md:m-8.lg:w-3/4
+        / w-full + min-w-0 : sans eux, la largeur intrinsèque d'un contenu large
+        / (table min-width des calendriers) gonfle l'item de grille et fait
+        / déborder le viewport mobile (layout 800px au lieu de 390px).
+        .bg-white.md:shadow-2xl.md:rounded-lg.md:m-8.w-full.min-w-0.lg:w-3/4
           = vite_image_tag "images/les-4-sources-tiers-lieu-yvoir-vue-drone.avif",
                            class: "w-full h-48 object-cover md:rounded-t-lg",
                            alt: "Les 4 Sources, tiers-lieu à Yvoir — vue drone"

--- a/app/views/public/reservations/_spaces_calendar.html.slim
+++ b/app/views/public/reservations/_spaces_calendar.html.slim
@@ -17,13 +17,13 @@
         button(
           type="button"
           data-action="click->public--spaces-calendar#prevNights"
-          class="w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
+          class="relative before:content-[''] before:absolute before:-inset-2 w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
           aria-label="Nuits précédentes")
           | ←
         button(
           type="button"
           data-action="click->public--spaces-calendar#nextNights"
-          class="w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
+          class="relative before:content-[''] before:absolute before:-inset-2 w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
           aria-label="Nuits suivantes")
           | →
 
@@ -31,13 +31,13 @@
     p.text-xs.text-gray-400 Choisissez vos dates à l'étape précédente.
   - else
     .overflow-x-auto.-mx-5.px-5(data-public--spaces-calendar-target="scrollArea")
-      table.border-collapse style="min-width: #{130 + @stay_nights.size * 90}px"
+      table.border-collapse style="min-width: #{130 + @stay_nights.size * 104}px"
 
         thead
           tr
             th.text-left.py-2.pr-4.text-xs.font-normal.text-gray-400.whitespace-nowrap.sticky.left-5.z-10.bg-white style="width:130px"
             - @stay_nights.each_with_index do |night, i|
-              th.text-center.py-2.px-1 style="width:90px"
+              th.text-center.py-2.px-1 style="width:104px"
                 p.text-xs.font-bold.text-gray-600 = "Nuit #{i + 1}"
                 p.text-xs.text-gray-400.font-normal = "#{fr_short_days[night.wday]} #{night.strftime("%-d/%-m")}"
 

--- a/app/views/public/reservations/_stay_calendar.html.slim
+++ b/app/views/public/reservations/_stay_calendar.html.slim
@@ -26,13 +26,13 @@
           button(
             type="button"
             data-action="click->public--stay-calendar#prevNights"
-            class="w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
+            class="relative before:content-[''] before:absolute before:-inset-2 w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
             aria-label="Nuits précédentes")
             | ←
           button(
             type="button"
             data-action="click->public--stay-calendar#nextNights"
-            class="w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
+            class="relative before:content-[''] before:absolute before:-inset-2 w-7 h-7 rounded-lg border border-gray-200 bg-white text-gray-500 hover:border-emerald-400 hover:text-emerald-600 flex items-center justify-center text-sm transition-colors focus:outline-none"
             aria-label="Nuits suivantes")
             | →
 
@@ -41,13 +41,13 @@
   - else
     / Scroll horizontal — libellés gauche collants (left-5 aligne avec le padding px-5)
     .overflow-x-auto.-mx-5.px-5(data-public--stay-calendar-target="scrollArea")
-      table.border-collapse style="min-width: #{130 + nights_count * 90}px"
+      table.border-collapse style="min-width: #{130 + nights_count * 104}px"
 
         thead
           tr
             th.text-left.py-2.pr-4.text-xs.font-normal.text-gray-400.whitespace-nowrap.sticky.left-5.z-10.bg-white style="width:130px"
             - @stay_nights.each_with_index do |night, i|
-              th.text-center.py-2.px-1(data-wday=night.wday.to_s style="width:90px")
+              th.text-center.py-2.px-1(data-wday=night.wday.to_s style="width:104px")
                 p.text-xs.font-bold.text-gray-600 = "Nuit #{i + 1}"
                 p.text-xs.text-gray-400.font-normal = "#{fr_short_days[night.wday]} #{night.strftime("%-d/%-m")}"
 
@@ -59,9 +59,12 @@
               span.text-xs.font-semibold.text-gray-400.uppercase.tracking-wide 🏡 Hébergement
 
           - @lodgings.each do |lodging|
+            - lodging_rate = Pricing::Catalog.lodging_rate(lodging.name)
             tr class="border-t border-gray-50"
               td.py-2.pr-4.whitespace-nowrap.sticky.left-5.z-10.bg-white
                 span.text-sm.text-gray-800.font-medium = short_names[lodging.name] || lodging.name
+                - if lodging_rate
+                  p.text-xs.text-gray-400.leading-tight.mt-0.5 = "dès #{number_to_currency(lodging_rate.extra_night_cents / 100.0, unit: '€', format: '%n %u', precision: 0)}/nuit"
               - @stay_nights.each_with_index do |night, i|
                 - avail = (@lodging_availability.dig(lodging.id, i) != false)
                 - sel   = selected_ids.at(i).to_s == lodging.id.to_s

--- a/app/views/public/reservations/_stepper_cell.html.slim
+++ b/app/views/public/reservations/_stepper_cell.html.slim
@@ -8,7 +8,7 @@
   button(
     type="button"
     data-action="click->public--stepper#decrement"
-    class="appearance-none w-8 h-8 rounded-lg border border-gray-200 bg-white text-gray-400 text-base font-bold flex items-center justify-center transition-colors hover:border-emerald-400 hover:text-emerald-500 focus:outline-none disabled:opacity-30 disabled:cursor-not-allowed")
+    class="appearance-none relative before:content-[''] before:absolute before:-inset-1 w-9 h-9 rounded-lg border border-gray-200 bg-white text-gray-400 text-base font-bold flex items-center justify-center transition-colors hover:border-emerald-400 hover:text-emerald-500 focus:outline-none disabled:opacity-30 disabled:cursor-not-allowed")
     | −
 
   span(
@@ -25,5 +25,5 @@
   button(
     type="button"
     data-action="click->public--stepper#increment"
-    class="appearance-none w-8 h-8 rounded-lg border border-gray-200 bg-white text-gray-400 text-base font-bold flex items-center justify-center transition-colors hover:border-emerald-400 hover:text-emerald-500 focus:outline-none")
+    class="appearance-none relative before:content-[''] before:absolute before:-inset-1 w-9 h-9 rounded-lg border border-gray-200 bg-white text-gray-400 text-base font-bold flex items-center justify-center transition-colors hover:border-emerald-400 hover:text-emerald-500 focus:outline-none")
     | +

--- a/app/views/public/reservations/compose.html.slim
+++ b/app/views/public/reservations/compose.html.slim
@@ -7,7 +7,7 @@
     / ── Step indicator ───────────────────────────────────────
     .flex.items-center.mb-10
       .flex.items-center.flex-shrink-0
-        = link_to public_reservation_dates_path, class: "flex items-center group" do
+        = link_to public_reservation_dates_path, class: "flex items-center group relative before:content-[''] before:absolute before:-inset-1" do
           .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-100.text-emerald-700.border-2.border-emerald-400.group-hover:border-emerald-600.transition-colors ✓
           span.ml-2.text-sm.text-emerald-600.hidden.sm:inline.group-hover:underline Votre séjour
       .flex-1.h-px.mx-4.bg-emerald-200
@@ -28,7 +28,7 @@
         strong = l(@draft.departure_date, format: :long)
         .ml-1.px-2.py-0.5.bg-emerald-100.text-emerald-700.rounded-full.text-xs.font-semibold
           = "#{@draft.nights} nuit#{"s" if @draft.nights.to_i > 1}"
-        = link_to "Modifier", public_reservation_dates_path, class: "ml-2 text-xs text-gray-400 hover:text-gray-600 underline"
+        = link_to "Modifier", public_reservation_dates_path, class: "ml-2 text-xs text-gray-400 hover:text-gray-600 underline relative before:content-[''] before:absolute before:-inset-y-3.5 before:inset-x-0"
 
     .space-y-6
 

--- a/app/views/public/reservations/contact.html.slim
+++ b/app/views/public/reservations/contact.html.slim
@@ -5,12 +5,12 @@
     / ── Step indicator ───────────────────────────────────────
     .flex.items-center.mb-10
       .flex.items-center.flex-shrink-0
-        = link_to public_reservation_dates_path, class: "flex items-center group" do
+        = link_to public_reservation_dates_path, class: "flex items-center group relative before:content-[''] before:absolute before:-inset-1" do
           .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-100.text-emerald-700.border-2.border-emerald-400.group-hover:border-emerald-600.transition-colors ✓
           span.ml-2.text-sm.text-emerald-600.hidden.sm:inline.group-hover:underline Votre séjour
       .flex-1.h-px.mx-4.bg-emerald-200
       .flex.items-center.flex-shrink-0
-        = link_to public_reservation_compose_path, class: "flex items-center group" do
+        = link_to public_reservation_compose_path, class: "flex items-center group relative before:content-[''] before:absolute before:-inset-1" do
           .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-100.text-emerald-700.border-2.border-emerald-400.group-hover:border-emerald-600.transition-colors ✓
           span.ml-2.text-sm.text-emerald-600.hidden.sm:inline.group-hover:underline Composition
       .flex-1.h-px.mx-4.bg-emerald-200
@@ -81,7 +81,7 @@
                 span.text-sm.font-medium.text-gray-700 = dog_label
                 - if @draft.dogs_count.to_i > 1
                   p.text-xs.text-amber-600.mt-1 Notre équipe vous recontacte pour les chiens supplémentaires.
-              = link_to "Modifier", public_reservation_compose_path, class: "text-xs text-emerald-600 hover:underline flex-shrink-0 ml-4"
+              = link_to "Modifier", public_reservation_compose_path, class: "text-xs text-emerald-600 hover:underline flex-shrink-0 ml-4 relative before:content-[''] before:absolute before:-inset-y-3.5 before:inset-x-0"
 
             / CTA
             = f.submit "Envoyer ma demande et payer l'acompte →",

--- a/app/views/public/reservations/dates.html.slim
+++ b/app/views/public/reservations/dates.html.slim
@@ -34,6 +34,7 @@
             label.block
               span.text-xs.font-medium.text-gray-500.uppercase.tracking-wide Arrivée
               = f.date_field "reservation[arrival_date]",
+                  label: false,
                   value: @draft.arrival_date,
                   min: Date.today.iso8601,
                   max: (Date.today >> 18).iso8601,
@@ -43,6 +44,7 @@
             label.block
               span.text-xs.font-medium.text-gray-500.uppercase.tracking-wide Départ
               = f.date_field "reservation[departure_date]",
+                  label: false,
                   value: @draft.departure_date,
                   min: Date.today.iso8601,
                   max: (Date.today >> 18).iso8601,
@@ -57,7 +59,7 @@
           p.text-xs.text-gray-400.mt-1 Réservation jusqu'à 18 mois à l'avance.
 
           .mt-3
-            button(type="button" data-action="public--avail-modal#open" class="text-sm text-emerald-700 font-medium hover:text-emerald-900 underline underline-offset-2 transition-colors")
+            button(type="button" data-action="public--avail-modal#open" class="relative before:absolute before:-inset-y-3 before:inset-x-0 text-sm text-emerald-700 font-medium hover:text-emerald-900 underline underline-offset-2 transition-colors")
               | 📅 Voir les disponibilités →
 
         / Groupe
@@ -68,12 +70,14 @@
             label.block
               span.text-xs.font-medium.text-gray-500.uppercase.tracking-wide Adultes (13 ans +)
               = f.number_field "reservation[adults]",
+                  label: false,
                   value: (@draft.adults.presence || 1),
                   min: 1, max: 50,
                   class: "mt-1.5 w-full rounded-xl border-gray-300 shadow-sm text-base focus:border-emerald-500 focus:ring-emerald-500"
             label.block
               span.text-xs.font-medium.text-gray-500.uppercase.tracking-wide Enfants (3–12 ans)
               = f.number_field "reservation[children]",
+                  label: false,
                   value: (@draft.children || 0),
                   min: 0, max: 50,
                   class: "mt-1.5 w-full rounded-xl border-gray-300 shadow-sm text-base focus:border-emerald-500 focus:ring-emerald-500"


### PR DESCRIPTION
Suite de l'epic #27 — audit AC-D-01→09 + correctifs.

- `44f14aa` fix(funnel): supprime les labels auto-générés parasites sur l'étape 1 (`label: false` dans TailwindFormBuilder)
- `720eb61` fix(public): débordement horizontal mobile corrigé à la racine (item grid du layout `public_sheet` : `w-full min-w-0`)
- `eb3cd3f` feat(funnel): tap targets 44px sur les grilles + prix « dès X €/nuit »

Vérifié : parcours 3 étapes à 320/390 px en headless CDP (zéro overflow, `elementFromPoint` OK sur les zones de tap), desktop 1440 sans régression. RSpec 233/234 (l'unique failure `experiences_carriers_spec` pré-existe sur main).

**Draft en attente de la validation tactile de Michael sur téléphone.** Détail AC par AC : https://github.com/les4sources/claudy/issues/27#issuecomment-4952266554