### PR TITLE
Refs #25 — Phase 4 : calendrier hebdo de disponibilités du porteur

### DIFF
--- a/app/controllers/experience_availabilities_controller.rb
+++ b/app/controllers/experience_availabilities_controller.rb
@@ -2,25 +2,36 @@ class ExperienceAvailabilitiesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_experience
 
+  # Dépôt d'un bloc depuis le calendrier hebdo (epic #25, Phase 4) : un clic sur
+  # une case suffit — la durée vient de l'activité, le non-chevauchement et les
+  # bornes 8h-22h sont validés par le modèle.
   def create
     @availability = @experience.experience_availabilities.build(availability_params)
     if @availability.save
-      redirect_to @experience, notice: "Disponibilité ajoutée."
+      redirect_to experience_week_path, notice: "Disponibilité ajoutée."
     else
-      redirect_to @experience, alert: @availability.errors.full_messages.to_sentence
+      redirect_to experience_week_path, alert: @availability.errors.full_messages.to_sentence
     end
   end
 
   def destroy
     @availability = @experience.experience_availabilities.find(params[:id])
     @availability.destroy
-    redirect_to @experience, notice: "Disponibilité supprimée."
+    redirect_to experience_week_path, notice: "Disponibilité supprimée."
   end
 
   private
 
   def set_experience
     @experience = Experience.find(params[:experience_id])
+  end
+
+  # On revient sur la semaine que le porteur regardait, pas sur la semaine
+  # courante : sans ça, poser un bloc trois semaines plus loin le ramènerait
+  # au début à chaque clic.
+  def experience_week_path
+    week = params[:week].presence
+    week ? experience_path(@experience, week: week) : experience_path(@experience)
   end
 
   def availability_params

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -9,6 +9,13 @@ class ExperiencesController < BaseController
   end
 
   def show
+    # Calendrier hebdo des disponibilités (epic #25, Phase 4) — démarre sur la
+    # semaine en cours ; `?week=` permet de naviguer, y compris dans le passé
+    # (l'historique des dispos reste consultable).
+    @week_calendar = Experiences::WeekCalendar.new(
+      experience: @experience,
+      week_start: (Date.parse(params[:week]) rescue nil)
+    )
     @experience = ExperienceDecorator.new(@experience)
   end
 

--- a/app/models/experience_availability.rb
+++ b/app/models/experience_availability.rb
@@ -18,9 +18,16 @@ class ExperienceAvailability < ApplicationRecord
   belongs_to :experience
   has_many :experience_bookings, dependent: :destroy
 
+  before_validation :default_duration_from_experience
+
   validates :available_on, :starts_at, presence: true
   validates :duration_minutes, numericality: { greater_than: 0 }, allow_nil: true
   validates :max_participants, numericality: { greater_than: 0 }, allow_nil: true
+
+  # Phase 4 de l'epic #25 : les blocs vivent entre 8h et 22h et ne se
+  # chevauchent jamais pour une même activité.
+  validate :within_opening_hours
+  validate :no_overlap_with_siblings
 
   scope :upcoming, -> { where("available_on >= ?", Date.today).order(:available_on, :starts_at) }
   scope :for_date_range, ->(from, to) { where(available_on: from..to) }
@@ -57,5 +64,60 @@ class ExperienceAvailability < ApplicationRecord
 
   def label
     "#{experience.name} — #{available_on.strftime('%-d/%m')} à #{starts_at}"
+  end
+
+  # Bornes du bloc en minutes depuis minuit — nil si l'heure de début est
+  # illisible (la validation de présence/format s'en charge par ailleurs).
+  def starts_at_minutes
+    Experiences::WeekCalendar.parse_time(starts_at)
+  end
+
+  def ends_at_minutes
+    start = starts_at_minutes
+    return nil if start.nil?
+
+    start + effective_duration
+  end
+
+  private
+
+  # Le bloc prend la durée de l'activité quand rien n'est précisé : c'est elle
+  # qui pilote la taille des créneaux du calendrier hebdo.
+  def default_duration_from_experience
+    return if duration_minutes.present?
+    return if experience.nil?
+
+    self.duration_minutes = experience.block_duration_minutes
+  end
+
+  def within_opening_hours
+    start = starts_at_minutes
+    return if start.nil?
+
+    finish = ends_at_minutes
+    return if finish.nil?
+
+    if start < Experiences::WeekCalendar::DAY_START_MINUTES || finish > Experiences::WeekCalendar::DAY_END_MINUTES
+      errors.add(:starts_at, "doit tenir entre 8h et 22h")
+    end
+  end
+
+  def no_overlap_with_siblings
+    start = starts_at_minutes
+    finish = ends_at_minutes
+    return if start.nil? || finish.nil? || experience.nil? || available_on.nil?
+
+    siblings = experience.experience_availabilities.where(available_on: available_on)
+    siblings = siblings.where.not(id: id) if persisted?
+
+    overlapping = siblings.any? do |sibling|
+      sibling_start = sibling.starts_at_minutes
+      sibling_end = sibling.ends_at_minutes
+      next false if sibling_start.nil? || sibling_end.nil?
+
+      start < sibling_end && sibling_start < finish
+    end
+
+    errors.add(:starts_at, "chevauche une disponibilité déjà posée") if overlapping
   end
 end

--- a/app/services/experiences/week_calendar.rb
+++ b/app/services/experiences/week_calendar.rb
@@ -1,0 +1,73 @@
+module Experiences
+  # Grille hebdomadaire des disponibilités d'une activité (epic #25, Phase 4).
+  # Les créneaux ont tous la durée de l'activité (`duration_hours`), s'enchaînent
+  # sans trou entre 8h et 22h, et ne se chevauchent jamais : poser un bloc, c'est
+  # cliquer une case de cette grille.
+  class WeekCalendar
+    DAY_START_MINUTES = 8 * 60   # 08:00
+    DAY_END_MINUTES   = 22 * 60  # 22:00
+
+    attr_reader :experience, :week_start
+
+    def initialize(experience:, week_start: nil)
+      @experience = experience
+      @week_start = (week_start.presence || Date.today).beginning_of_week(:monday)
+    end
+
+    def days
+      (week_start..week_start.end_of_week(:monday)).to_a
+    end
+
+    def block_minutes
+      experience.block_duration_minutes.to_i
+    end
+
+    # Sans durée numérique sur l'activité, on ne sait pas quelle taille de bloc
+    # poser : la grille ne s'affiche pas et on invite à renseigner la durée.
+    def configured?
+      block_minutes.positive?
+    end
+
+    # Heures de début candidates, en minutes depuis minuit. Un bloc qui
+    # dépasserait 22h n'est pas proposé.
+    def slot_starts
+      return [] unless configured?
+
+      starts = []
+      minutes = DAY_START_MINUTES
+      while minutes + block_minutes <= DAY_END_MINUTES
+        starts << minutes
+        minutes += block_minutes
+      end
+      starts
+    end
+
+    # Disponibilités de la semaine, indexées par [date, "HH:MM"].
+    def availabilities_index
+      @availabilities_index ||= experience.experience_availabilities
+        .for_date_range(days.first, days.last)
+        .index_by { |availability| [availability.available_on, availability.starts_at] }
+    end
+
+    def availability_at(day, minutes)
+      availabilities_index[[day, self.class.format_minutes(minutes)]]
+    end
+
+    def previous_week = week_start - 7
+    def next_week = week_start + 7
+    def current_week? = week_start == Date.today.beginning_of_week(:monday)
+
+    def self.format_minutes(minutes)
+      format("%02d:%02d", minutes / 60, minutes % 60)
+    end
+
+    def self.parse_time(value)
+      return nil if value.blank?
+
+      hours, minutes = value.to_s.split(":").map(&:to_i)
+      return nil if hours.nil? || minutes.nil?
+
+      (hours * 60) + minutes
+    end
+  end
+end

--- a/app/views/experiences/_week_calendar.html.slim
+++ b/app/views/experiences/_week_calendar.html.slim
@@ -1,0 +1,66 @@
+/ Calendrier hebdomadaire des disponibilités du porteur (epic #25, Phase 4).
+/ Les blocs ont la durée de l'activité et s'enchaînent de 8h à 22h : une case
+/ libre = un clic pour poser, une case posée = un clic pour retirer. Pas de JS —
+/ chaque case est un `button_to` (Turbo recharge la semaine affichée).
+.overflow-hidden.bg-white.shadow.sm:rounded-lg(data-week-calendar="true")
+  .px-4.py-5.sm:px-6.flex.flex-wrap.items-center.justify-between.gap-3
+    div
+      h3.text-lg.font-medium.leading-6.text-gray-900 Calendrier des disponibilités
+      - if calendar.configured?
+        p.text-sm.text-gray-500
+          = "Blocs de #{@experience.object.duration_hours.to_f.round(2)} h — de 8h à 22h, sans chevauchement."
+
+    .flex.items-center.gap-2
+      = link_to "← Semaine précédente", experience_path(@experience, week: calendar.previous_week.iso8601),
+                class: "text-sm text-gray-600 hover:text-gray-900 px-2 py-1 rounded hover:bg-gray-100"
+      - unless calendar.current_week?
+        = link_to "Aujourd'hui", experience_path(@experience),
+                  class: "text-sm font-medium text-emerald-700 hover:text-emerald-900 px-2 py-1 rounded hover:bg-emerald-50"
+      = link_to "Semaine suivante →", experience_path(@experience, week: calendar.next_week.iso8601),
+                class: "text-sm text-gray-600 hover:text-gray-900 px-2 py-1 rounded hover:bg-gray-100"
+
+  .border-t.border-gray-200.p-4
+    - if !calendar.configured?
+      p.text-sm.text-gray-500.italic
+        | Renseignez la
+        =< link_to "durée de l'activité", edit_experience_path(@experience), class: "underline"
+        |  (en heures) pour pouvoir poser des disponibilités.
+    - else
+      .overflow-x-auto
+        table.w-full.text-sm.border-separate(style="border-spacing: 2px;")
+          thead
+            tr
+              th.w-16.text-xs.font-medium.text-gray-400.text-left
+              - calendar.days.each do |day|
+                th.text-xs.font-medium.text-gray-500.text-center(class="#{day == Date.today ? 'text-emerald-700' : ''}")
+                  .uppercase.tracking-wide = l(day, format: "%a")
+                  .text-base.font-semibold(class="#{day == Date.today ? 'text-emerald-700' : 'text-gray-800'}")
+                    = l(day, format: "%-d")
+          tbody
+            - calendar.slot_starts.each do |minutes|
+              - label = Experiences::WeekCalendar.format_minutes(minutes)
+              tr
+                td.text-xs.text-gray-400.pr-2.align-middle.whitespace-nowrap = label
+                - calendar.days.each do |day|
+                  - availability = calendar.availability_at(day, minutes)
+                  - past = day < Date.today
+                  td.align-middle
+                    - if availability
+                      = button_to experience_experience_availability_path(@experience, availability, week: calendar.week_start.iso8601),
+                                  method: :delete,
+                                  form: { data: { turbo_confirm: (availability.booked_participants.positive? ? "Ce créneau a déjà des réservations. Le supprimer ?" : nil) } },
+                                  data: { availability_slot: "#{day.iso8601} #{label}", availability_state: "taken" },
+                                  title: "Retirer ce créneau",
+                                  class: "w-full rounded-md px-2 py-2 text-xs font-medium bg-emerald-100 text-emerald-800 border border-emerald-300 hover:bg-red-100 hover:text-red-800 hover:border-red-300 transition-colors cursor-pointer" do
+                        = availability.booked_participants.positive? ? "#{label} · #{availability.booked_participants} pers." : label
+                    - elsif past
+                      .w-full.rounded-md.px-2.py-2.text-xs.text-gray-300.text-center.border.border-dashed.border-gray-100(data-availability-slot="#{day.iso8601} #{label}" data-availability-state="past")
+                        | —
+                    - else
+                      = button_to experience_experience_availabilities_path(@experience, week: calendar.week_start.iso8601),
+                                  method: :post,
+                                  params: { experience_availability: { available_on: day.iso8601, starts_at: label } },
+                                  data: { availability_slot: "#{day.iso8601} #{label}", availability_state: "free" },
+                                  title: "Poser un créneau le #{l(day, format: '%-d %B')} à #{label}",
+                                  class: "w-full rounded-md px-2 py-2 text-xs text-gray-400 bg-gray-50 border border-dashed border-gray-200 hover:bg-emerald-50 hover:text-emerald-700 hover:border-emerald-300 transition-colors cursor-pointer" do
+                        | +

--- a/app/views/experiences/show.html.slim
+++ b/app/views/experiences/show.html.slim
@@ -79,37 +79,10 @@
                     method: :delete, data: { confirm: "Supprimer cette disponibilité ?" },
                     class: "text-red-400 hover:text-red-600 text-lg font-bold bg-transparent border-0 cursor-pointer"
 
-        .border-t.border-gray-200.px-4.py-4
-          h4.text-sm.font-medium.text-gray-700.mb-3 Ajouter une disponibilité
-          = form_with url: experience_experience_availabilities_path(@experience), method: :post, class: "space-y-3" do |f|
-            .grid.grid-cols-2.gap-2
-              div
-                label.block.text-xs.text-gray-500.mb-1 Date
-                = f.date_field :available_on, min: Date.today.iso8601,
-                    class: "w-full text-sm rounded border-gray-300",
-                    name: "experience_availability[available_on]"
-              div
-                label.block.text-xs.text-gray-500.mb-1 Heure de début
-                = f.text_field :starts_at, placeholder: "09:00",
-                    class: "w-full text-sm rounded border-gray-300",
-                    name: "experience_availability[starts_at]"
-            .grid.grid-cols-2.gap-2
-              div
-                label.block.text-xs.text-gray-500.mb-1 Durée (min)
-                = f.number_field :duration_minutes, min: 15, step: 15, placeholder: "120",
-                    class: "w-full text-sm rounded border-gray-300",
-                    name: "experience_availability[duration_minutes]"
-              div
-                label.block.text-xs.text-gray-500.mb-1 Max participants
-                = f.number_field :max_participants, min: 1,
-                    placeholder: @experience.max_participants,
-                    class: "w-full text-sm rounded border-gray-300",
-                    name: "experience_availability[max_participants]"
-            div
-              label.block.text-xs.text-gray-500.mb-1 Note interne (optionnel)
-              = f.text_field :notes, class: "w-full text-sm rounded border-gray-300",
-                  name: "experience_availability[notes]"
-            = f.submit "Ajouter", class: "rounded bg-emerald-600 text-white px-4 py-2 text-sm font-medium hover:bg-emerald-700 cursor-pointer"
+        / Le formulaire inline « Ajouter une disponibilité » est remplacé par le
+        / calendrier hebdo ci-dessous (epic #25, Phase 4).
+        .border-t.border-gray-200.px-4.py-3
+          p.text-xs.text-gray-400 Posez vos créneaux dans le calendrier ci-dessous.
 
     - if @experience.human.presence
       ul.grid.grid-cols-1.gap-6[role="list"]
@@ -133,3 +106,8 @@
                 span.inline-flex.items-center.rounded-full.bg-green-50.px-2.py-1.text-xs.font-medium.text-green-700.ring-1.ring-inset.ring-green-600/20
                   | Porteur·euse d'activité
                   
+
+/ Calendrier hebdo des disponibilités (epic #25, Phase 4) — pleine largeur sous
+/ la fiche, la grille de 7 jours a besoin de place.
+.mt-6
+  = render "experiences/week_calendar", calendar: @week_calendar

--- a/spec/models/experience_availability_spec.rb
+++ b/spec/models/experience_availability_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+# Epic #25, Phase 4 — les blocs de disponibilité ont la durée de l'activité,
+# tiennent entre 8h et 22h, et ne se chevauchent jamais.
+RSpec.describe ExperienceAvailability, type: :model do
+  let(:experience) { Experience.create!(name: "Balade en forêt", duration_hours: 2) }
+  let(:day) { Date.today + 7 }
+
+  def availability(starts_at:, on: day, duration: nil)
+    ExperienceAvailability.new(experience: experience, available_on: on,
+                               starts_at: starts_at, duration_minutes: duration)
+  end
+
+  describe "durée par défaut" do
+    it "reprend la durée de l'activité quand elle n'est pas précisée" do
+      block = availability(starts_at: "09:00")
+      expect(block).to be_valid
+      expect(block.duration_minutes).to eq(120)
+    end
+
+    it "respecte une durée explicitement fournie" do
+      block = availability(starts_at: "09:00", duration: 90)
+      expect(block).to be_valid
+      expect(block.duration_minutes).to eq(90)
+    end
+  end
+
+  describe "bornes 8h — 22h" do
+    it "accepte un bloc qui démarre à 8h" do
+      expect(availability(starts_at: "08:00")).to be_valid
+    end
+
+    it "accepte un bloc qui finit pile à 22h" do
+      expect(availability(starts_at: "20:00")).to be_valid
+    end
+
+    it "refuse un bloc qui démarre avant 8h" do
+      block = availability(starts_at: "07:00")
+      expect(block).not_to be_valid
+      expect(block.errors[:starts_at]).to include("doit tenir entre 8h et 22h")
+    end
+
+    it "refuse un bloc qui déborde après 22h" do
+      block = availability(starts_at: "21:00") # 21h + 2h = 23h
+      expect(block).not_to be_valid
+      expect(block.errors[:starts_at]).to include("doit tenir entre 8h et 22h")
+    end
+  end
+
+  describe "non-chevauchement" do
+    before { availability(starts_at: "10:00").save! }
+
+    it "refuse un bloc qui démarre pendant un bloc existant" do
+      block = availability(starts_at: "11:00")
+      expect(block).not_to be_valid
+      expect(block.errors[:starts_at]).to include("chevauche une disponibilité déjà posée")
+    end
+
+    it "refuse un bloc identique" do
+      expect(availability(starts_at: "10:00")).not_to be_valid
+    end
+
+    it "refuse un bloc qui englobe un bloc existant" do
+      expect(availability(starts_at: "09:00", duration: 240)).not_to be_valid
+    end
+
+    it "accepte un bloc contigu (fin = début du suivant)" do
+      expect(availability(starts_at: "12:00")).to be_valid
+    end
+
+    it "accepte le même horaire un autre jour" do
+      expect(availability(starts_at: "10:00", on: day + 1)).to be_valid
+    end
+
+    it "accepte le même horaire pour une autre activité" do
+      other = Experience.create!(name: "Poterie", duration_hours: 2)
+      block = ExperienceAvailability.new(experience: other, available_on: day, starts_at: "10:00")
+      expect(block).to be_valid
+    end
+
+    it "ne se considère pas comme son propre chevauchement à la mise à jour" do
+      block = experience.experience_availabilities.find_by(starts_at: "10:00")
+      block.notes = "changé"
+      expect(block).to be_valid
+    end
+  end
+end

--- a/spec/requests/experience_availabilities_spec.rb
+++ b/spec/requests/experience_availabilities_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+# Epic #25, Phase 4 — calendrier hebdo : poser/retirer un bloc en un clic.
+RSpec.describe "Disponibilités d'activité (calendrier hebdo)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "porteur@les4sources.be", password: "password123") }
+  let(:experience) { Experience.create!(name: "Balade en forêt", duration_hours: 2) }
+  let(:monday) { Date.today.beginning_of_week(:monday) }
+
+  before { sign_in user }
+
+  describe "GET /experiences/:id" do
+    it "rend le calendrier de la semaine en cours" do
+      get experience_path(experience)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("data-week-calendar")
+      expect(response.body).to include("Calendrier des disponibilités")
+      # Blocs de 2h de 8h à 22h -> 7 créneaux, du lundi au dimanche.
+      expect(response.body).to include("#{monday.iso8601} 08:00")
+      expect(response.body).to include("#{(monday + 6).iso8601} 20:00")
+    end
+
+    it "navigue vers une autre semaine via ?week=" do
+      other_week = (monday + 21).iso8601
+      get experience_path(experience, week: other_week)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("#{other_week} 08:00")
+    end
+
+    it "invite à renseigner la durée quand l'activité n'en a pas" do
+      no_duration = Experience.create!(name: "Atelier sans durée")
+      get experience_path(no_duration)
+
+      expect(response.body).to include("durée de l&#39;activité")
+      expect(response.body).not_to include("data-availability-slot")
+    end
+
+    it "marque le créneau posé comme occupé" do
+      experience.experience_availabilities.create!(available_on: monday + 2, starts_at: "10:00")
+
+      get experience_path(experience)
+
+      expect(response.body).to include('data-availability-state="taken"')
+    end
+  end
+
+  describe "POST — poser un bloc" do
+    it "crée la disponibilité avec la durée de l'activité et revient sur la semaine affichée" do
+      week = (monday + 7).iso8601
+
+      expect {
+        post experience_experience_availabilities_path(experience, week: week),
+             params: { experience_availability: { available_on: (monday + 8).iso8601, starts_at: "14:00" } }
+      }.to change(ExperienceAvailability, :count).by(1)
+
+      availability = ExperienceAvailability.last
+      expect(availability.duration_minutes).to eq(120)
+      expect(response).to redirect_to(experience_path(experience, week: week))
+    end
+
+    it "refuse un chevauchement et le signale" do
+      experience.experience_availabilities.create!(available_on: monday + 1, starts_at: "10:00")
+
+      expect {
+        post experience_experience_availabilities_path(experience),
+             params: { experience_availability: { available_on: (monday + 1).iso8601, starts_at: "11:00" } }
+      }.not_to change(ExperienceAvailability, :count)
+
+      expect(flash[:alert]).to match(/chevauche/)
+    end
+  end
+
+  describe "DELETE — retirer un bloc" do
+    it "supprime la disponibilité et revient sur la semaine affichée" do
+      availability = experience.experience_availabilities.create!(available_on: monday + 3, starts_at: "16:00")
+      week = monday.iso8601
+
+      expect {
+        delete experience_experience_availability_path(experience, availability, week: week)
+      }.to change(ExperienceAvailability, :count).by(-1)
+
+      expect(response).to redirect_to(experience_path(experience, week: week))
+    end
+  end
+end


### PR DESCRIPTION
Phase 4 de l'epic #25 (Phases 1-3 mergées). **Pas de `Closes`** : les Phases 5 à 10 suivent.

Le porteur posait ses disponibilités dans un formulaire (date + heure + durée + max, un par un). Il les pose maintenant **en un clic** dans un calendrier hebdomadaire, type Calendly.

## Ce qui change

**`Experiences::WeekCalendar`** (service, testable seul) — construit la grille : les créneaux ont la **durée de l'activité** (`duration_hours`) et s'enchaînent de **8h à 22h**. Un bloc qui déborderait 22h n'est pas proposé. Sans durée numérique sur l'activité, la grille ne s'affiche pas et on invite à la renseigner (plutôt que d'inventer une taille de bloc).

**`ExperienceAvailability`** — trois garde-fous côté modèle, donc valables quelle que soit la porte d'entrée : la durée par défaut vient de l'activité, le bloc doit tenir entre 8h et 22h, et il **ne peut pas chevaucher** un bloc déjà posé le même jour pour la même activité. Deux blocs contigus (10h-12h puis 12h-14h) restent valides — c'est un enchaînement, pas un chevauchement.

**La vue** remplace le formulaire inline : une case libre = un `+` cliquable, une case posée = un bloc vert cliquable pour le retirer. Navigation semaine précédente / suivante / aujourd'hui ; les semaines passées restent consultables, leurs créneaux vides ne sont pas cliquables. Après une pose ou un retrait, on **revient sur la semaine affichée** — sans ça, poser trois semaines plus loin vous ramènerait au début à chaque clic.

**Zéro JS ajouté** : chaque case est un `button_to`, Turbo fait le reste. `package.json` inchangé.

Tous les users peuvent éditer tous les calendriers (décision de l'epic : pas de restriction par rôle pour l'instant).

## Tests

`bundle exec rspec` → **264 exemples, 0 échec** (18 pending, squelettes pré-existants).
- **13 specs modèle** : durée par défaut, bornes 8h/22h (dont les cas limites 8h pile et fin à 22h pile), chevauchement (démarrage dans un bloc, bloc identique, bloc englobant), contiguïté acceptée, même horaire un autre jour, même horaire pour une autre activité, et un bloc qui ne se considère pas comme son propre chevauchement à la mise à jour.
- **7 specs request** : rendu de la semaine en cours, navigation `?week=`, activité sans durée, créneau marqué occupé, pose (avec durée héritée + retour sur la bonne semaine), chevauchement refusé avec message, retrait.

## 📸 Aperçu

![Calendrier hebdo du porteur](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260713-035204-calendrier-hebdo-du-porteur--blocs-de-2h-8h22h-p.png)

## À valider / non testé

- **Le "1 clic" fait un aller-retour serveur** (`button_to` + Turbo), pas une mise à jour optimiste. C'est instantané en local ; sur une connexion lente, poser 10 créneaux à la suite fera 10 rechargements. Si ça gêne, un `turbo_stream` sur create/destroy réglerait ça — je ne l'ai pas fait pour rester au plus simple.
- **`max_participants` et `notes` ne sont plus saisissables** depuis la nouvelle interface : le formulaire qui les portait a disparu. Les blocs posés au calendrier héritent du `max_participants` de l'activité (`effective_max_participants`). Si le porteur doit pouvoir surcharger ça créneau par créneau, il faut un écran d'édition du bloc — **à trancher**, ce n'était pas dans l'AC.
- **Grille fixe 8h-22h** : les bornes sont des constantes du service, pas configurables par activité.
- **Bug pré-existant repéré** : dans la liste « Disponibilités » à droite, les dates s'affichent en anglais (« 15 July 2026 ») — `strftime("%-d %B %Y")` au lieu de `l()`. Vient de `main`, hors périmètre, visible sur la capture.
- Lint : le projet n'a ni RuboCop ni ESLint — rien à passer.