### PR TITLE
Funnel étape 1 : contrainte « départ > arrivée » visible et validée

### DIFF
--- a/app/controllers/public/reservations_controller.rb
+++ b/app/controllers/public/reservations_controller.rb
@@ -18,14 +18,24 @@ module Public
 
     # Étape 1 — dates, groupe, animal.
     def dates
-      @lodgings              = bookable_lodgings
-      @cal_month             = (@draft.arrival_date&.beginning_of_month || Date.today.beginning_of_month)
-      @availability_calendar = build_availability_calendar(@lodgings, month: @cal_month)
+      prepare_dates_view
     end
 
-    # Transition étape 1 → 2.
+    # Transition étape 1 → 2. Un départ antérieur ou égal à l'arrivée re-rend
+    # l'étape 1 avec une erreur, sans écrire quoi que ce soit en session : un
+    # draft valide déjà présent reste intact.
     def advance_dates
-      persist_draft(merged_draft_params)
+      attrs     = merged_draft_params
+      candidate = merge_draft(attrs)
+
+      if invalid_stay_dates?(candidate)
+        @draft       = candidate
+        @dates_error = "La date de départ doit être postérieure à la date d'arrivée."
+        prepare_dates_view
+        return render :dates, status: :unprocessable_entity
+      end
+
+      persist_draft(attrs)
       redirect_to public_reservation_compose_path
     end
 
@@ -113,14 +123,33 @@ module Public
       @draft = Reservations::Draft.new(session[DRAFT_SESSION_KEY] || {})
     end
 
-    def persist_draft(attrs)
+    # Fusionne des paramètres dans le draft courant sans toucher à la session.
+    def merge_draft(attrs)
       incoming = attrs.to_h.deep_symbolize_keys
       merged = @draft.to_h.merge(incoming) do |_key, old, new|
         new.nil? || (new.respond_to?(:empty?) && new.empty? && !old.nil?) ? old : new
       end
-      @draft = Reservations::Draft.new(merged)
+      Reservations::Draft.new(merged)
+    end
+
+    def persist_draft(attrs)
+      @draft = merge_draft(attrs)
       session[DRAFT_SESSION_KEY] = @draft.to_h
       @draft
+    end
+
+    # Dates incohérentes : les deux sont saisies mais le départ ne suit pas
+    # l'arrivée. Des dates absentes restent tolérées (l'étape 2 le signale).
+    def invalid_stay_dates?(draft)
+      return false if draft.arrival_date.blank? || draft.departure_date.blank?
+
+      draft.departure_date <= draft.arrival_date
+    end
+
+    def prepare_dates_view
+      @lodgings              = bookable_lodgings
+      @cal_month             = (@draft.arrival_date&.beginning_of_month || Date.today.beginning_of_month)
+      @availability_calendar = build_availability_calendar(@lodgings, month: @cal_month)
     end
 
     def clear_draft

--- a/app/views/public/reservations/dates.html.slim
+++ b/app/views/public/reservations/dates.html.slim
@@ -44,11 +44,15 @@
               span.text-xs.font-medium.text-gray-500.uppercase.tracking-wide Départ
               = f.date_field "reservation[departure_date]",
                   value: @draft.departure_date,
-                  min: Date.today.iso8601,
+                  min: ((@draft.arrival_date + 1) if @draft.arrival_date).try(:iso8601) || Date.today.iso8601,
                   max: (Date.today >> 18).iso8601,
                   class: "mt-1.5 w-full rounded-xl border-gray-300 shadow-sm text-base focus:border-emerald-500 focus:ring-emerald-500",
                   data: { "public--dates-nights-target": "departure",
                           action: "change->public--dates-nights#compute" }
+
+          - if @dates_error.present?
+            p.mt-3.rounded-xl.bg-red-50.border.border-red-200.text-red-700.text-sm.p-3(role="alert" data-dates-error="true")
+              = @dates_error
 
           / Badge nuits dynamique
           .mt-3.h-6.flex.items-center

--- a/spec/requests/public/reservations_spec.rb
+++ b/spec/requests/public/reservations_spec.rb
@@ -27,6 +27,46 @@ RSpec.describe "Public::Reservations (/reservation)", type: :request do
     end
   end
 
+  describe "étape 1 — contrainte départ > arrivée (#40)" do
+    it "GET /reservation/sejour n'affiche aucune erreur de dates au premier affichage" do
+      get "/reservation/sejour"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("data-dates-error")
+    end
+
+    it "POST avec un départ antérieur à l'arrivée re-rend l'étape 1 avec une erreur" do
+      post "/reservation/sejour", params: { reservation: { arrival_date: departure, departure_date: arrival, adults: 2 } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("data-dates-error")
+      expect(response.body).to include("postérieure à la date d&#39;arrivée")
+    end
+
+    it "POST avec un départ égal à l'arrivée re-rend l'étape 1 avec une erreur" do
+      post "/reservation/sejour", params: { reservation: { arrival_date: arrival, departure_date: arrival, adults: 2 } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("data-dates-error")
+    end
+
+    it "POST avec des dates valides avance vers l'étape 2 (comportement préservé)" do
+      post "/reservation/sejour", params: { reservation: { arrival_date: arrival, departure_date: departure, adults: 2 } }
+
+      expect(response).to redirect_to("/reservation/composer")
+    end
+
+    it "ne corrompt pas un draft valide déjà en session (anti-régression)" do
+      post "/reservation/sejour", params: { reservation: { arrival_date: arrival, departure_date: departure, adults: 2 } }
+      post "/reservation/sejour", params: { reservation: { arrival_date: departure, departure_date: arrival, adults: 2 } }
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      # L'étape 2 reste alimentée par les dates valides mémorisées.
+      get "/reservation/composer"
+      expect(response.body).to include(I18n.l(Date.parse(arrival), format: :long))
+      expect(response.body).not_to include("Choisissez vos dates à l'étape précédente")
+    end
+  end
+
   describe "devis temps-réel (AC-T2-10/11)" do
     it "POST /reservation/devis répond en Turbo Stream et affiche le total TVAC" do
       post "/reservation/devis", params: { reservation: { lodging_id: hulotte.id, arrival_date: arrival, departure_date: departure } },


### PR DESCRIPTION
Closes #40

Le funnel laissait passer un départ ≤ arrivée : `Draft#nights` clampait à 0 et l'étape 2 s'affichait vide, sans explication. Cette PR ferme le trou côté serveur et rend la contrainte visible dès le premier rendu.

## Ce qui change

- **`Public::ReservationsController#advance_dates`** : si les deux dates sont saisies et que le départ ne suit pas l'arrivée, on re-rend l'étape 1 (`422`) avec un message d'erreur inline au lieu d'avancer. Extraction de `merge_draft` (fusion sans écriture) et de `prepare_dates_view` (données de la vue partagées entre `dates` et le re-render).
- **Session intacte** : une soumission invalide n'écrit rien — un draft valide déjà mémorisé n'est pas altéré (AC anti-régression, couvert par une spec).
- **Vue `dates.html.slim`** : bloc d'erreur inline sous les champs (`[data-dates-error]`), et `min` du champ départ = arrivée + 1 dès le rendu serveur quand une arrivée est déjà connue.
- Le contrôleur Stimulus `public--dates-nights` faisait **déjà** le travail côté client (pose du `min`, vidage du départ devenu invalide, badge « X nuits ») : rien à changer là, je l'ai vérifié au navigateur.

## Tests

- `bundle exec rspec` → **249 exemples, 0 échec** (18 pending, squelettes pré-existants). La failure `experiences_carriers_spec` mentionnée dans l'issue n'existe plus.
- 5 nouvelles specs request : départ <, départ =, pas d'erreur au GET, parcours nominal (redirect `/reservation/composer`), draft valide en session préservé après une soumission invalide.
- Lint : le projet n'a **ni RuboCop ni ESLint** (rien dans le `Gemfile`, aucun script `lint`, la seule CI est le gate d'issues) — donc aucun lint à passer.

## 📸 Aperçu

Garde-fou serveur, obtenu en contournant volontairement la contrainte client (`novalidate` + `min` retiré) pour prouver que le serveur refuse bien :

![Étape 1 — départ ≤ arrivée : erreur serveur affichée](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260713-032039-tape-1--dpart--arrive--erreur-serveur-affiche.png)

## À valider / non testé

- **Vérification navigateur du garde-fou client** faite via une spec système Chrome headless jetable (supprimée avant commit — le repo n'a pas d'infra system-spec, et la gem `webdrivers` n'y résout plus chromedriver pour Chrome 150). Le comportement JS n'est donc **pas couvert par une spec permanente**.
- **Bug pré-existant repéré au passage, hors périmètre** : le `FormBuilder` custom injecte un libellé parasite au-dessus de chaque champ de l'étape 1 (« Reservation[arrival date] », « Reservation[adults] »… — visible sur la capture). Ça vient de `main`, pas de cette PR. Ça mérite une issue dédiée.
- Le cas « dates absentes » reste toléré comme avant (l'étape 2 le signale) — je n'ai rien changé là, c'était hors périmètre.