### PR TITLE
Refs #10 — Phase 1 : barres continues pour les bookings (calendrier)

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,6 +29,12 @@ class PagesController < BaseController
         .where.not(booking: { status: ["declined", "canceled"] })
         .between_times(@first, @last, field: :date)
       @grouped_reservations = @reservations.to_a.group_by { |r| r.date }
+      # Bookings à dessiner en barres continues sur le calendrier (issue #10).
+      # Dérivés des mêmes réservations (même filtre de statut) : pas de requête
+      # supplémentaire. Ordre stable — hébergement, puis date de création — pour
+      # que l'empilement des barres ne bouge pas d'un rendu à l'autre.
+      @calendar_bookings = @reservations.map(&:booking).uniq
+        .sort_by { |b| [b.lodging&.name.to_s, b.created_at.to_i] }
       @activities = PublicActivity::Activity.where("created_at > ?", 14.days.ago).order(created_at: :desc)
     end
   end

--- a/app/helpers/calendar_segments_helper.rb
+++ b/app/helpers/calendar_segments_helper.rb
@@ -1,0 +1,76 @@
+# Découpage d'un séjour en segments de barre, une ligne de semaine à la fois
+# (issue #10, Phase 1). Le calendrier mensuel est une grille de 7 colonnes par
+# semaine ; on dessine par-dessus une bande de **14 demi-colonnes** pour que la
+# barre démarre au milieu du jour d'arrivée (après-midi) et finisse au milieu du
+# jour de départ (matin), comme dans n'importe quel calendrier de booking.
+#
+# Colonnes (1-indexées, comme CSS grid) pour le jour d'indice d dans la semaine :
+#   AM = 2d + 1   ·   PM = 2d + 2
+#
+# Une extrémité qui tombe hors de la semaine affichée est « coupée » : le segment
+# occupe alors la cellule entière de ce côté (bord droit, pas d'arrondi).
+module CalendarSegmentsHelper
+  HALF_COLUMNS_PER_WEEK = 14
+
+  Segment = Struct.new(:start_column, :span, :starts_stay, :ends_stay, keyword_init: true) do
+    def starts_stay? = starts_stay
+    def ends_stay? = ends_stay
+
+    # Arrondi seulement du côté où le séjour commence/finit réellement.
+    def rounded_classes
+      classes = []
+      classes << "rounded-l-full" if starts_stay
+      classes << "rounded-r-full" if ends_stay
+      classes.join(" ")
+    end
+  end
+
+  # Segment d'un séjour [from_date, to_date] sur une semaine donnée (tableau de
+  # 7 dates consécutives). nil si le séjour ne touche pas cette semaine.
+  def calendar_segment_for(week_days, from_date, to_date)
+    return nil if week_days.blank? || from_date.blank? || to_date.blank?
+    return nil if to_date <= from_date # un séjour de 0 nuit n'a pas de barre
+
+    week_start = week_days.first
+    week_end   = week_days.last
+    return nil if from_date > week_end || to_date < week_start
+
+    segment_start = [from_date, week_start].max
+    segment_end   = [to_date, week_end].min
+
+    starts_stay = segment_start == from_date
+    ends_stay   = segment_end == to_date
+
+    first_index = (segment_start - week_start).to_i
+    last_index  = (segment_end - week_start).to_i
+
+    start_column = (2 * first_index) + (starts_stay ? 2 : 1)
+    end_column   = (2 * last_index) + (ends_stay ? 1 : 2)
+    return nil if end_column < start_column
+
+    Segment.new(
+      start_column: start_column,
+      span: end_column - start_column + 1,
+      starts_stay: starts_stay,
+      ends_stay: ends_stay
+    )
+  end
+
+  # Les segments d'une semaine, un par booking, dans un ordre stable (hébergement
+  # puis date de création) : deux rendus successifs empilent les barres pareil.
+  def calendar_booking_segments(week_days, bookings)
+    Array(bookings).filter_map do |booking|
+      segment = calendar_segment_for(week_days, booking.from_date, booking.to_date)
+      next if segment.nil?
+
+      [booking, segment]
+    end
+  end
+
+  # Style inline plutôt que classes Tailwind : les classes dynamiques
+  # (`col-start-#{n}`) ne sont pas compilées par le JIT, et la grille de 14
+  # demi-colonnes n'existe pas dans la config par défaut.
+  def calendar_segment_style(segment, row)
+    "grid-column: #{segment.start_column} / span #{segment.span}; grid-row: #{row};"
+  end
+end

--- a/app/views/pages/calendar/_bookings.html.slim
+++ b/app/views/pages/calendar/_bookings.html.slim
@@ -51,7 +51,11 @@
             = space_booking.duration
         .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-space-reservation-#{space_reservation.id}" data-popover-trigger-value="click")
 
-  / Reservations
+  / Reservations — pastilles jour par jour. Sur desktop (lg+), les bookings sont
+  / rendus en barres continues au-dessus de la ligne de semaine (issue #10) : on
+  / masque les pastilles pour ne pas afficher deux fois la même réservation. Sous
+  / lg, les jours s'empilent verticalement — la barre n'a pas de sens, on garde
+  / les pastilles.
   - if @grouped_reservations[date]
     - @grouped_reservations[date].sort_by {|r| r.start_time }.group_by { |r| r.booking.id }.each do |grouped_reservations|
       - reservation = grouped_reservations.last.first
@@ -62,7 +66,7 @@
                  booking: booking
         div[data-popper-arrow]
 
-      div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_class}")
+      div(class="lg:hidden relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_class}")
         .block.min-w-0.w-full
           div.min-w-0
             strong.block.min-w-0.break-words

--- a/app/views/simple_calendar/_dashboard_calendar.html.erb
+++ b/app/views/simple_calendar/_dashboard_calendar.html.erb
@@ -91,6 +91,30 @@
       <% end %>
 
       <div class="week min-w-0" data-dashboard-calendar-target="week" data-past-week="<%= weekdays.first < Date.today && !weekdays.include?(Date.today) %>" data-first-weekday="<%= weekdays.first %>" data-beginning-of-week="<%= Date.today.beginning_of_week %>">
+        <%# issue #10 — barres continues des bookings, une bande de 14 demi-colonnes %>
+        <%# par semaine (arrivée = milieu de cellule PM, départ = milieu de cellule AM). %>
+        <%# Desktop uniquement : sous lg, les jours s'empilent verticalement et les %>
+        <%# pastilles jour-par-jour restent le bon rendu. %>
+        <% week_segments = calendar_booking_segments(weekdays, @calendar_bookings) %>
+        <% if week_segments.any? %>
+          <div class="hidden lg:grid gap-y-1 px-px py-1 bg-gray-200" style="grid-template-columns: repeat(14, minmax(0, 1fr));">
+            <% week_segments.each_with_index do |(booking, segment), row| %>
+              <% decorated = BookingDecorator.new(booking) %>
+              <%= link_to booking_path(booking),
+                          title: "#{decorated.group_or_name} — #{decorated.date_range}",
+                          style: calendar_segment_style(segment, row + 1),
+                          data: { booking_segment: booking.id, segment_start: segment.starts_stay, segment_end: segment.ends_stay },
+                          class: "block min-w-0 truncate px-2 py-0.5 text-xs font-medium text-gray-800 hover:shadow-md transition-shadow #{decorated.calendar_class} #{segment.rounded_classes}" do %>
+                <% if segment.starts_stay %>
+                  <%= decorated.group_or_name.html_safe %>
+                <% else %>
+                  <span class="opacity-70">↩ <%= decorated.group_or_name.html_safe %></span>
+                <% end %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+
         <div class="flex min-w-0 bg-gray-200 text-xs leading-6 text-gray-700 lg:flex-auto">
           <div class="w-full min-w-0 lg:grid lg:grid-cols-7 lg:gap-px">
             <% weekdays.each do |day| %>

--- a/spec/helpers/calendar_segments_helper_spec.rb
+++ b/spec/helpers/calendar_segments_helper_spec.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+# Issue #10, Phase 1 — découpage d'un séjour en segments de barre par semaine.
+# Semaine de référence : lundi 6 juillet 2026 → dimanche 12 juillet 2026.
+RSpec.describe CalendarSegmentsHelper, type: :helper do
+  let(:week) { (Date.new(2026, 7, 6)..Date.new(2026, 7, 12)).to_a }
+  let(:next_week) { (Date.new(2026, 7, 13)..Date.new(2026, 7, 19)).to_a }
+
+  # Indices dans la semaine : lundi=0 … vendredi=4, samedi=5, dimanche=6.
+  # Colonnes 1-indexées : AM = 2d+1, PM = 2d+2.
+
+  describe "#calendar_segment_for" do
+    it "vendredi → dimanche : une seule barre, du vendredi PM au dimanche AM" do
+      segment = helper.calendar_segment_for(week, Date.new(2026, 7, 10), Date.new(2026, 7, 12))
+
+      expect(segment.start_column).to eq(10) # vendredi PM = 2*4 + 2
+      expect(segment.span).to eq(4)          # jusqu'au dimanche AM = colonne 13
+      expect(segment.starts_stay).to be(true)
+      expect(segment.ends_stay).to be(true)
+    end
+
+    it "une nuit (vendredi → samedi) : vendredi PM → samedi AM" do
+      segment = helper.calendar_segment_for(week, Date.new(2026, 7, 10), Date.new(2026, 7, 11))
+
+      expect(segment.start_column).to eq(10)
+      expect(segment.span).to eq(2)
+      expect(segment).to be_starts_stay
+      expect(segment).to be_ends_stay
+    end
+
+    it "séjour à cheval sur deux semaines : le segment de la 1re semaine est coupé à droite" do
+      segment = helper.calendar_segment_for(week, Date.new(2026, 7, 10), Date.new(2026, 7, 15))
+
+      expect(segment.start_column).to eq(10)          # vendredi PM
+      expect(segment.span).to eq(5)                   # jusqu'à la fin du dimanche (colonne 14)
+      expect(segment.starts_stay).to be(true)
+      expect(segment.ends_stay).to be(false)          # ça continue la semaine suivante
+    end
+
+    it "séjour à cheval sur deux semaines : le segment de la 2e semaine est coupé à gauche" do
+      segment = helper.calendar_segment_for(next_week, Date.new(2026, 7, 10), Date.new(2026, 7, 15))
+
+      expect(segment.start_column).to eq(1)           # lundi AM, bord coupé
+      expect(segment.span).to eq(5)                   # jusqu'au mercredi AM (colonne 2*2+1 = 5)
+      expect(segment.starts_stay).to be(false)
+      expect(segment.ends_stay).to be(true)
+    end
+
+    it "semaine entièrement traversée : barre pleine largeur, coupée des deux côtés" do
+      segment = helper.calendar_segment_for(week, Date.new(2026, 7, 1), Date.new(2026, 7, 20))
+
+      expect(segment.start_column).to eq(1)
+      expect(segment.span).to eq(14)
+      expect(segment.starts_stay).to be(false)
+      expect(segment.ends_stay).to be(false)
+    end
+
+    it "séjour à cheval sur deux mois : la semaine de bord porte bien son segment" do
+      # 29 juillet (mer) → 2 août (dim). Semaine du 27 juillet.
+      border_week = (Date.new(2026, 7, 27)..Date.new(2026, 8, 2)).to_a
+      segment = helper.calendar_segment_for(border_week, Date.new(2026, 7, 29), Date.new(2026, 8, 2))
+
+      expect(segment.start_column).to eq(6)  # mercredi PM = 2*2 + 2
+      expect(segment.span).to eq(8)          # jusqu'au dimanche AM = colonne 13
+      expect(segment).to be_starts_stay
+      expect(segment).to be_ends_stay
+    end
+
+    it "ne rend rien quand le séjour ne touche pas la semaine" do
+      expect(helper.calendar_segment_for(week, Date.new(2026, 8, 1), Date.new(2026, 8, 3))).to be_nil
+      expect(helper.calendar_segment_for(week, Date.new(2026, 6, 1), Date.new(2026, 6, 3))).to be_nil
+    end
+
+    it "ne rend rien pour un séjour de 0 nuit (arrivée = départ)" do
+      expect(helper.calendar_segment_for(week, Date.new(2026, 7, 10), Date.new(2026, 7, 10))).to be_nil
+    end
+
+    it "ne rend rien sans dates" do
+      expect(helper.calendar_segment_for(week, nil, Date.new(2026, 7, 10))).to be_nil
+      expect(helper.calendar_segment_for(week, Date.new(2026, 7, 10), nil)).to be_nil
+    end
+
+    it "arrondit seulement les extrémités réelles du séjour" do
+      inside = helper.calendar_segment_for(week, Date.new(2026, 7, 7), Date.new(2026, 7, 9))
+      expect(inside.rounded_classes).to eq("rounded-l-full rounded-r-full")
+
+      cut_right = helper.calendar_segment_for(week, Date.new(2026, 7, 7), Date.new(2026, 7, 15))
+      expect(cut_right.rounded_classes).to eq("rounded-l-full")
+
+      cut_left = helper.calendar_segment_for(next_week, Date.new(2026, 7, 7), Date.new(2026, 7, 15))
+      expect(cut_left.rounded_classes).to eq("rounded-r-full")
+    end
+  end
+
+  describe "#calendar_segment_style" do
+    it "produit un style de grille exploitable" do
+      segment = helper.calendar_segment_for(week, Date.new(2026, 7, 10), Date.new(2026, 7, 12))
+      expect(helper.calendar_segment_style(segment, 2)).to eq("grid-column: 10 / span 4; grid-row: 2;")
+    end
+  end
+
+  describe "#calendar_booking_segments" do
+    let(:lodging) { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+
+    def booking(from:, to:)
+      Booking.create!(firstname: "Test", from_date: from, to_date: to, adults: 1,
+                      status: "confirmed", lodging: lodging, price_cents: 0)
+    end
+
+    it "ne garde que les bookings qui touchent la semaine" do
+      inside = booking(from: Date.new(2026, 7, 10), to: Date.new(2026, 7, 12))
+      outside = booking(from: Date.new(2026, 8, 10), to: Date.new(2026, 8, 12))
+
+      result = helper.calendar_booking_segments(week, [inside, outside])
+
+      expect(result.map(&:first)).to eq([inside])
+      expect(result.first.last.start_column).to eq(10)
+    end
+
+    it "conserve l'ordre reçu (empilement stable d'un rendu à l'autre)" do
+      first = booking(from: Date.new(2026, 7, 6), to: Date.new(2026, 7, 8))
+      second = booking(from: Date.new(2026, 7, 7), to: Date.new(2026, 7, 9))
+
+      result = helper.calendar_booking_segments(week, [first, second])
+      expect(result.map(&:first)).to eq([first, second])
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,9 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  # `sign_in` dans les specs request des pages authentifiées (issue #10).
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:

--- a/spec/requests/calendar_booking_bars_spec.rb
+++ b/spec/requests/calendar_booking_bars_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+# Issue #10, Phase 1 — barres continues des bookings sur le calendrier racine.
+RSpec.describe "Calendrier — barres de booking", type: :request do
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  let(:lodging) { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+  let(:room) do
+    r = Room.create!(name: "Chambre 1", level: 1)
+    lodging.rooms << r
+    r
+  end
+
+  before { sign_in user }
+
+  # Crée un booking confirmé + ses réservations jour par jour (c'est ce que lit
+  # le calendrier), sur les nuits [from, to).
+  def confirmed_booking(from:, to:, group: "Groupe test")
+    booking = Booking.create!(firstname: "Alex", group_name: group, lodging: lodging,
+                              from_date: from, to_date: to, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0)
+    (from...to).each { |date| Reservation.create!(booking: booking, room: room, date: date) }
+    booking
+  end
+
+  it "rend un segment pour un booking intra-semaine" do
+    booking = confirmed_booking(from: Date.today.next_occurring(:friday),
+                                to: Date.today.next_occurring(:friday) + 2)
+
+    get "/"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("data-booking-segment=\"#{booking.id}\"")
+    expect(response.body.scan("data-booking-segment=\"#{booking.id}\"").size).to eq(1)
+  end
+
+  it "rend un segment par semaine traversée pour un booking multi-semaines" do
+    from = Date.today.next_occurring(:friday)
+    booking = confirmed_booking(from: from, to: from + 9) # traverse 2 bords de semaine
+
+    get "/"
+
+    segments = response.body.scan("data-booking-segment=\"#{booking.id}\"").size
+    expect(segments).to be >= 2
+  end
+
+  it "garde le lien vers la fiche booking" do
+    booking = confirmed_booking(from: Date.today.next_occurring(:friday),
+                                to: Date.today.next_occurring(:friday) + 2)
+
+    get "/"
+
+    expect(response.body).to include(booking_path(booking))
+  end
+
+  it "n'ajoute aucune barre sur la vue Sourciers (anti-régression)" do
+    confirmed_booking(from: Date.today.next_occurring(:friday),
+                      to: Date.today.next_occurring(:friday) + 2)
+
+    get "/?view=organisation"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("data-booking-segment")
+  end
+end


### PR DESCRIPTION
Phase 1 de l'epic #10. **Pas de `Closes`** : la Phase 2 (créneaux am/pm/journée/soirée des espaces) suit.

Un booking ven→dim s'affichait en pastilles répétées jour par jour. Il s'affiche maintenant en **une barre continue**, server-rendered, **sans aucune lib JS** (`package.json` inchangé, conforme à la décision produit).

## Comment

Le calendrier est une grille de 7 colonnes par semaine. On dessine par-dessus une **bande de 14 demi-colonnes** : le jour d'indice `d` occupe les colonnes `2d+1` (matin) et `2d+2` (après-midi). Une barre démarre donc au **milieu du jour d'arrivée** et finit au **milieu du jour de départ**, exactement comme demandé.

`CalendarSegmentsHelper` (pur, testable seul) découpe un séjour en **un segment par semaine traversée**. Quand une extrémité tombe hors de la semaine affichée, le segment occupe la cellule entière de ce côté et perd son arrondi : le bord « coupé » signale visuellement que ça continue.

Les positions passent par des **styles inline** (`grid-column: X / span Y`) et non des classes Tailwind : `col-start-#{n}` dynamique n'est pas compilé par le JIT.

**Empilement** : une barre par booking, une ligne de grille par booking, ordre stable (hébergement puis date de création) — deux rendus successifs empilent pareil. Pas de limite dure : la ligne de semaine grandit.

**Aucune requête SQL en plus** : `@calendar_bookings` est dérivé des `@reservations` déjà chargées, donc même filtre de statut qu'avant.

## Choix à valider : desktop vs mobile

Les barres n'ont de sens que quand la semaine est une vraie ligne de 7 colonnes — c'est-à-dire **à partir de `lg`**. Sous `lg`, les jours s'empilent verticalement, et une barre horizontale n'a aucun sens.

J'ai donc gardé **les deux rendus** : barres en `lg+`, pastilles jour-par-jour en dessous (`lg:hidden`). L'issue ne tranchait pas ce point ; si vous voulez les pastilles supprimées partout, dites-le et je les retire.

## Tests

`bundle exec rspec` → **261 exemples, 0 échec** (18 pending, squelettes pré-existants).
- **13 specs du découpage** (le cœur) : intra-semaine, 1 nuit, à cheval sur 2 semaines (des deux côtés), semaine entièrement traversée, à cheval sur 2 mois, 0 nuit, hors semaine, dates absentes, arrondis des extrémités.
- **4 specs request** : un segment pour un booking intra-semaine, ≥ 2 segments pour un booking de 10 jours, lien vers la fiche booking préservé, et **la vue Sourciers ne contient aucune barre** (anti-régression).
- J'ai branché `Devise::Test::IntegrationHelpers` dans `rails_helper` — il manquait, aucune spec request authentifiée n'existait jusqu'ici.

## 📸 Aperçu

« Famille Durand » (ven → dim) : une barre continue, arrondie aux deux bouts. « Groupe Yoga » : empilée au-dessus, coupée au bord de semaine, et reprise en demi-cellule le lundi suivant. « Séminaire Aubel » (10 jours) : découpé proprement sur deux semaines.

![Calendrier — barres continues](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260713-034345-calendrier--barres-continues-vendim-empilement-s.png)

## À valider / non testé

- **Piège local** : Vite ne surveille pas les vues, donc son build en cache ne recompile pas les nouvelles classes Tailwind. Si les barres ne s'affichent pas chez vous, faites `rm -rf public/vite-dev && bin/vite build`. En prod, Hatchbox construit à neuf — pas de souci. (C'est ce qui m'a fait perdre du temps en vérification, ça vaut la peine d'être connu.)
- **Aspect visuel non arbitré** : les barres reprennent `BookingDecorator#calendar_class` (pâle, bordure gauche colorée). Les statuts restent distinguables, mais une passe de design ferait du bien — je n'ai pas voulu inventer une palette.
- **Le popover au clic n'est pas repris sur la barre** : la barre est un simple lien vers la fiche booking (`booking_path`), avec le nom + les dates en `title`. Le popover riche reste sur les pastilles mobiles. L'AC demandait « la même cible qu'aujourd'hui » — c'est le cas pour le lien, pas pour le popover.
- **Phase 2 non entamée** : les réservations d'espaces s'affichent toujours en pastilles jour-par-jour, y compris sur desktop.
- Lint : le projet n'a ni RuboCop ni ESLint — rien à passer.