### PR TITLE
Refs #26 — Phase 3 : canal admin/OTA sur Stay

### DIFF
--- a/app/services/bookings/create_service.rb
+++ b/app/services/bookings/create_service.rb
@@ -30,7 +30,14 @@ module Bookings
       rooms = get_rooms
       if !rooms.nil? && available?(rooms)
         build_reservations(rooms)
-        @booking.save!
+        # Stay-first (epic #26, Phase 3) : tout Booking créé côté admin/OTA obtient
+        # automatiquement un Stay + Customer. Booking et Stay sont persistés dans la
+        # MÊME transaction — un échec de Stay annule le booking pour ne jamais laisser
+        # d'orphelin. Les effets de bord (email, abonnement) restent hors transaction.
+        ActiveRecord::Base.transaction do
+          @booking.save!
+          Stays::EnsureForBooking.call(@booking)
+        end
         notify_customer_on_create
         create_subscription(from: @booking)
       end

--- a/app/services/bookings/update_service.rb
+++ b/app/services/bookings/update_service.rb
@@ -33,6 +33,10 @@ module Bookings
           build_reservations(rooms)
           @booking.save!
           @booking.set_payment_status
+          # Stay-first (epic #26, Phase 3) : soigne un Booking legacy dépourvu de Stay
+          # (créé avant le backfill ou via un bypass). Idempotent — no-op si un Stay
+          # vivant existe déjà. Dans la transaction pour rester atomique avec le save.
+          Stays::EnsureForBooking.call(@booking)
         end
       end
       raise error_message if !error.nil?

--- a/app/services/concerns/bookable.rb
+++ b/app/services/concerns/bookable.rb
@@ -146,14 +146,15 @@ module Bookable
         :to_date,
         :towels,
         :wifi,
-        room_ids: [],
-        payments_attributes: [
-          :id,
-          :amount,
-          :payment_method,
-          :_destroy
-        ]
+        room_ids: []
       )
+      # NB (epic #26, Phase 3) : `payments_attributes` a été RETIRÉ de la liste
+      # permise. Aucun formulaire admin ne soumet de paiement niché (le partial
+      # bookings/form/_payment n'édite que :price/:invoice_status), et un Payment
+      # niché serait sauvé DANS @booking.save! — donc AVANT Stays::EnsureForBooking —
+      # d'où un Payment sans stay_id (trou exploitable par requête forgée/API, et
+      # bloquant en Phase 4 où stay_id devient requis). Les paiements admin passent
+      # par Payments::CreateService, qui rattache bien le stay_id.
   end
 
   def public_booking_params(params)

--- a/app/services/customers/upsert_by_email.rb
+++ b/app/services/customers/upsert_by_email.rb
@@ -1,0 +1,73 @@
+module Customers
+  # Politique unique d'upsert d'un Customer à partir d'un email (epic #26,
+  # Phase 3). Extrait la logique jusqu'ici enfermée dans
+  # LegacyBookingMigration::Runner#upsert_customer_for pour qu'admin/OTA et
+  # futurs importeurs partagent EXACTEMENT la même règle « même email → même
+  # Customer ».
+  #
+  # Règle déterministe (cf. Customer.exploitable_email?) :
+  #   - email exploitable (format valide, y compris relais OTA) → on retrouve le
+  #     Customer vivant portant cet email normalisé (lowercase, citext) ou on en
+  #     crée un ;
+  #   - email inexploitable (vide/invalide) → rattachement au Customer fourre-tout
+  #     CATCH_ALL_EMAIL, jamais de perte.
+  #
+  # On ne recâble PAS Runner sur ce service dans cette PR (Runner est testé, a
+  # tourné en prod et gère ses compteurs/cache de rapport). Ce service est le
+  # foyer unique pour tout NOUVEL appelant.
+  class UpsertByEmail
+    def self.call(email:, attrs: {})
+      new(email: email, attrs: attrs).call
+    end
+
+    def initialize(email:, attrs: {})
+      @raw_email = email
+      @attrs = attrs || {}
+    end
+
+    def call
+      if Customer.exploitable_email?(@raw_email)
+        upsert_real_customer
+      else
+        catch_all_customer
+      end
+    end
+
+    private
+
+    def upsert_real_customer
+      email = Customer.normalize_email(@raw_email)
+      # Index unique partiel sur les lignes vivantes : un email exploitable ne
+      # peut désigner qu'un seul Customer vivant. On le réutilise donc plutôt que
+      # d'en créer un doublon (idempotence par email).
+      existing = Customer.find_by(email: email)
+      return existing if existing
+
+      persist(@attrs.merge(email: email))
+    end
+
+    def catch_all_customer
+      existing = Customer.find_by(email: Customer::CATCH_ALL_EMAIL)
+      return existing if existing
+
+      persist(
+        email: Customer::CATCH_ALL_EMAIL,
+        first_name: "Client",
+        last_name: "Les 4 Sources",
+        customer_type: "individual",
+        language: "fr"
+      )
+    end
+
+    # Les données admin/OTA peuvent être incomplètes (pas de nom, pas de langue…)
+    # sans que cela doive jamais empêcher la création du séjour. La clé est
+    # l'email, dont l'unicité vivante est déjà garantie par le find_by ci-dessus.
+    # On persiste donc en contournant les validations non structurantes, comme le
+    # fait Runner pour la donnée legacy.
+    def persist(attributes)
+      customer = Customer.new(attributes)
+      customer.save!(validate: false)
+      customer
+    end
+  end
+end

--- a/app/services/payments/create_service.rb
+++ b/app/services/payments/create_service.rb
@@ -23,7 +23,14 @@ module Payments
       @payment.attributes = payment_params(params)
       return false if !@payment.valid?
       set_status
-      @payment.save!
+      # Stay-first (epic #26, Phase 3) : un paiement admin porte désormais un
+      # stay_id. On garantit (idempotent) que le booking a un Stay AVANT de sauver,
+      # puis on rattache le paiement au Stay. booking_id reste renseigné (canal
+      # historique). Ensure + save dans la même transaction pour l'atomicité.
+      ActiveRecord::Base.transaction do
+        @payment.stay = Stays::EnsureForBooking.call(@booking)
+        @payment.save!
+      end
       @booking.set_payment_status
       raise error_message if !error.nil?
       true

--- a/app/services/public/bookings/create_service.rb
+++ b/app/services/public/bookings/create_service.rb
@@ -28,11 +28,19 @@ module Public
         set_invoice_status
         set_tier
         rooms = get_rooms
-        if ready_to_book?(rooms) 
+        if ready_to_book?(rooms)
           initialize_public_booking
           set_price
           build_reservations(rooms)
-          @booking.save!
+          # Stay-first (epic #26, Phase 3) : le funnel public legacy (POST /public/bookings,
+          # encore lié depuis le calendrier iframe et les mails) doit lui aussi produire un
+          # Stay, sinon il recrée des Bookings sans Stay et casse l'invariant global. Booking
+          # et Stay dans la MÊME transaction (échec du Stay ⇒ rollback du booking, zéro
+          # orphelin) ; effets de bord (mails, abonnement) hors transaction.
+          ActiveRecord::Base.transaction do
+            @booking.save!
+            Stays::EnsureForBooking.call(@booking)
+          end
           notify_customer_on_create
           notify_admin_on_create
           create_subscription(from: @booking)

--- a/app/services/stays/ensure_for_booking.rb
+++ b/app/services/stays/ensure_for_booking.rb
@@ -39,7 +39,15 @@ module Stays
           departure_date: @booking.to_date,
           total_amount_cents: @booking.price_cents.to_i
         )
-        StayItem.create!(stay: stay, bookable: @booking)
+        # On n'arrive ici que si live_stay_for est nil (pas de StayItem vivant → Stay
+        # vivant). Un StayItem vivant PEUT toutefois subsister en pointant vers un Stay
+        # soft-deleted (état latent improbable) : dans ce cas on le REPOINTE vers le
+        # Stay neuf plutôt que d'en créer un second — sinon deux StayItem vivants pour
+        # un même booking (l'unicité est scoped sur stay_id, donc autorisés). find_or_
+        # initialize garantit exactement UN StayItem vivant par booking.
+        item = StayItem.find_or_initialize_by(bookable: @booking)
+        item.stay = stay
+        item.save!
         stay
       end
     end

--- a/app/services/stays/ensure_for_booking.rb
+++ b/app/services/stays/ensure_for_booking.rb
@@ -1,0 +1,79 @@
+module Stays
+  # Garantit qu'un Booking porte un Stay (epic #26, Phase 3). IDEMPOTENT :
+  #   - si le Booking a déjà un Stay vivant (has_one :stay through stay_item),
+  #     on le renvoie sans rien créer ;
+  #   - sinon on upserte le Customer par email (service partagé), on crée le Stay
+  #     et le StayItem qui le relie au Booking.
+  #
+  # N'écrit JAMAIS sur le Booking (zéro perte de donnée). Ne pose PAS de
+  # legacy_origin : ce n'est pas une reprise legacy mais le canal courant
+  # admin/OTA — l'idempotence repose sur la présence du Stay vivant, pas sur un
+  # marqueur d'import.
+  #
+  # Appelé par Bookings::CreateService (tout nouveau booking admin/OTA), par
+  # Payments::CreateService (garantir un stay avant de rattacher le paiement) et
+  # par la rake stays:backfill_missing (rattrapage rétroactif).
+  class EnsureForBooking
+    def self.call(booking)
+      new(booking).call
+    end
+
+    def initialize(booking)
+      @booking = booking
+    end
+
+    def call
+      existing = live_stay_for(@booking)
+      return existing if existing.present?
+
+      ActiveRecord::Base.transaction do
+        customer = Customers::UpsertByEmail.call(
+          email: @booking.email,
+          attrs: customer_attrs
+        )
+        stay = Stay.create!(
+          customer: customer,
+          source: source_for(@booking),
+          status: @booking.status,
+          arrival_date: @booking.from_date,
+          departure_date: @booking.to_date,
+          total_amount_cents: @booking.price_cents.to_i
+        )
+        StayItem.create!(stay: stay, bookable: @booking)
+        stay
+      end
+    end
+
+    private
+
+    # Clé d'idempotence : le Stay VIVANT rattaché au booking, lu FRAÎCHEMENT en
+    # base (StayItem live + Stay live) plutôt que via le cache d'association du
+    # booking — sinon un même objet booking passé deux fois (ou dont
+    # l'association a été chargée avant la création du stay) recréerait un
+    # doublon. Robuste au re-run comme à l'objet en mémoire non rechargé.
+    def live_stay_for(booking)
+      StayItem.find_by(bookable: booking)&.stay
+    end
+
+    def customer_attrs
+      group_name = @booking.group_name.presence
+      {
+        first_name: @booking.firstname,
+        last_name: @booking.lastname,
+        phone: @booking.phone,
+        organization_name: group_name,
+        customer_type: group_name.present? ? "organization" : "individual"
+      }
+    end
+
+    # Canal d'attribution du Stay : les résas OTA (airbnb / bookingdotcom) passent
+    # par le même formulaire admin, distinguées par `platform`. Tout le reste
+    # (web, direct, téléphone…) est de la saisie manuelle admin.
+    def source_for(booking)
+      case booking.platform.to_s
+      when "airbnb", "bookingdotcom" then "ota"
+      else "manual"
+      end
+    end
+  end
+end

--- a/lib/tasks/stays.rake
+++ b/lib/tasks/stays.rake
@@ -1,0 +1,44 @@
+namespace :stays do
+  desc "Rattache un Stay à tout Booking qui n'en a pas (idempotent) — epic #26 Phase 3"
+  task backfill_missing: :environment do
+    created = 0
+    skipped = 0
+    seen = 0
+
+    # On couvre TOUTE l'histoire (actifs, passés, annulés ET soft-deleted), comme
+    # la migration legacy : `with_deleted` relâche le seul default scope de Booking.
+    # Stay/StayItem gardent leur scope vivant, donc `booking.stay` reste la clé
+    # d'idempotence (un booking déjà rattaché est sauté).
+    Booking.with_deleted do
+      Booking.unscoped.find_each do |booking|
+        seen += 1
+        if booking.stay.present?
+          skipped += 1
+          next
+        end
+        Stays::EnsureForBooking.call(booking)
+        created += 1
+      end
+    end
+
+    remaining = bookings_without_live_stay
+
+    puts "=== Backfill stays (epic #26, Phase 3) ==="
+    puts "Bookings vus                 : #{seen}"
+    puts "Déjà rattachés (skip)        : #{skipped}"
+    puts "Stays créés                  : #{created}"
+    puts "Bookings encore sans Stay    : #{remaining}"
+    abort("ÉCHEC : #{remaining} booking(s) sans Stay après backfill.") if remaining.positive?
+    puts "OK — 0 Booking sans Stay."
+  end
+end
+
+# Compte les Bookings (deleted inclus) dépourvus d'un StayItem vivant. Passe par
+# les StayItem vivants pour n'exclure QUE les rattachements actifs, cohérent avec
+# la clé d'idempotence booking.stay.
+def bookings_without_live_stay
+  linked_ids = StayItem.where(bookable_type: "Booking").pluck(:bookable_id)
+  Booking.with_deleted do
+    Booking.unscoped.where.not(id: linked_ids).count
+  end
+end

--- a/lib/tasks/stays.rake
+++ b/lib/tasks/stays.rake
@@ -33,11 +33,17 @@ namespace :stays do
   end
 end
 
-# Compte les Bookings (deleted inclus) dépourvus d'un StayItem vivant. Passe par
-# les StayItem vivants pour n'exclure QUE les rattachements actifs, cohérent avec
-# la clé d'idempotence booking.stay.
+# Compte les Bookings (deleted inclus) dépourvus d'un Stay VIVANT. « Rattaché » =
+# StayItem vivant pointant vers un Stay vivant — exactement la même définition que
+# booking.stay et que Stays::EnsureForBooking#live_stay_for, sinon skip et count
+# divergent dans le cas latent « StayItem vivant → Stay soft-deleted ».
+# On restreint aux stay_id vivants via le default scope de Stay : `joins(:stay)`
+# n'applique PAS le default scope de la table jointe (il compterait les Stays
+# soft-deleted), d'où le sous-select explicite `stay_id: Stay.select(:id)`.
 def bookings_without_live_stay
-  linked_ids = StayItem.where(bookable_type: "Booking").pluck(:bookable_id)
+  linked_ids = StayItem
+    .where(bookable_type: "Booking", stay_id: Stay.select(:id))
+    .pluck(:bookable_id)
   Booking.with_deleted do
     Booking.unscoped.where.not(id: linked_ids).count
   end

--- a/spec/services/bookings/create_service_spec.rb
+++ b/spec/services/bookings/create_service_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+# Couvre AC1 de la Phase 3 (epic #26) AU POINT D'ENTRÉE réel du canal admin/OTA :
+# Bookings::CreateService#run. Tout Booking créé ici doit repartir avec un Stay
+# et un Customer upserté par email — résas manuelles ET OTA (même formulaire,
+# distinguées par `platform`).
+RSpec.describe Bookings::CreateService do
+  let(:lodging) do
+    l = Lodging.create!(name: "Gîte Test", available_for_bookings: true, price_night: 100)
+    room = Room.create!(code: "TST", name: "Test")
+    l.rooms << room
+    l
+  end
+
+  def params(overrides = {})
+    ActionController::Parameters.new(
+      booking: {
+        firstname: "Nadia",
+        lastname: "Bianchi",
+        email: "Nadia@Example.com",
+        booking_type: "lodging",
+        lodging_id: lodging.id,
+        from_date: Date.today + 30,
+        to_date: Date.today + 33,
+        adults: 2,
+        price: "300",
+        status: "pending",
+        platform: "web"
+      }.merge(overrides)
+    )
+  end
+
+  it "crée un Booking ET son Stay + Customer (canal admin)" do
+    service = described_class.new
+
+    expect(service.run(params)).to be(true)
+
+    booking = service.booking.reload
+    expect(booking.stay).to be_present
+    expect(booking.stay.customer.email).to eq("nadia@example.com")
+    expect(booking.stay.source).to eq("manual")
+  end
+
+  it "attribue source 'ota' à une résa OTA (platform airbnb) via le même canal" do
+    service = described_class.new
+
+    expect(service.run(params(platform: "airbnb", email: "guest@guest.airbnb.com"))).to be(true)
+
+    expect(service.booking.reload.stay.source).to eq("ota")
+  end
+
+  it "upserte le même Customer pour deux bookings au même email" do
+    described_class.new.tap { |s| s.run(params(email: "repeat@example.com")) }
+    described_class.new.tap { |s| s.run(params(email: "repeat@example.com", from_date: Date.today + 60, to_date: Date.today + 62)) }
+
+    expect(Customer.where(email: "repeat@example.com").count).to eq(1)
+  end
+end

--- a/spec/services/bookings/create_service_spec.rb
+++ b/spec/services/bookings/create_service_spec.rb
@@ -55,4 +55,18 @@ RSpec.describe Bookings::CreateService do
 
     expect(Customer.where(email: "repeat@example.com").count).to eq(1)
   end
+
+  # Trou fermé (epic #26, Phase 3) : `payments_attributes` n'est plus permis dans
+  # booking_params. Une requête forgée qui nicherait un paiement ne doit créer AUCUN
+  # Payment (sinon il serait sauvé sans stay_id, avant EnsureForBooking).
+  it "ignore un payments_attributes forgé : aucun Payment n'est créé, le Stay l'est" do
+    forged = params(payments_attributes: [{ amount: "150", payment_method: "cash" }])
+    service = described_class.new
+
+    expect { expect(service.run(forged)).to be(true) }.not_to change(Payment, :count)
+
+    booking = service.booking.reload
+    expect(booking.payments).to be_empty
+    expect(booking.stay).to be_present
+  end
 end

--- a/spec/services/bookings/update_service_spec.rb
+++ b/spec/services/bookings/update_service_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+# Couvre le durcissement de la Phase 3 (epic #26) sur Bookings::UpdateService :
+# éditer un Booking legacy dépourvu de Stay doit désormais lui en créer un
+# (idempotent — pas de second Stay si un vivant existe déjà).
+RSpec.describe Bookings::UpdateService do
+  let(:lodging) do
+    l = Lodging.create!(name: "Gîte Update", available_for_bookings: true, price_night: 100)
+    l.rooms << Room.create!(code: "UPD", name: "Update")
+    l
+  end
+
+  def stayless_booking
+    # Création directe, SANS EnsureForBooking : reproduit un booking legacy d'avant
+    # le backfill (aucun Stay rattaché).
+    Booking.create!(
+      firstname: "Léa",
+      lastname: "Petit",
+      email: "lea@example.com",
+      booking_type: "lodging",
+      lodging_id: lodging.id,
+      from_date: Date.today + 40,
+      to_date: Date.today + 43,
+      adults: 2,
+      status: "pending",
+      price_cents: 30_000
+    )
+  end
+
+  def update_params(booking, overrides = {})
+    ActionController::Parameters.new(
+      booking: {
+        firstname: booking.firstname,
+        lastname: booking.lastname,
+        email: booking.email,
+        booking_type: "lodging",
+        lodging_id: lodging.id,
+        from_date: booking.from_date,
+        to_date: booking.to_date,
+        adults: booking.adults,
+        status: "pending",
+        price: "300"
+      }.merge(overrides)
+    )
+  end
+
+  it "crée un Stay pour un Booking legacy qui n'en avait pas" do
+    booking = stayless_booking
+    expect(booking.stay).to be_nil
+
+    service = described_class.new(booking_id: booking.id)
+    expect(service.run(update_params(booking))).to be(true)
+
+    expect(booking.reload.stay).to be_present
+  end
+
+  it "est idempotent : éditer un booking déjà rattaché ne crée pas de second Stay" do
+    booking = stayless_booking
+    Stays::EnsureForBooking.call(booking)
+
+    service = described_class.new(booking_id: booking.id)
+    expect { service.run(update_params(booking)) }.not_to change(Stay, :count)
+
+    expect(StayItem.where(bookable: booking.reload).count).to eq(1)
+  end
+end

--- a/spec/services/customers/upsert_by_email_spec.rb
+++ b/spec/services/customers/upsert_by_email_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Customers::UpsertByEmail do
+  describe "email exploitable" do
+    it "crée un Customer portant l'email normalisé (lowercase)" do
+      customer = described_class.call(
+        email: "  Alice@Example.COM ",
+        attrs: { first_name: "Alice", last_name: "Martin" }
+      )
+
+      expect(customer).to be_persisted
+      expect(customer.email).to eq("alice@example.com")
+      expect(customer.first_name).to eq("Alice")
+    end
+
+    it "réutilise le même Customer pour le même email (aucun doublon)" do
+      first  = described_class.call(email: "bob@example.com", attrs: { first_name: "Bob" })
+      second = described_class.call(email: "BOB@example.com", attrs: { first_name: "Bobby" })
+
+      expect(second.id).to eq(first.id)
+      expect(Customer.where(email: "bob@example.com").count).to eq(1)
+    end
+
+    it "réutilise un Customer vivant préexistant sans le muter" do
+      existing = Customer.create!(email: "carol@example.com", first_name: "Carol",
+                                  customer_type: "individual")
+
+      customer = described_class.call(email: "carol@example.com", attrs: { first_name: "Autre" })
+
+      expect(customer.id).to eq(existing.id)
+      expect(customer.reload.first_name).to eq("Carol")
+    end
+
+    it "traite un relais OTA (format valide) comme un email exploitable" do
+      customer = described_class.call(email: "guest-xyz@guest.airbnb.com")
+
+      expect(customer).to be_persisted
+      expect(customer.email).to eq("guest-xyz@guest.airbnb.com")
+      expect(customer.catch_all?).to be(false)
+    end
+  end
+
+  describe "email inexploitable (vide ou invalide)" do
+    it "rattache un email vide au Customer fourre-tout" do
+      customer = described_class.call(email: "")
+
+      expect(customer.email).to eq(Customer::CATCH_ALL_EMAIL)
+      expect(customer.catch_all?).to be(true)
+    end
+
+    it "rattache un email invalide au Customer fourre-tout" do
+      customer = described_class.call(email: "pas-un-email")
+
+      expect(customer.catch_all?).to be(true)
+    end
+
+    it "réutilise le même Customer fourre-tout (un seul créé)" do
+      first  = described_class.call(email: nil)
+      second = described_class.call(email: "   ")
+
+      expect(second.id).to eq(first.id)
+      expect(Customer.where(email: Customer::CATCH_ALL_EMAIL).count).to eq(1)
+    end
+  end
+end

--- a/spec/services/payments/create_service_spec.rb
+++ b/spec/services/payments/create_service_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Payments::CreateService do
+  def build_booking(**attrs)
+    Booking.create!({
+      firstname: "Marc",
+      email: "marc@example.com",
+      from_date: Date.new(2026, 9, 1),
+      to_date: Date.new(2026, 9, 3),
+      adults: 1,
+      status: "confirmed",
+      price_cents: 20_000
+    }.merge(attrs))
+  end
+
+  def payment_params(amount: 50, method: "cash")
+    ActionController::Parameters.new(payment: { amount: amount, payment_method: method })
+  end
+
+  it "crée un paiement admin porteur d'un stay_id (et conserve booking_id)" do
+    booking = build_booking
+    service = described_class.new(booking_id: booking.id)
+
+    expect(service.run(payment_params)).to be(true)
+
+    payment = service.payment.reload
+    expect(payment.stay_id).to be_present
+    expect(payment.booking_id).to eq(booking.id)
+    expect(payment.stay).to eq(booking.reload.stay)
+  end
+
+  it "réutilise le Stay existant du booking plutôt que d'en créer un autre" do
+    booking = build_booking
+    stay = Stays::EnsureForBooking.call(booking)
+
+    service = described_class.new(booking_id: booking.id)
+    expect { service.run(payment_params) }.not_to change(Stay, :count)
+
+    expect(service.payment.reload.stay_id).to eq(stay.id)
+  end
+
+  it "backfille un Stay pour un vieux booking qui n'en avait pas, puis relie le paiement" do
+    booking = build_booking
+    expect(booking.stay).to be_nil
+
+    service = described_class.new(booking_id: booking.id)
+    expect(service.run(payment_params)).to be(true)
+
+    expect(booking.reload.stay).to be_present
+    expect(service.payment.reload.stay_id).to eq(booking.stay.id)
+  end
+
+  it "met à jour le statut de paiement du booking" do
+    booking = build_booking(price_cents: 10_000)
+    service = described_class.new(booking_id: booking.id)
+
+    service.run(payment_params(amount: 100, method: "cash")) # 100 € = 10 000 cents, payé
+
+    expect(booking.reload.payment_status).to eq("paid")
+  end
+end

--- a/spec/services/public/bookings/create_service_spec.rb
+++ b/spec/services/public/bookings/create_service_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+# Couvre le durcissement de la Phase 3 (epic #26) sur le funnel PUBLIC legacy
+# (POST /public/bookings), encore vivant : tout Booking créé ici doit lui aussi
+# repartir avec un Stay + un Customer, comme le canal admin/OTA — sinon l'invariant
+# global « 0 Booking sans Stay » se casse pour les nouvelles résas publiques.
+RSpec.describe Public::Bookings::CreateService do
+  let(:lodging) do
+    l = Lodging.create!(name: "Gîte Public", available_for_bookings: true, price_night: 100)
+    l.rooms << Room.create!(code: "PUB", name: "Public")
+    l
+  end
+
+  def params(overrides = {})
+    ActionController::Parameters.new(
+      booking: {
+        firstname: "Camille",
+        lastname: "Martin",
+        email: "Camille@Example.com",
+        booking_type: "lodging",
+        lodging_id: lodging.id,
+        from_date: Date.today + 30,
+        to_date: Date.today + 33,
+        adults: 2,
+        shown_price_cents: 30_000,
+        terms_approval: "1"
+      }.merge(overrides)
+    )
+  end
+
+  it "crée le Booking ET son Stay + Customer (source manual, plateforme web)" do
+    service = described_class.new
+
+    expect(service.run(params)).to be(true)
+
+    booking = service.booking.reload
+    expect(booking.platform).to eq("web")
+    expect(booking.stay).to be_present
+    expect(booking.stay.source).to eq("manual")
+    expect(booking.stay.customer.email).to eq("camille@example.com")
+  end
+
+  it "reste idempotent : un Booking public ne porte qu'un seul StayItem vivant" do
+    service = described_class.new
+    service.run(params(email: "unique@example.com"))
+
+    booking = service.booking.reload
+    expect(StayItem.where(bookable: booking).count).to eq(1)
+  end
+
+  it "n'expose aucun payments_attributes : public_booking_params ne le permet pas" do
+    service = described_class.new
+
+    expect do
+      service.run(params(payments_attributes: [{ amount: "80", payment_method: "cash" }]))
+    end.not_to change(Payment, :count)
+
+    expect(service.booking.reload.payments).to be_empty
+  end
+end

--- a/spec/services/stays/ensure_for_booking_spec.rb
+++ b/spec/services/stays/ensure_for_booking_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe Stays::EnsureForBooking do
+  def build_booking(**attrs)
+    Booking.create!({
+      firstname: "Zoé",
+      lastname: "Durand",
+      email: "zoe@example.com",
+      from_date: Date.new(2026, 8, 1),
+      to_date: Date.new(2026, 8, 4),
+      adults: 2,
+      status: "pending",
+      price_cents: 30_000
+    }.merge(attrs))
+  end
+
+  describe "création d'un Stay pour un Booking qui n'en a pas" do
+    it "crée le Stay, le StayItem et upserte le Customer par email" do
+      booking = build_booking
+
+      stay = described_class.call(booking)
+
+      expect(stay).to be_persisted
+      expect(booking.reload.stay).to eq(stay)
+      expect(stay.customer.email).to eq("zoe@example.com")
+      expect(stay.stay_items.map(&:bookable)).to contain_exactly(booking)
+    end
+
+    it "recopie dates, statut et montant depuis le booking sans le muter" do
+      booking = build_booking
+
+      expect { described_class.call(booking) }.not_to change { booking.reload.attributes }
+
+      stay = booking.reload.stay
+      expect(stay.arrival_date).to eq(Date.new(2026, 8, 1))
+      expect(stay.departure_date).to eq(Date.new(2026, 8, 4))
+      expect(stay.status).to eq("pending")
+      expect(stay.total_amount_cents).to eq(30_000)
+    end
+
+    it "attribue source 'ota' pour une résa airbnb" do
+      stay = described_class.call(build_booking(platform: "airbnb"))
+      expect(stay.source).to eq("ota")
+    end
+
+    it "attribue source 'ota' pour une résa bookingdotcom" do
+      stay = described_class.call(build_booking(platform: "bookingdotcom"))
+      expect(stay.source).to eq("ota")
+    end
+
+    it "attribue source 'manual' pour une saisie admin classique" do
+      stay = described_class.call(build_booking(platform: "web"))
+      expect(stay.source).to eq("manual")
+    end
+
+    it "rattache un booking sans email exploitable au Customer fourre-tout" do
+      stay = described_class.call(build_booking(email: nil))
+      expect(stay.customer.catch_all?).to be(true)
+    end
+
+    it "crée un Customer organisation quand group_name est présent" do
+      stay = described_class.call(build_booking(email: "asso@example.com", group_name: "Les Amis"))
+      expect(stay.customer.customer_type).to eq("organization")
+      expect(stay.customer.organization_name).to eq("Les Amis")
+    end
+  end
+
+  describe "idempotence" do
+    it "renvoie le Stay existant sans en créer un second" do
+      booking = build_booking
+      first = described_class.call(booking)
+
+      second = nil
+      expect { second = described_class.call(booking) }.not_to change(Stay, :count)
+      expect(second).to eq(first)
+      expect(StayItem.where(bookable: booking).count).to eq(1)
+    end
+  end
+end

--- a/spec/services/stays/ensure_for_booking_spec.rb
+++ b/spec/services/stays/ensure_for_booking_spec.rb
@@ -76,4 +76,36 @@ RSpec.describe Stays::EnsureForBooking do
       expect(StayItem.where(bookable: booking).count).to eq(1)
     end
   end
+
+  # État latent (improbable mais possible) : un StayItem VIVANT pointant vers un
+  # Stay soft-deleted. `booking.stay` (double scope vivant) vaut alors nil, donc
+  # EnsureForBooking est rappelé. Sans le repoint, il créerait un 2e StayItem vivant
+  # (unicité scoped sur stay_id ⇒ autorisé) et divergerait du compteur du backfill.
+  describe "état latent : StayItem vivant → Stay soft-deleted" do
+    def build_latent_state
+      booking = build_booking(email: "latent@example.com")
+      dead_stay = described_class.call(booking)
+      dead_stay.soft_delete!(validate: false)
+      # Le soft-delete du Stay cascade sur son StayItem : on le ressuscite pour
+      # reconstruire l'état exact « StayItem vivant → Stay mort ».
+      StayItem.with_deleted do
+        StayItem.unscoped
+          .find_by(bookable_id: booking.id, bookable_type: "Booking")
+          .update_column(:deleted_at, nil)
+      end
+      [booking.reload, dead_stay]
+    end
+
+    it "repointe le StayItem orphelin au lieu d'en créer un second" do
+      booking, dead_stay = build_latent_state
+      expect(booking.stay).to be_nil
+      expect(StayItem.where(bookable: booking).count).to eq(1)
+
+      new_stay = described_class.call(booking)
+
+      expect(StayItem.where(bookable: booking).count).to eq(1)
+      expect(new_stay.id).not_to eq(dead_stay.id)
+      expect(booking.reload.stay).to eq(new_stay)
+    end
+  end
 end

--- a/spec/tasks/stays_backfill_missing_spec.rb
+++ b/spec/tasks/stays_backfill_missing_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "stays:backfill_missing", type: :task do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("stays:backfill_missing")
+  end
+
+  def run_task
+    task = Rake::Task["stays:backfill_missing"]
+    task.reenable
+    # La tâche imprime un rapport : on le silence pour garder la sortie de test propre.
+    original = $stdout
+    $stdout = StringIO.new
+    task.invoke
+  ensure
+    $stdout = original
+  end
+
+  def build_booking(**attrs)
+    Booking.create!({
+      firstname: "Backfill",
+      email: "backfill@example.com",
+      from_date: Date.new(2026, 10, 1),
+      to_date: Date.new(2026, 10, 3),
+      adults: 1,
+      status: "confirmed",
+      price_cents: 15_000
+    }.merge(attrs))
+  end
+
+  it "ne laisse aucun Booking sans Stay après exécution" do
+    b1 = build_booking(email: "a@example.com")
+    b2 = build_booking(email: "b@example.com", platform: "airbnb")
+
+    run_task
+
+    expect(b1.reload.stay).to be_present
+    expect(b2.reload.stay).to be_present
+    expect(b2.reload.stay.source).to eq("ota")
+  end
+
+  it "est idempotente : un second passage ne crée aucun Stay" do
+    build_booking(email: "c@example.com")
+    run_task
+    count_after_first = Stay.count
+
+    expect { run_task }.not_to change(Stay, :count)
+    expect(Stay.count).to eq(count_after_first)
+  end
+
+  it "ne recrée pas de Stay pour un Booking déjà rattaché" do
+    booking = build_booking(email: "d@example.com")
+    existing = Stays::EnsureForBooking.call(booking)
+
+    expect { run_task }.not_to change(Stay, :count)
+    expect(booking.reload.stay).to eq(existing)
+  end
+
+  it "couvre aussi les Bookings soft-deleted" do
+    booking = build_booking(email: "deleted@example.com")
+    booking.soft_delete!(validate: false) # deleted_at posé, la ligne subsiste
+
+    run_task
+
+    expect(Booking.with_deleted { Booking.unscoped.find(booking.id).stay }).to be_present
+  end
+end


### PR DESCRIPTION
Refs #26 — **Phase 3** de l'epic « Payment devient Stay-first ». Inclut le durcissement issu de la revue adversariale.

## Ce que fait cette PR
Tout Booking (admin/OTA **et** funnel public legacy) obtient automatiquement un Stay, avec Customer upserté par email. Les Payments admin portent un `stay_id`.

- `customers/upsert_by_email.rb` — upsert idempotent par email (citext/lowercase, esquive les Customer soft-deleted, fallback catch-all).
- `stays/ensure_for_booking.rb` — garantit un Stay ; repointe un StayItem orphelin plutôt que d'en créer un second.
- `bookings/create_service.rb`, `bookings/update_service.rb`, `public/bookings/create_service.rb` — tous branchés sur `EnsureForBooking` (transaction atomique).
- `payments/create_service.rb` — rattache `stay_id`.
- `lib/tasks/stays.rake` — backfill one-shot idempotent, compteur sur Stay vivant.
- `payments_attributes` retiré des params admin permis (fermait un trou : Payment nested sans stay_id).

## Critères d'acceptation (phase 3)
- [x] Booking admin/OTA → Stay auto + Customer upserté par email
- [x] Rake backfill idempotente, 0 Booking sans Stay après run
- [x] Payment admin porte un `stay_id`

## Revue adversariale
Verdict **concerns → résolu** : les 4 trous de durabilité identifiés (public bookings sans Stay, `payments_attributes` ouvert, UpdateService sans ensure, edge StayItem orphelin) sont tous fermés par le durcissement.

## Tests
Suite complète verte : **377 exemples, 0 failure, 18 pending** (pending pré-existants).

## À faire après merge
- Exécuter `rake stays:backfill_missing` en prod (one-shot).

🤖 Forge (GPT-5.4) + revue Claude, via workflow multi-agents ; PRs vérifiées par Bee. **Ne pas merger sans revue Michael.**