### PR TITLE
Refs #26 — Phase 1 : Stay public (jeton) + payment_status

### DIFF
--- a/app/controllers/public/stays_controller.rb
+++ b/app/controllers/public/stays_controller.rb
@@ -1,0 +1,15 @@
+module Public
+  # Page client du séjour-composite (epic #26, Phase 1). Accessible sans Devise,
+  # via le jeton général du séjour — comme la page booking historique, qui reste
+  # en place pour les liens déjà envoyés.
+  class StaysController < Public::BaseController
+    layout "public_sheet"
+
+    def show
+      @stay = Stay.find_by!(token: params[:token]).decorate
+      @payments = PaymentDecorator.decorate_collection(@stay.payments.order(created_at: :asc))
+    rescue ActiveRecord::RecordNotFound
+      raise ActionController::RoutingError, "Not Found"
+    end
+  end
+end

--- a/app/decorators/stay_decorator.rb
+++ b/app/decorators/stay_decorator.rb
@@ -29,6 +29,42 @@ class StayDecorator < ApplicationDecorator
                   title: "Réservation provenant de #{style[:label]}")
   end
 
+  PAYMENT_STATUS_STYLES = {
+    "paid"           => { key: "paid", classes: "bg-green-100 text-green-800" },
+    "partially_paid" => { key: "partially_paid", classes: "bg-amber-100 text-amber-800" },
+    "pending"        => { key: "pending", classes: "bg-gray-100 text-gray-700" }
+  }.freeze
+
+  # Badge du statut de paiement du séjour (epic #26). Libellé traduit — la page
+  # client est destinée à devenir trilingue (issue #15).
+  def payment_status_badge
+    style = PAYMENT_STATUS_STYLES.fetch(object.payment_status, PAYMENT_STATUS_STYLES["pending"])
+    h.content_tag(:span, h.t("public.stays.payment_status.#{style[:key]}"),
+                  class: "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium #{style[:classes]}")
+  end
+
+  # Lignes du séjour-composite : un réservable (Booking / SpaceBooking) par ligne,
+  # avec ses dates et son montant. Alimente la page client /sejour/:token.
+  def item_lines
+    object.stay_items.map do |item|
+      bookable = item.bookable
+      next if bookable.nil?
+
+      {
+        kind: item.bookable_type,
+        name: item_label(bookable),
+        date_range: bookable.decorate.try(:date_range),
+        amount: h.humanized_money_with_symbol(Money.new(bookable.try(:price_cents).to_i))
+      }
+    end.compact
+  end
+
+  # Total formaté pour la page client. Volontairement PAS nommé `total_amount` :
+  # les vues admin appellent `@stay.total_amount.format` et attendent un Money.
+  def formatted_total
+    h.humanized_money_with_symbol(object.total_amount)
+  end
+
   def status_badge
     style = STATUS_STYLES.fetch(object.status, { label: object.status.presence || "—", classes: "bg-gray-100 text-gray-700" })
     h.content_tag(:span, style[:label],
@@ -41,6 +77,20 @@ class StayDecorator < ApplicationDecorator
     from = arrival_date.present? ? h.l(arrival_date, format: :long) : "?"
     to = departure_date.present? ? h.l(departure_date, format: :long) : "?"
     "#{from} → #{to}"
+  end
+
+  # Libellé d'une ligne du séjour : ce qui est réservé (hébergement, espace), pas
+  # qui l'a réservé — le nom du client est déjà affiché en tête de page.
+  def item_label(bookable)
+    case bookable
+    when Booking
+      bookable.lodging&.name.presence || h.t("public.stays.items.lodging")
+    when SpaceBooking
+      spaces = bookable.try(:spaces)&.map(&:name)&.compact_blank
+      spaces.presence&.join(", ") || h.t("public.stays.items.space")
+    else
+      h.t("public.stays.items.other")
+    end
   end
 
   # Nom/prénom + nom de groupe issus du booking sous-jacent.

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -20,6 +20,10 @@ class Stay < ApplicationRecord
   # porte la valeur par défaut "reservation".
   SOURCES = %w[reservation tally_legacy ota manual].freeze
 
+  # Statut de paiement du séjour (epic #26, Phase 1). Le séjour devient l'ancre
+  # de paiement ; Booking garde le sien tant que la colonne existe.
+  PAYMENT_STATUSES = %w[pending partially_paid paid].freeze
+
   belongs_to :customer
   has_many :stay_items, dependent: :destroy
   has_many :experience_bookings, dependent: :destroy
@@ -30,8 +34,11 @@ class Stay < ApplicationRecord
   monetize :total_amount_cents
 
   before_create :generate_activity_token
+  before_create :generate_token
 
   validates :source, inclusion: { in: SOURCES, message: "Canal d'attribution invalide" }
+  validates :payment_status, inclusion: { in: PAYMENT_STATUSES, message: "Statut de paiement invalide" }
+  validates :token, uniqueness: true, allow_nil: true
 
   scope :current_and_future, -> { where("departure_date >= ?", Date.today).order(arrival_date: :asc) }
   scope :past, -> { where("departure_date < ?", Date.today).order(arrival_date: :desc) }
@@ -62,12 +69,46 @@ class Stay < ApplicationRecord
   # Recompute aggregate dates / amount from the attached items (min arrival,
   # max departure, sum of prices). Booking and SpaceBooking both expose
   # from_date/to_date/price_cents.
+  # Recalcule le statut de paiement à partir des paiements encaissés. Même
+  # sémantique que `Booking#set_payment_status`, à une nuance près : un séjour
+  # dont le total est à 0 € et sans paiement reste « pending » (et ne bascule
+  # pas en « paid » par l'effet de bord d'un `0 >= 0`).
+  def set_payment_status
+    paid_cents = payments.paid.sum(:amount_cents)
+
+    status = if paid_cents.positive? && paid_cents >= total_amount_cents.to_i
+      "paid"
+    elsif paid_cents.positive?
+      "partially_paid"
+    else
+      "pending"
+    end
+
+    update(payment_status: status)
+  end
+
+  def paid?
+    payment_status == "paid"
+  end
+
   private
 
   def generate_activity_token
     loop do
       self.activity_selection_token = SecureRandom.urlsafe_base64(20)
       break unless Stay.exists?(activity_selection_token: activity_selection_token)
+    end
+  end
+
+  # Jeton public général du séjour — support de la page client /sejour/:token.
+  # Distinct de `activity_selection_token` (jeton d'usage unique pour le choix
+  # des activités), qu'on ne réutilise pas pour ne pas élargir sa portée.
+  def generate_token
+    return if token.present?
+
+    loop do
+      self.token = SecureRandom.urlsafe_base64(20)
+      break unless Stay.unscoped.exists?(token: token)
     end
   end
 

--- a/app/views/public/stays/_payments.html.slim
+++ b/app/views/public/stays/_payments.html.slim
@@ -1,0 +1,43 @@
+/ Paiements du séjour — même mécanisme que la page booking : chaque paiement
+/ `pending` expose le CTA Stripe via `pay_public_payment_path` (epic #26, Phase 1).
+- pending_payments = @payments.select(&:pending?)
+- paid_payments = @payments.select(&:paid?)
+
+- if pending_payments.any?
+  .mt-6.space-y-4(data-stay-payments="pending")
+    - pending_payments.each do |payment|
+      .bg-teal-100.sm:rounded-lg
+        .px-4.py-5.sm:p-6
+          .sm:flex.sm:items-start.sm:justify-between
+            div
+              h3.text-base.font-semibold.leading-6.text-gray-900
+                = t("public.stays.payments.pay_online")
+              .mt-2.max-w-xl.text-sm.text-gray-700
+                p
+                  span.font-semibold
+                    = t("public.stays.payments.invitation", amount: payment.amount)
+                  = " "
+                  = t("public.stays.payments.stripe_notice")
+                .mt-4
+                  = render "payments/icons"
+
+            .mt-5.sm:ml-6.sm:mt-0.sm:flex.sm:flex-shrink-0.sm:items-center
+              = link_to t("public.stays.payments.pay_cta"),
+                        pay_public_payment_path(payment),
+                        target: "_blank",
+                        class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+
+- if paid_payments.any?
+  .mt-6(data-stay-payments="paid")
+    h4.font-semibold.my-4 = t("public.stays.payments.received_heading")
+    ul.divide-y.divide-gray-100[role="list"]
+      - paid_payments.each do |payment|
+        li.flex.items-center.justify-between.gap-4.py-3
+          .flex.items-center.gap-3
+            span.text-2xl = payment.payment_method_emoji
+            / `line` ne couvre pas tous les moyens de paiement — on retombe sur le montant.
+            span.text-sm.text-gray-700 = payment.line.presence || payment.amount
+          span.text-sm.text-gray-500 = payment.updated_at
+
+- if pending_payments.empty? && paid_payments.empty?
+  p.mt-6.text-sm.text-gray-500 = t("public.stays.show.no_payment")

--- a/app/views/public/stays/show.html.slim
+++ b/app/views/public/stays/show.html.slim
@@ -1,0 +1,45 @@
+/ Page client du séjour-composite (epic #26, Phase 1). Toutes les chaînes vivent
+/ dans config/locales/public.*.yml (scope public.stays.*) — la page naît
+/ i18n-ready pour le passage FR/NL/EN de l'issue #15.
+- content_for :meta_title, t(".meta_title")
+
+- content_for :page_header do
+  = render 'layouts/public/components/page_header', title: t(".title")
+
+.overflow-hidden
+  .py-5
+    .flex.items-center.justify-between.mb-6
+      h3.text-xl.font-bold.leading-6.text-gray-900
+        = t(".composition_heading")
+      = @stay.payment_status_badge
+
+    dl.grid.grid-cols-1.gap-x-4.gap-y-8.sm:grid-cols-2.mb-8
+      .sm:col-span-1
+        dt.text-base.font-medium.text-gray-500
+          = t(".contact_heading")
+        dd.mt-1.text-gray-900.text-base
+          = @stay.contact_line
+      .sm:col-span-1
+        dt.text-base.font-medium.text-gray-500
+          = t(".dates_heading")
+        dd.mt-1.text-base.text-gray-900
+          = @stay.date_range
+
+    - lines = @stay.item_lines
+    - if lines.empty?
+      p.text-sm.text-gray-500 = t(".empty_composition")
+    - else
+      ul.divide-y.divide-gray-200.border-t.border-b.border-gray-200(data-stay-items="true")
+        - lines.each do |line|
+          li.flex.items-center.justify-between.gap-4.py-4
+            div
+              p.text-base.font-medium.text-gray-900 = line[:name]
+              - if line[:date_range].present?
+                p.text-sm.text-gray-500 = line[:date_range]
+            p.text-base.font-semibold.text-gray-900.whitespace-nowrap = line[:amount]
+
+      .flex.items-center.justify-between.py-4
+        p.text-base.font-semibold.text-gray-900 = t(".total")
+        p.text-lg.font-bold.text-gray-900 = @stay.formatted_total
+
+    = render "public/stays/payments"

--- a/config/locales/public.fr.yml
+++ b/config/locales/public.fr.yml
@@ -1,0 +1,28 @@
+fr:
+  public:
+    stays:
+      show:
+        meta_title: "Votre séjour aux 4 Sources"
+        title: "Votre séjour aux 4 Sources"
+        contact_heading: "Vos informations"
+        dates_heading: "Dates de votre séjour"
+        composition_heading: "Votre séjour"
+        empty_composition: "Aucun élément n'est encore rattaché à ce séjour."
+        total: "Total"
+        no_payment: "Aucun paiement n'est attendu pour le moment."
+        questions_html: "Une question ? Écrivez-nous à %{email} ou appelez Malau au %{phone}."
+      items:
+        lodging: "Hébergement"
+        space: "Espace"
+        other: "Prestation"
+      payment_status:
+        pending: "En attente de paiement"
+        partially_paid: "Partiellement payé"
+        paid: "Payé"
+      payments:
+        heading: "Paiement"
+        pay_online: "Payer en ligne"
+        invitation: "Nous vous invitons à payer en ligne le montant de %{amount}."
+        stripe_notice: "Ce paiement est géré par Stripe : nous n'avons à aucun moment accès à vos données de paiement."
+        pay_cta: "Paiement →"
+        received_heading: "Paiements reçus"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,11 @@ Rails.application.routes.draw do
   # Vue admin Pôle Accueil — index des Stays récents filtrable par source (Devise).
   get "sejours/recents", to: "stays#recent", as: :recent_stays
 
+  # Page client du séjour-composite (epic #26, Phase 1) — jeton, sans Devise.
+  # Route à la racine (et non sous /public) : c'est l'URL envoyée aux clients et
+  # la cible des redirections Stripe, on la garde courte, comme /reservation/sejour.
+  get "sejour/:token", to: "public/stays#show", as: :public_stay
+
   namespace :public do
     resources :bookings, only: [:new, :create] do
       get "edit_estimated_arrival", on: :member

--- a/db/migrate/20260713031500_add_token_and_payment_status_to_stays.rb
+++ b/db/migrate/20260713031500_add_token_and_payment_status_to_stays.rb
@@ -1,0 +1,55 @@
+class AddTokenAndPaymentStatusToStays < ActiveRecord::Migration[7.0]
+  # Phase 1 de l'epic #26 : le Stay devient l'objet public et l'ancre de statut
+  # de paiement. Additive et réversible — Booking garde son token et son
+  # payment_status tant qu'il existe.
+  def up
+    add_column :stays, :token, :string
+    add_column :stays, :payment_status, :string, default: "pending", null: false
+
+    say_with_time "backfill stays.token" do
+      select_values("SELECT id FROM stays WHERE token IS NULL").each do |id|
+        execute("UPDATE stays SET token = #{quote(SecureRandom.urlsafe_base64(20))} WHERE id = #{id.to_i}")
+      end
+    end
+
+    add_index :stays, :token, unique: true
+
+    # payment_status dérivé des paiements déjà encaissés. Un paiement compte pour
+    # le séjour s'il pointe directement dessus (stay_id, posé par la fondation
+    # PR #30) ou s'il pointe sur un Booking rattaché au séjour. Sous-requête
+    # corrélée : un même paiement ne peut pas être compté deux fois, même quand
+    # le séjour porte plusieurs bookings.
+    execute(<<~SQL)
+      UPDATE stays
+         SET payment_status = CASE
+               WHEN paid.cents > 0 AND paid.cents >= stays.total_amount_cents THEN 'paid'
+               WHEN paid.cents > 0 THEN 'partially_paid'
+               ELSE 'pending'
+             END
+        FROM (
+          SELECT s.id AS stay_id,
+                 COALESCE((
+                   SELECT SUM(p.amount_cents)
+                     FROM payments p
+                    WHERE p.status = 'paid'
+                      AND p.deleted_at IS NULL
+                      AND (p.stay_id = s.id
+                           OR p.booking_id IN (
+                                SELECT si.bookable_id
+                                  FROM stay_items si
+                                 WHERE si.stay_id = s.id
+                                   AND si.bookable_type = 'Booking'
+                                   AND si.deleted_at IS NULL))
+                 ), 0) AS cents
+            FROM stays s
+        ) AS paid
+       WHERE paid.stay_id = stays.id
+    SQL
+  end
+
+  def down
+    remove_index :stays, :token
+    remove_column :stays, :payment_status
+    remove_column :stays, :token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_02_201250) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_13_031500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -587,10 +587,13 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_02_201250) do
     t.string "source", default: "reservation", null: false
     t.string "activity_selection_token"
     t.datetime "activity_email_sent_at"
+    t.string "token"
+    t.string "payment_status", default: "pending", null: false
     t.index ["activity_selection_token"], name: "index_stays_on_activity_selection_token"
     t.index ["customer_id"], name: "index_stays_on_customer_id"
     t.index ["legacy_origin"], name: "index_stays_on_legacy_origin_unique_live", unique: true, where: "((legacy_origin IS NOT NULL) AND (deleted_at IS NULL))"
     t.index ["source"], name: "index_stays_on_source"
+    t.index ["token"], name: "index_stays_on_token", unique: true
   end
 
   create_table "stripe_events", force: :cascade do |t|

--- a/spec/models/stay_spec.rb
+++ b/spec/models/stay_spec.rb
@@ -84,6 +84,70 @@ RSpec.describe Stay, type: :model do
     end
   end
 
+  describe "jeton public (#26 Phase 1)" do
+    it "génère un token à la création" do
+      expect(Stay.create!(customer: customer).token).to be_present
+    end
+
+    it "génère des tokens distincts" do
+      first = Stay.create!(customer: customer)
+      second = Stay.create!(customer: customer)
+      expect(first.token).not_to eq(second.token)
+    end
+
+    it "refuse un token dupliqué" do
+      existing = Stay.create!(customer: customer)
+      duplicate = Stay.new(customer: customer, token: existing.token)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:token]).to be_present
+    end
+  end
+
+  describe "#set_payment_status (#26 Phase 1)" do
+    let(:stay) { Stay.create!(customer: customer, total_amount_cents: 20_000) }
+
+    def pay(cents, status)
+      b = booking(from: Date.new(2026, 7, 1), to: Date.new(2026, 7, 3), price_cents: 20_000)
+      stay.stay_items.create!(bookable: b)
+      Payment.create!(booking: b, stay: stay, amount_cents: cents, status: status, payment_method: "card")
+    end
+
+    it "démarre à pending" do
+      expect(stay.payment_status).to eq("pending")
+    end
+
+    it "passe en paid quand les paiements encaissés couvrent le total" do
+      pay(20_000, "paid")
+      stay.set_payment_status
+      expect(stay.reload.payment_status).to eq("paid")
+      expect(stay).to be_paid
+    end
+
+    it "passe en partially_paid quand l'encaissé est insuffisant" do
+      pay(5_000, "paid")
+      stay.set_payment_status
+      expect(stay.reload.payment_status).to eq("partially_paid")
+    end
+
+    it "reste pending tant que le paiement n'est pas encaissé" do
+      pay(20_000, "pending")
+      stay.set_payment_status
+      expect(stay.reload.payment_status).to eq("pending")
+    end
+
+    it "reste pending pour un séjour à 0 € sans paiement (pas de bascule 0 >= 0)" do
+      zero = Stay.create!(customer: customer, total_amount_cents: 0)
+      zero.set_payment_status
+      expect(zero.reload.payment_status).to eq("pending")
+    end
+
+    it "refuse un statut de paiement inconnu" do
+      stay.payment_status = "refunded"
+      expect(stay).not_to be_valid
+      expect(stay.errors[:payment_status]).to be_present
+    end
+  end
+
   describe "#source (Q9 — AC-T2-22 / AC-T2-22b)" do
     it "défaute sur 'reservation' quand non précisé" do
       stay = Stay.create!(customer: customer)

--- a/spec/requests/public/stays_spec.rb
+++ b/spec/requests/public/stays_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "Public::Stays (/sejour/:token)", type: :request do
+  let(:customer) { Customer.create!(email: "stay@example.com", customer_type: "individual") }
+
+  let(:booking) do
+    Booking.create!(firstname: "Alex", lastname: "Durand", from_date: Date.today + 10,
+                    to_date: Date.today + 12, adults: 2, status: "pending",
+                    booking_type: "lodging", price_cents: 48_500)
+  end
+
+  let(:stay) do
+    s = Stay.create!(customer: customer, status: "pending", total_amount_cents: 48_500,
+                     arrival_date: Date.today + 10, departure_date: Date.today + 12)
+    s.stay_items.create!(bookable: booking)
+    s
+  end
+
+  describe "GET /sejour/:token" do
+    it "rend la page sans authentification Devise" do
+      get "/sejour/#{stay.token}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Votre séjour aux 4 Sources")
+      expect(response.body).to include("data-stay-items")
+    end
+
+    it "affiche le statut de paiement du séjour" do
+      get "/sejour/#{stay.token}"
+      expect(response.body).to include("En attente de paiement")
+
+      Payment.create!(booking: booking, stay: stay, amount_cents: 48_500, status: "paid", payment_method: "card")
+      stay.set_payment_status
+
+      get "/sejour/#{stay.token}"
+      expect(response.body).to include("Payé")
+    end
+
+    it "expose le CTA de paiement Stripe pour chaque paiement en attente" do
+      payment = Payment.create!(booking: booking, stay: stay, amount_cents: 48_500,
+                                status: "pending", payment_method: "card")
+
+      get "/sejour/#{stay.token}"
+
+      expect(response.body).to include('data-stay-payments="pending"')
+      expect(response.body).to include(pay_public_payment_path(payment))
+    end
+
+    it "liste les paiements reçus" do
+      Payment.create!(booking: booking, stay: stay, amount_cents: 48_500, status: "paid", payment_method: "card")
+
+      get "/sejour/#{stay.token}"
+
+      expect(response.body).to include('data-stay-payments="paid"')
+    end
+
+    it "renvoie 404 sur un token inconnu" do
+      get "/sejour/inconnu"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
Phase 1 de l'epic #26 (`Payment` devient Stay-first). **Pas de `Closes`** : 3 phases suivent.

Cette phase pose l'objet public manquant. Sans page Séjour et sans statut de paiement sur `Stay`, la Phase 2 (redirections Stripe Stay-first) n'a nulle part où atterrir.

## Ce qui change

**Migration** (additive, réversible) — `stays.token` (unique, backfillé, index unique) et `stays.payment_status` (défaut `pending`). Le backfill du statut se fait en SQL, avec une sous-requête corrélée : un paiement compte pour le séjour s'il pointe dessus (`stay_id`, posé par la fondation PR #30) **ou** s'il pointe sur un Booking rattaché — et il ne peut pas être compté deux fois quand le séjour porte plusieurs bookings.

**Modèle `Stay`** — `generate_token` (`before_create`, distinct de `activity_selection_token` pour ne pas élargir la portée de ce jeton-là), `set_payment_status`, validation d'inclusion sur `payment_status`, unicité du token.

> ⚠️ Une nuance assumée vs `Booking#set_payment_status` : un séjour à **0 €** sans paiement reste `pending` au lieu de basculer `paid` par l'effet de bord d'un `0 >= 0`. Spec dédiée.

**Page client `GET /sejour/:token`** — `Public::StaysController`, sans Devise, layout `public_sheet`. Récap composite (chaque `stay_item` avec son libellé, ses dates, son montant), total, statut, et un CTA Stripe par paiement `pending` via `pay_public_payment_path` — exactement le mécanisme de la page booking.

**Route à la racine** (`/sejour/:token`, pas `/public/sejour/:token`) : c'est l'URL envoyée au client et la future cible des redirections Stripe, on la garde courte comme `/reservation/sejour`. Les pages booking/espaces historiques restent où elles sont.

**i18n-ready dès la naissance** (coordination avec #15) — toutes les chaînes dans `config/locales/public.fr.yml`, scope `public.stays.*`. Quand `Public::BaseController` recevra le `switch_locale` de #15, cette page suivra sans retouche.

## Tests

`bundle exec rspec` → **258 exemples, 0 échec** (18 pending, squelettes pré-existants).
- Modèle : génération/unicité du token, `set_payment_status` (pending → partially_paid → paid), le cas 0 €, statut invalide rejeté.
- Request : 200 sans auth, 404 sur token inconnu, présence du récap, du badge de statut, du CTA Stripe et des paiements reçus.

## 📸 Aperçu

![Page client /sejour/:token — récap composite, statut et paiement](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260713-032803-page-client-sejourtoken--rcap-composite-statut-e.png)

## À valider / non testé

- **Le parcours Stripe réel n'est pas encore branché sur cette page** — c'est précisément l'objet de la Phase 2. Ici le CTA pointe sur `pay_public_payment_path`, qui redirige aujourd'hui vers la page booking après paiement. Aucune régression, mais le tour complet séjour → Checkout → retour `/sejour/:token` n'existe pas encore.
- **Backfill non joué sur la prod** : vérifié uniquement sur la base de dev et la base de test. À surveiller au déploiement (les stays existants doivent tous ressortir avec un token et un statut cohérent).
- Le libellé des lignes du séjour vient de `Booking#lodging` / `SpaceBooking#spaces` ; un booking sans lodging retombe sur « Hébergement ». À confirmer que ça convient pour les séjours camping/hamacs.
- Lint : le projet n'a ni RuboCop ni ESLint — rien à passer.