### PR TITLE
Réparer l'auditabilité PaperTrail de Payment (PK UUID vs versions.item_id bigint)

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -31,7 +31,9 @@ class Payment < ApplicationRecord
 
   monetize :amount_cents, allow_nil: false
 
-  has_paper_trail
+  # Table de versions dédiée : la PK de Payment est un UUID, incompatible avec
+  # `versions.item_id bigint` (issue #52). Voir `PaymentVersion`.
+  has_paper_trail versions: { class_name: "PaymentVersion" }
   has_soft_deletion default_scope: true
 
   validates :amount, numericality: { greater_than: 0.0 }

--- a/app/models/payment_version.rb
+++ b/app/models/payment_version.rb
@@ -1,0 +1,8 @@
+# Version PaperTrail dédiée aux Payment (issue #52).
+#
+# Stockée dans `payment_versions` (item_id UUID) plutôt que dans la table
+# `versions` partagée (item_id bigint), car la PK de Payment est un UUID.
+# Voir `Payment#has_paper_trail versions: { class_name: "PaymentVersion" }`.
+class PaymentVersion < PaperTrail::Version
+  self.table_name = :payment_versions
+end

--- a/db/migrate/20260716011705_create_payment_versions.rb
+++ b/db/migrate/20260716011705_create_payment_versions.rb
@@ -1,0 +1,24 @@
+# Table de versions PaperTrail dédiée aux Payment (issue #52).
+#
+# `payments` est le seul modèle à clé primaire UUID du schéma. La table
+# partagée `versions` a `item_id bigint` : un UUID n'y rentre pas, donc aucune
+# version n'était enregistrée pour les Payment (trou d'auditabilité, principe
+# P2 de l'ISA). On isole Payment dans sa propre table `payment_versions` dont
+# `item_id` est un `uuid`, sans toucher à la table `versions` partagée (qui
+# continue de servir tous les autres modèles, en bigint).
+class CreatePaymentVersions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :payment_versions do |t|
+      t.string   :item_type,     null: false
+      t.uuid     :item_id,       null: false
+      t.string   :event,         null: false
+      t.string   :whodunnit
+      t.text     :object
+      t.datetime :created_at
+      t.text     :object_changes
+    end
+
+    add_index :payment_versions, %i[item_type item_id],
+              name: "index_payment_versions_on_item_type_and_item_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_14_013705) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_16_011705) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -410,6 +410,17 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_14_013705) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at", precision: nil
     t.string "color"
+  end
+
+  create_table "payment_versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.uuid "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at"
+    t.text "object_changes"
+    t.index ["item_type", "item_id"], name: "index_payment_versions_on_item_type_and_item_id"
   end
 
   create_table "payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/payment_booking_id_nullable_spec.rb
+++ b/spec/models/payment_booking_id_nullable_spec.rb
@@ -49,14 +49,10 @@ RSpec.describe "Payment — booking_id nullable (epic #26, Phase 4)", type: :mod
         .not_to change { Payment.with_deleted { Payment.unscoped.count } }
     end
 
-    # NOTE (dette technique réelle, HORS périmètre Phase 4) : PaperTrail ne versionne
-    # PAS correctement Payment. La table `versions` a `item_id` en bigint alors que
-    # `Payment` a une clé primaire UUID : chaque version de Payment est écrite avec
-    # `item_id = 0` (cast UUID→bigint) et `payment.versions` ne retrouve donc rien.
-    # L'assertion PaperTrail d'origine était structurellement invérifiable et flaky
-    # (collision sur item_id = 0) : on ne la rejoue pas ici, la voir « verte » aurait
-    # menti. Correctif propre (à planifier hors de cette PR) : migrer `versions.item_id`
-    # en string (impacte TOUS les modèles audités) ou retirer `has_paper_trail` de
-    # Payment si l'audit n'est pas requis.
+    # NOTE (résolu depuis, issue #52) : le trou d'auditabilité PaperTrail décrit ici
+    # (table `versions` en `item_id bigint` incompatible avec la PK UUID de Payment)
+    # est refermé. Payment est désormais versionné dans une table dédiée
+    # `payment_versions` (`item_id uuid`) via `PaymentVersion`. La preuve
+    # d'auditabilité vit dans `spec/models/payment_paper_trail_spec.rb`.
   end
 end

--- a/spec/models/payment_paper_trail_spec.rb
+++ b/spec/models/payment_paper_trail_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+# Issue #52 — `Payment` a une clé primaire UUID, incompatible avec la table
+# `versions` partagée (`item_id bigint`) : aucune version n'était enregistrée
+# (trou d'auditabilité, principe P2 de l'ISA). On isole Payment dans une table
+# dédiée `payment_versions` (`item_id uuid`) via `PaymentVersion`.
+#
+# Ce spec prouve les DEUX moitiés du correctif :
+#   1. Payment est de nouveau audité (create + update + soft-delete) ;
+#   2. les versions des AUTRES modèles (table `versions` partagée) restent
+#      intactes et requêtables.
+RSpec.describe "Payment — auditabilité PaperTrail (issue #52)", type: :model do
+  let(:customer) { Customer.create!(email: "audit@example.com", customer_type: "individual") }
+  let(:stay) do
+    Stay.create!(customer: customer, source: "reservation", status: "pending",
+                 total_amount_cents: 10_000)
+  end
+
+  describe "Payment est de nouveau audité (via PaymentVersion)" do
+    it "enregistre une version à la création puis à la modification" do
+      payment = Payment.create!(stay: stay, amount_cents: 5_000, status: "pending",
+                                payment_method: "card")
+
+      expect(payment.versions.count).to eq(1)
+      expect(payment.versions.last.event).to eq("create")
+
+      payment.update!(status: "paid")
+
+      expect(payment.versions.count).to eq(2)
+      expect(payment.versions.last.event).to eq("update")
+    end
+
+    it "relie la version au Payment par son UUID, dans la table dédiée" do
+      payment = Payment.create!(stay: stay, amount_cents: 5_000, status: "pending",
+                                payment_method: "card")
+
+      version = payment.versions.last
+      expect(version).to be_a(PaymentVersion)
+      expect(version.item_id).to eq(payment.id) # l'UUID réel, plus le 0 du cast raté
+      expect(version.class.table_name).to eq("payment_versions")
+    end
+
+    it "trace aussi le soft-delete (update de deleted_at)" do
+      payment = Payment.create!(stay: stay, amount_cents: 5_000, status: "pending",
+                                payment_method: "card")
+
+      expect { payment.soft_delete! }.to change { payment.versions.count }.by(1)
+    end
+  end
+
+  describe "les versions des autres modèles sont préservées" do
+    it "n'écrit aucune version Payment dans la table `versions` partagée" do
+      before_count = PaperTrail::Version.where(item_type: "Payment").count
+
+      Payment.create!(stay: stay, amount_cents: 5_000, status: "pending",
+                      payment_method: "card")
+
+      expect(PaperTrail::Version.where(item_type: "Payment").count).to eq(before_count)
+    end
+
+    it "continue de versionner les autres modèles dans `versions` (Booking)" do
+      booking = Booking.create!(firstname: "Audit", from_date: Date.today,
+                                to_date: Date.today + 2, adults: 1, status: "pending",
+                                price_cents: 10_000)
+
+      expect(booking.versions.count).to be >= 1
+      expect(booking.versions.last).to be_a(PaperTrail::Version)
+      expect(booking.versions.last.class.table_name).to eq("versions")
+
+      expect { booking.update!(status: "confirmed") }
+        .to change { booking.versions.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
Closes #52

## Résumé

`Payment` déclarait `has_paper_trail`, mais sa clé primaire est un **UUID** alors que la table `versions` partagée a `item_id bigint`. Résultat : le cast UUID→bigint écrivait `item_id = 0` et `payment.versions` ne retrouvait rien — **aucun Payment n'était réellement audité** (viole le principe P2 de l'ISA « Rien ne se perd, tout se trace »).

## Correctif (approche 1, recommandée par l'issue)

Table de versions **dédiée** à Payment, sans toucher à la table partagée :

- Migration `CreatePaymentVersions` → table `payment_versions` avec `item_id` en **`uuid`** (miroir de `versions`).
- Modèle `PaymentVersion < PaperTrail::Version` (`table_name = :payment_versions`).
- `Payment` : `has_paper_trail versions: { class_name: "PaymentVersion" }`.

La table `versions` partagée reste **inchangée** — tous les autres modèles (Booking, Human, Decision…) continuent en `bigint`, aucune migration lourde, aucun risque sur l'historique existant.

## Tests

Nouveau `spec/models/payment_paper_trail_spec.rb` couvrant les deux moitiés du critère :
- Payment audité : version à la création (`create`), à la modification (`update`), au soft-delete ; `item_id` = l'UUID réel du Payment ; stockage dans `payment_versions`.
- Préservation : aucune version Payment n'atterrit dans `versions` ; `Booking` reste versionné normalement dans `versions` (create + update).

Mise à jour de la note désormais obsolète dans `payment_booking_id_nullable_spec.rb` (elle décrivait le bug comme non corrigé).

**`bundle exec rspec` : 393 examples, 0 failures, 18 pending** (les pending sont les stubs « Not yet implemented » pré-existants). Les specs de `Payments::CreateService` et du webhook Stripe restent verts — aucun changement fonctionnel sur le flux de paiement.

## Points à valider / non testé
- Pas de backfill rétroactif de l'historique Payment déjà modifié (impossible — hors scope, explicité dans l'issue).
- Migration testée en local (dev + test) ; à appliquer en prod via le déploiement habituel Hatchbox (`rails db:migrate`).
- Note ISA (P2) : le trou d'auditabilité Payment est refermé — à reporter dans l'ISA côté humain si elle est tenue hors repo.

## 📸 Aperçu
Aucun rendu visible — changement purement modèle/DB (migration + modèle + specs). Pas de capture d'écran applicable.