### PR TITLE
Refs #25 — Phase 5 : calendrier global des activités sur l'index

### DIFF
--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -4,6 +4,11 @@ class ExperiencesController < BaseController
   breadcrumb "Activités", :experiences_path, match: :exact
 
   def index
+    # Calendrier global des créneaux, toutes activités confondues (epic #25,
+    # Phase 5) — `?week=` navigue, comme sur la fiche d'une activité.
+    @global_calendar = Experiences::GlobalWeekCalendar.new(
+      week_start: (Date.parse(params[:week]) rescue nil)
+    )
     @experiences = ExperienceDecorator
       .decorate_collection(Experience.all.order(name: :asc))
   end

--- a/app/decorators/experience_decorator.rb
+++ b/app/decorators/experience_decorator.rb
@@ -1,6 +1,25 @@
 class ExperienceDecorator < ApplicationDecorator
   delegate_all
 
+  # Couleur de repli pour les activités antérieures à la migration (epic #25,
+  # Phase 5) qui n'auraient pas été backfillées.
+  FALLBACK_COLOR = "#6b7280".freeze
+
+  def color
+    object.color.presence || FALLBACK_COLOR
+  end
+
+  # Les couleurs sont en base : impossible de passer par des classes Tailwind
+  # (le purge JIT ne voit pas les classes construites à l'exécution). On rend
+  # donc la couleur en style inline — fond translucide + liseré plein.
+  def calendar_chip_style
+    "background-color: #{color}1a; border-left: 3px solid #{color}; color: #{color};"
+  end
+
+  def legend_dot_style
+    "background-color: #{color};"
+  end
+
   def fixed_price
     h.humanized_money_with_symbol(object.fixed_price)
   end

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -19,6 +19,14 @@
 #  duration_hours    :decimal(, )
 #
 class Experience < ApplicationRecord
+  # Couleurs du calendrier global des activités (epic #25, Phase 5). Palette fixe
+  # et lisible plutôt qu'un vrai hasard : les créneaux de deux activités qui se
+  # chevauchent doivent rester distinguables au premier coup d'œil.
+  PALETTE = %w[
+    #059669 #2563eb #d97706 #7c3aed #db2777 #0891b2
+    #65a30d #dc2626 #4f46e5 #ea580c #0d9488 #9333ea
+  ].freeze
+
   belongs_to :human, optional: true
 
   has_many :experience_availabilities, dependent: :destroy
@@ -40,6 +48,11 @@ class Experience < ApplicationRecord
   validates :duration_hours,
             numericality: { greater_than: 0 },
             allow_nil: true
+  validates :color,
+            format: { with: /\A#[0-9a-f]{6}\z/i },
+            allow_nil: true
+
+  before_validation :assign_color, on: :create
 
   # Durée d'un bloc de disponibilité, en minutes, dérivée de la durée numérique
   # en heures. Pilote la taille des créneaux (Phase 4 de l'épic #25). Renvoie
@@ -48,5 +61,18 @@ class Experience < ApplicationRecord
     return nil if duration_hours.nil?
 
     (duration_hours * 60).round
+  end
+
+  private
+
+  # Couleur attribuée à la création : on prend la couleur la moins utilisée de la
+  # palette (à égalité, la première dans l'ordre de la palette). Résultat agréable
+  # ET stable — deux activités créées à la suite ne peuvent pas se retrouver de la
+  # même couleur tant que la palette n'est pas épuisée.
+  def assign_color
+    return if color.present?
+
+    used = Experience.unscoped.where.not(color: nil).group(:color).count
+    self.color = PALETTE.min_by { |candidate| used.fetch(candidate, 0) }
   end
 end

--- a/app/services/experiences/global_week_calendar.rb
+++ b/app/services/experiences/global_week_calendar.rb
@@ -1,0 +1,68 @@
+module Experiences
+  # Calendrier hebdomadaire de TOUTES les activités (epic #25, Phase 5), affiché
+  # au-dessus du tableau de l'index.
+  #
+  # Différence clé avec `Experiences::WeekCalendar` (calendrier d'UNE activité) :
+  # ici, les activités ont des durées de bloc différentes et leurs créneaux ont le
+  # droit de se chevaucher. Une grille de créneaux à pas fixe n'a donc pas de sens
+  # — on retombe sur une grille à l'heure, et chaque créneau est rangé dans la
+  # ligne de son heure de début. Plusieurs créneaux dans la même case s'empilent.
+  class GlobalWeekCalendar
+    START_HOUR = WeekCalendar::DAY_START_MINUTES / 60 # 8
+    END_HOUR   = WeekCalendar::DAY_END_MINUTES / 60   # 22
+
+    attr_reader :week_start
+
+    def initialize(week_start: nil)
+      @week_start = (week_start.presence || Date.today).beginning_of_week(:monday)
+    end
+
+    def days
+      (week_start..week_start.end_of_week(:monday)).to_a
+    end
+
+    # Lignes de la grille : 8h → 21h (un créneau qui démarre à 21h30 se range dans
+    # la ligne 21h ; rien ne peut démarrer à 22h, c'est la borne de fermeture).
+    def hours
+      (START_HOUR...END_HOUR).to_a
+    end
+
+    def availabilities
+      @availabilities ||= ExperienceAvailability
+        .includes(:experience)
+        .for_date_range(days.first, days.last)
+        .to_a
+        .sort_by { |availability| [availability.available_on, availability.starts_at_minutes || 0] }
+    end
+
+    # Créneaux indexés par [date, heure de début] — l'empilement dans une case est
+    # simplement l'ordre chronologique puis alphabétique de l'activité, pour que
+    # l'affichage soit stable d'un rendu à l'autre.
+    def index
+      @index ||= availabilities.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |availability, memo|
+        minutes = availability.starts_at_minutes
+        next if minutes.nil?
+
+        memo[[availability.available_on, minutes / 60]] << availability
+      end
+    end
+
+    def availabilities_at(day, hour)
+      index[[day, hour]].sort_by { |availability| [availability.starts_at_minutes, availability.experience.name.to_s] }
+    end
+
+    def any?
+      availabilities.any?
+    end
+
+    # Activités présentes dans la semaine affichée — sert à dessiner la légende
+    # (une couleur par activité).
+    def experiences
+      @experiences ||= availabilities.map(&:experience).uniq.sort_by { |experience| experience.name.to_s }
+    end
+
+    def previous_week = week_start - 7
+    def next_week = week_start + 7
+    def current_week? = week_start == Date.today.beginning_of_week(:monday)
+  end
+end

--- a/app/views/experiences/_global_week_calendar.html.slim
+++ b/app/views/experiences/_global_week_calendar.html.slim
@@ -1,0 +1,63 @@
+/ Calendrier hebdo de TOUTES les activités (epic #25, Phase 5), au-dessus du
+/ tableau de l'index. Une couleur par activité ; les créneaux de deux activités
+/ différentes peuvent se chevaucher — ils s'empilent alors dans la même case.
+.mb-8.overflow-hidden.bg-white.shadow.sm:rounded-lg(data-global-week-calendar="true")
+  .px-4.py-5.sm:px-6.flex.flex-wrap.items-center.justify-between.gap-3
+    div
+      h3.text-lg.font-medium.leading-6.text-gray-900 Créneaux de la semaine
+      p.text-sm.text-gray-500
+        = "Semaine du #{l(calendar.week_start, format: '%-d %B')} au #{l(calendar.days.last, format: '%-d %B %Y')}"
+
+    .flex.items-center.gap-2
+      = link_to "← Semaine précédente", experiences_path(week: calendar.previous_week.iso8601),
+                class: "text-sm text-gray-600 hover:text-gray-900 px-2 py-1 rounded hover:bg-gray-100"
+      - unless calendar.current_week?
+        = link_to "Aujourd'hui", experiences_path,
+                  class: "text-sm font-medium text-emerald-700 hover:text-emerald-900 px-2 py-1 rounded hover:bg-emerald-50"
+      = link_to "Semaine suivante →", experiences_path(week: calendar.next_week.iso8601),
+                class: "text-sm text-gray-600 hover:text-gray-900 px-2 py-1 rounded hover:bg-gray-100"
+
+  / Légende : une pastille par activité présente dans la semaine affichée.
+  - if calendar.experiences.any?
+    .px-4.pb-4.sm:px-6.flex.flex-wrap.gap-x-4.gap-y-2(data-calendar-legend="true")
+      - calendar.experiences.each do |experience|
+        - decorated = ExperienceDecorator.new(experience)
+        .flex.items-center.gap-1.5.text-xs.text-gray-600
+          span.inline-block.h-2.5.w-2.5.rounded-full(style=decorated.legend_dot_style)
+          = link_to experience.name, experience_path(experience), class: "hover:text-gray-900"
+
+  .border-t.border-gray-200.p-4
+    - if !calendar.any?
+      p.text-sm.text-gray-500.italic
+        | Aucun créneau posé cette semaine. Les disponibilités se posent depuis la fiche de chaque activité.
+    - else
+      .overflow-x-auto
+        table.w-full.text-sm.border-separate(style="border-spacing: 2px;")
+          thead
+            tr
+              th.w-16.text-xs.font-medium.text-gray-400.text-left
+              - calendar.days.each do |day|
+                th.text-xs.font-medium.text-gray-500.text-center(class="#{day == Date.today ? 'text-emerald-700' : ''}")
+                  .uppercase.tracking-wide = l(day, format: "%a")
+                  .text-base.font-semibold(class="#{day == Date.today ? 'text-emerald-700' : 'text-gray-800'}")
+                    = l(day, format: "%-d")
+          tbody
+            - calendar.hours.each do |hour|
+              tr
+                td.text-xs.text-gray-400.pr-2.align-top.whitespace-nowrap.pt-1
+                  = format("%02d:00", hour)
+                - calendar.days.each do |day|
+                  - slots = calendar.availabilities_at(day, hour)
+                  td.align-top(class="#{slots.any? ? '' : 'bg-gray-50/50'}")
+                    - if slots.any?
+                      .flex.flex-col.gap-1
+                        - slots.each do |availability|
+                          - decorated = ExperienceDecorator.new(availability.experience)
+                          = link_to experience_path(availability.experience),
+                                    style: decorated.calendar_chip_style,
+                                    title: "#{availability.experience.name} — #{availability.starts_at}→#{availability.ends_at}",
+                                    data: { global_slot: "#{day.iso8601} #{availability.starts_at}", experience_id: availability.experience_id },
+                                    class: "block rounded px-1.5 py-1 text-xs font-medium leading-tight hover:opacity-80 transition-opacity" do
+                            .font-semibold.whitespace-nowrap
+                              = "#{availability.starts_at}→#{availability.ends_at}"
+                            .truncate = availability.experience.name

--- a/app/views/experiences/index.html.slim
+++ b/app/views/experiences/index.html.slim
@@ -5,6 +5,8 @@
              link_to("➕ Nouvelle activité", new_experience_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2") \
            ]
 
+= render "global_week_calendar", calendar: @global_calendar
+
 .overflow-x-auto.relative
   table.w-full.text-sm.text-left.text-gray-500
     thead.text-xs.text-gray-700.uppercase.bg-gray-50

--- a/db/migrate/20260714012843_add_color_to_experiences.rb
+++ b/db/migrate/20260714012843_add_color_to_experiences.rb
@@ -1,0 +1,19 @@
+class AddColorToExperiences < ActiveRecord::Migration[7.0]
+  # Une couleur par activité (epic #25, Phase 5) : c'est elle qui distingue les
+  # créneaux des différentes activités sur le calendrier global de l'index, où
+  # les activités ont le droit de se chevaucher.
+  def up
+    add_column :experiences, :color, :string
+
+    # Backfill : on répartit la palette dans l'ordre plutôt que de tirer au
+    # hasard, pour éviter que deux activités tombent sur la même couleur.
+    palette = Experience::PALETTE
+    Experience.unscoped.order(:id).pluck(:id).each_with_index do |id, index|
+      Experience.unscoped.where(id: id).update_all(color: palette[index % palette.size])
+    end
+  end
+
+  def down
+    remove_column :experiences, :color
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_13_031500) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_14_012843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -288,6 +288,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_13_031500) do
     t.integer "max_participants"
     t.string "duration"
     t.decimal "duration_hours", precision: 4, scale: 2
+    t.string "color"
     t.index ["human_id"], name: "index_experiences_on_human_id"
   end
 

--- a/spec/models/experience_color_spec.rb
+++ b/spec/models/experience_color_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Epic #25, Phase 5 — une couleur par activité, attribuée à la création.
+RSpec.describe Experience, "couleur" do
+  it "attribue une couleur de la palette à la création" do
+    experience = Experience.create!(name: "Balade avec les ânes")
+
+    expect(experience.color).to be_present
+    expect(Experience::PALETTE).to include(experience.color)
+  end
+
+  it "ne donne pas la même couleur à deux activités créées à la suite" do
+    couleurs = 3.times.map { |i| Experience.create!(name: "Activité #{i}").color }
+
+    expect(couleurs.uniq.size).to eq(3)
+  end
+
+  it "répartit la palette avant de réutiliser une couleur" do
+    Experience::PALETTE.size.times { |i| Experience.create!(name: "Activité #{i}") }
+    couleurs = Experience.unscoped.pluck(:color)
+
+    expect(couleurs.sort).to eq(Experience::PALETTE.sort)
+  end
+
+  it "respecte une couleur fournie explicitement" do
+    experience = Experience.create!(name: "Poterie", color: "#123abc")
+
+    expect(experience.color).to eq("#123abc")
+  end
+
+  it "refuse une couleur qui n'est pas un hexadécimal à 6 chiffres" do
+    experience = Experience.new(name: "Poterie", color: "vert")
+
+    expect(experience).not_to be_valid
+    expect(experience.errors[:color]).to be_present
+  end
+
+  describe "décorateur" do
+    it "rend un style inline (les classes Tailwind dynamiques seraient purgées)" do
+      decorated = ExperienceDecorator.new(Experience.create!(name: "Poterie", color: "#059669"))
+
+      expect(decorated.calendar_chip_style).to include("#059669")
+      expect(decorated.legend_dot_style).to eq("background-color: #059669;")
+    end
+
+    it "retombe sur une couleur neutre si l'activité n'en a pas" do
+      experience = Experience.create!(name: "Poterie")
+      experience.update_columns(color: nil)
+
+      expect(ExperienceDecorator.new(experience.reload).color).to eq(ExperienceDecorator::FALLBACK_COLOR)
+    end
+  end
+end

--- a/spec/requests/experiences_global_calendar_spec.rb
+++ b/spec/requests/experiences_global_calendar_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+# Epic #25, Phase 5 — calendrier global au-dessus du tableau des activités.
+RSpec.describe "Experiences — calendrier global de l'index", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  let(:monday) { Date.today.beginning_of_week(:monday) }
+  let(:balade) { Experience.create!(name: "Balade avec les ânes", duration_hours: 2) }
+  let(:poterie) { Experience.create!(name: "Atelier poterie", duration_hours: 3) }
+
+  before { sign_in user }
+
+  it "rend le calendrier même sans aucun créneau" do
+    balade
+
+    get experiences_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("data-global-week-calendar")
+    expect(response.body).to include("Aucun créneau posé cette semaine")
+  end
+
+  it "affiche les créneaux de la semaine en cours, toutes activités confondues" do
+    ExperienceAvailability.create!(experience: balade, available_on: monday + 1, starts_at: "10:00")
+    ExperienceAvailability.create!(experience: poterie, available_on: monday + 2, starts_at: "14:00")
+
+    get experiences_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("data-global-slot=\"#{(monday + 1).iso8601} 10:00\"")
+    expect(response.body).to include("data-global-slot=\"#{(monday + 2).iso8601} 14:00\"")
+    expect(response.body).to include("10:00→12:00")
+    expect(response.body).to include("14:00→17:00")
+  end
+
+  it "donne à chaque activité sa couleur (style inline, pas de classe Tailwind)" do
+    ExperienceAvailability.create!(experience: balade, available_on: monday + 1, starts_at: "10:00")
+
+    get experiences_path
+
+    expect(response.body).to include(balade.reload.color)
+    expect(response.body).to include("data-calendar-legend")
+  end
+
+  it "affiche les créneaux qui se chevauchent entre deux activités" do
+    ExperienceAvailability.create!(experience: balade, available_on: monday + 3, starts_at: "10:00")
+    ExperienceAvailability.create!(experience: poterie, available_on: monday + 3, starts_at: "10:00")
+
+    get experiences_path
+
+    expect(response.body.scan("data-global-slot=\"#{(monday + 3).iso8601} 10:00\"").size).to eq(2)
+  end
+
+  it "navigue vers une autre semaine via ?week=" do
+    ExperienceAvailability.create!(experience: balade, available_on: monday + 8, starts_at: "10:00")
+
+    get experiences_path(week: (monday + 7).iso8601)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("data-global-slot=\"#{(monday + 8).iso8601} 10:00\"")
+    expect(response.body).to include("Aujourd&#39;hui") # retour à la semaine en cours proposé
+  end
+
+  it "ignore un ?week= illisible et retombe sur la semaine en cours" do
+    ExperienceAvailability.create!(experience: balade, available_on: monday + 1, starts_at: "10:00")
+
+    get experiences_path(week: "pas-une-date")
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("data-global-slot=\"#{(monday + 1).iso8601} 10:00\"")
+  end
+end

--- a/spec/services/experiences/global_week_calendar_spec.rb
+++ b/spec/services/experiences/global_week_calendar_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+# Epic #25, Phase 5 — calendrier hebdo de TOUTES les activités.
+RSpec.describe Experiences::GlobalWeekCalendar do
+  let(:monday) { Date.today.beginning_of_week(:monday) }
+  let(:balade) { Experience.create!(name: "Balade avec les ânes", duration_hours: 2) }
+  let(:poterie) { Experience.create!(name: "Atelier poterie", duration_hours: 3) }
+
+  def availability(experience, day, starts_at)
+    ExperienceAvailability.create!(experience: experience, available_on: day, starts_at: starts_at)
+  end
+
+  describe "cadrage de la semaine" do
+    it "démarre sur la semaine en cours par défaut" do
+      calendar = described_class.new
+
+      expect(calendar.week_start).to eq(monday)
+      expect(calendar).to be_current_week
+      expect(calendar.days.size).to eq(7)
+      expect(calendar.days.first).to eq(monday)
+      expect(calendar.days.last).to eq(monday + 6)
+    end
+
+    it "se cale sur le lundi de la semaine demandée" do
+      calendar = described_class.new(week_start: monday + 9) # un mercredi
+
+      expect(calendar.week_start).to eq(monday + 7)
+      expect(calendar).not_to be_current_week
+    end
+
+    it "navigue d'une semaine à l'autre" do
+      calendar = described_class.new(week_start: monday)
+
+      expect(calendar.previous_week).to eq(monday - 7)
+      expect(calendar.next_week).to eq(monday + 7)
+    end
+
+    it "expose les lignes horaires de 8h à 21h (22h = fermeture)" do
+      expect(described_class.new.hours).to eq((8..21).to_a)
+    end
+  end
+
+  describe "agrégation des créneaux" do
+    it "ne retient que les créneaux de la semaine affichée" do
+      dans_la_semaine = availability(balade, monday + 1, "10:00")
+      availability(balade, monday + 10, "10:00") # semaine suivante
+
+      calendar = described_class.new(week_start: monday)
+
+      expect(calendar.availabilities).to eq([dans_la_semaine])
+    end
+
+    it "range chaque créneau dans la ligne de son heure de début" do
+      matin = availability(balade, monday + 1, "10:00")
+      apres_midi = availability(balade, monday + 1, "14:00")
+
+      calendar = described_class.new(week_start: monday)
+
+      expect(calendar.availabilities_at(monday + 1, 10)).to eq([matin])
+      expect(calendar.availabilities_at(monday + 1, 14)).to eq([apres_midi])
+      expect(calendar.availabilities_at(monday + 1, 9)).to be_empty
+    end
+
+    it "range un créneau de 21h30 dans la ligne de 21h" do
+      tardif = Experience.create!(name: "Observation des étoiles", duration_hours: 0.5)
+      bloc = availability(tardif, monday + 2, "21:30")
+
+      calendar = described_class.new(week_start: monday)
+
+      expect(calendar.availabilities_at(monday + 2, 21)).to eq([bloc])
+    end
+
+    it "empile les créneaux de DEUX activités qui se chevauchent (c'est voulu)" do
+      a = availability(balade, monday + 3, "10:00")
+      b = availability(poterie, monday + 3, "10:00")
+
+      calendar = described_class.new(week_start: monday)
+      slots = calendar.availabilities_at(monday + 3, 10)
+
+      expect(slots).to contain_exactly(a, b)
+      # ordre stable : à heure égale, alphabétique par activité
+      expect(slots.map { |s| s.experience.name }).to eq(["Atelier poterie", "Balade avec les ânes"])
+    end
+  end
+
+  describe "légende" do
+    it "liste les activités présentes dans la semaine, sans doublon, par ordre alphabétique" do
+      availability(poterie, monday + 1, "09:00")
+      availability(balade, monday + 2, "09:00")
+      availability(balade, monday + 3, "09:00")
+
+      calendar = described_class.new(week_start: monday)
+
+      expect(calendar.experiences.map(&:name)).to eq(["Atelier poterie", "Balade avec les ânes"])
+    end
+
+    it "est vide quand aucun créneau n'est posé" do
+      calendar = described_class.new(week_start: monday)
+
+      expect(calendar).not_to be_any
+      expect(calendar.experiences).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Phase 5 de l'epic #25 (activités : porteurs, calendrier, réservation client).

Ajoute un **calendrier hebdo de toutes les activités** au-dessus du tableau de l'index, avec **une couleur par activité**.

## Ce que fait la PR

- **`experiences.color`** (migration + backfill). La couleur est attribuée **à la création** : on prend la couleur **la moins utilisée** de la palette `Experience::PALETTE` (12 teintes lisibles) plutôt qu'un vrai tirage au sort — comme ça, deux activités créées à la suite ne peuvent pas sortir de la même couleur, et le résultat reste stable/testable. Le backfill répartit la palette dans l'ordre des id.
- **`Experiences::GlobalWeekCalendar`** — grille semaine 8h→22h agrégeant les créneaux de **toutes** les activités. Différence avec le `WeekCalendar` de la Phase 4 (une seule activité) : ici les durées de bloc diffèrent d'une activité à l'autre, donc une grille à pas fixe n'a pas de sens — je range chaque créneau dans la **ligne de son heure de début**, et les créneaux qui **se chevauchent s'empilent** dans la case (c'est le comportement voulu par l'epic).
- **Vue `_global_week_calendar`** + **légende** (pastille de couleur + lien vers chaque activité présente dans la semaine). Navigation `?week=` passé/futur et retour « Aujourd'hui », comme sur la fiche d'activité.
- **Couleurs en style inline** dans `ExperienceDecorator`, pas en classes Tailwind : les classes construites à l'exécution (`bg-#{...}`) sont purgées par le JIT et ne sortiraient jamais dans le CSS. C'est le seul endroit où je m'écarte du tout-Tailwind, et c'est pour cette raison.

## Tests

- `bundle exec rspec` : **320 exemples, 0 échec** (18 pending pré-existants). Baseline avant la PR : 297 — pas de régression.
- Nouvelles specs : `spec/services/experiences/global_week_calendar_spec.rb` (cadrage de la semaine, agrégation, créneau de 21h30 rangé en ligne 21h, **chevauchement de deux activités**, légende), `spec/models/experience_color_spec.rb` (palette, non-collision, format, fallback décorateur), `spec/requests/experiences_global_calendar_spec.rb` (rendu, `?week=` valide et illisible, couleurs présentes dans le HTML).

## Non testé / à valider

- **Aucun test d'interaction JS** : le calendrier est 100 % server-rendered (aucune dépendance JS ajoutée), donc rien à tester côté navigateur au-delà du rendu — mais je n'ai pas de couverture system-spec permanente (pas d'infra Capybara/chromedriver dans le repo ; j'ai utilisé un test système **jetable**, supprimé avant commit, uniquement pour produire la capture).
- **Rendu mobile** non vérifié : la grille passe en `overflow-x-auto`, mais je ne l'ai pas ouverte sur un petit écran.
- **Volume** : avec beaucoup d'activités et de créneaux, une case peut empiler pas mal de pastilles. Je n'ai pas mis de limite (comme pour les barres du calendrier principal, la ligne grandit). À voir à l'usage.
- La couleur est **modifiable en base** mais **pas encore éditable dans le formulaire** d'activité — l'epic ne le demandait pas ; dis-moi si tu veux un sélecteur.

## 📸 Aperçu

Semaine avec 3 activités, dont un **chevauchement voulu** lundi 10h (Atelier poterie + Balade avec les ânes) :

![Calendrier global des activités (index) — une couleur par activité, chevauchements empilés](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260714-033422-calendrier-global-des-activits-index--une-couleu.png)
