### PR TITLE
feat(activités): Phase 1 — fondations composite (prix activités dans le total, acompte/solde, service pricing)

### DIFF
--- a/app/models/experience_booking.rb
+++ b/app/models/experience_booking.rb
@@ -30,6 +30,13 @@ class ExperienceBooking < ApplicationRecord
   def confirmed? = status == "confirmed"
   def cancelled? = status == "cancelled"
 
+  # Montant TVAC de l'activité réservée (epic #55, Phase 1). Délègue au service
+  # `Pricing::ExperienceLine`, source de vérité unique du barème « forfait fixe
+  # + €/pers ». `experience` est délégué depuis `experience_availability`.
+  def price_cents
+    Pricing::ExperienceLine.amount_cents(experience, participants: participants)
+  end
+
   private
 
   def set_default_status

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -66,6 +66,28 @@ class Stay < ApplicationRecord
     Payment.where(stay_id: id).or(Payment.where(booking_id: booking_ids))
   end
 
+  # --- Montant dû / soldé (epic #55, Phase 1) -----------------------------
+  # « Soldé » n'est PAS un 4e statut : c'est simplement le statut `paid`
+  # existant (epic #26), exprimé ici en euros via des helpers réutilisables.
+
+  # Total effectivement encaissé (paiements au statut `paid`).
+  def amount_paid_cents
+    payments.paid.sum(:amount_cents)
+  end
+
+  # Reste dû = total du séjour − encaissé. Peut être négatif en cas de
+  # trop-perçu (remboursement à traiter à la main) ; `settled?` le tolère.
+  def amount_due_cents
+    total_amount_cents.to_i - amount_paid_cents
+  end
+
+  # Séjour soldé : au moins un paiement encaissé ET plus rien à devoir. La
+  # condition `amount_paid_cents.positive?` préserve le garde-fou « 0 € sans
+  # paiement ne bascule pas en soldé par l'effet de bord d'un 0 >= 0 ».
+  def settled?
+    amount_paid_cents.positive? && amount_due_cents <= 0
+  end
+
   # Recompute aggregate dates / amount from the attached items (min arrival,
   # max departure, sum of prices). Booking and SpaceBooking both expose
   # from_date/to_date/price_cents.
@@ -74,11 +96,9 @@ class Stay < ApplicationRecord
   # dont le total est à 0 € et sans paiement reste « pending » (et ne bascule
   # pas en « paid » par l'effet de bord d'un `0 >= 0`).
   def set_payment_status
-    paid_cents = payments.paid.sum(:amount_cents)
-
-    status = if paid_cents.positive? && paid_cents >= total_amount_cents.to_i
+    status = if settled?
       "paid"
-    elsif paid_cents.positive?
+    elsif amount_paid_cents.positive?
       "partially_paid"
     else
       "pending"
@@ -118,7 +138,12 @@ class Stay < ApplicationRecord
     items = bookables
     arrivals = items.map { |b| b.try(:from_date) }.compact
     departures = items.map { |b| b.try(:to_date) }.compact
-    amount = items.sum { |b| b.try(:price_cents).to_i }
+    # Le montant agrège désormais les activités réservées (epic #55, Phase 1) :
+    # bookables (hébergement/espaces) + activités ACTIVES (hors annulées). Les
+    # DATES restent dérivées des SEULS bookables — une activité ne déborde
+    # jamais les bornes du calendrier du séjour.
+    amount = items.sum { |b| b.try(:price_cents).to_i } +
+             experience_bookings.active.sum(&:price_cents)
     update!(
       arrival_date: arrivals.min,
       departure_date: departures.max,

--- a/app/services/pricing/experience_line.rb
+++ b/app/services/pricing/experience_line.rb
@@ -1,0 +1,49 @@
+module Pricing
+  # Source de vérité UNIQUE du tarif d'une activité (Experience) — epic #55,
+  # Phase 1. Centralise la formule « forfait fixe + €/pers » et le rendu du
+  # barème, jusqu'ici dupliqués entre `PricingModel#experience_lines`
+  # (calcul) et la vue `activities.html.slim` (libellé). Tout consommateur
+  # (moteur de devis, `ExperienceBooking#price_cents`, vue) passe désormais
+  # par ici : un seul endroit à corriger si le barème évolue.
+  #
+  # Tous les montants sont en cents et TVAC ("pas de TVA en plus").
+  module ExperienceLine
+    module_function
+
+    # Montant TVAC d'une réservation d'activité : forfait fixe (facturé une
+    # fois) + prix par personne × nombre de participants.
+    def amount_cents(experience, participants:)
+      experience.fixed_price_cents.to_i + experience.price_cents.to_i * participants.to_i
+    end
+
+    # Libellé du barème affiché dans le funnel, reproduisant à l'identique les
+    # 4 variantes historiques de la vue :
+    #   - forfait fixe + €/pers  → "40 € + 15 €/pers"
+    #   - €/pers seul            → "15 €/pers"
+    #   - forfait fixe seul      → "40 €"
+    #   - ni l'un ni l'autre     → "Gratuit"
+    def rate_label(experience)
+      fixed = experience.fixed_price_cents.to_i
+      per   = experience.price_cents.to_i
+
+      if fixed.positive? && per.positive?
+        "#{format_eur(fixed)} + #{format_eur(per)}/pers"
+      elsif per.positive?
+        "#{format_eur(per)}/pers"
+      elsif fixed.positive?
+        format_eur(fixed)
+      else
+        "Gratuit"
+      end
+    end
+
+    # Rendu monétaire aligné sur la vue : "290 €" (unité suffixée, sans
+    # décimale). Passe par ActiveSupport pour rester utilisable hors contexte
+    # de vue (service, modèle).
+    def format_eur(cents)
+      ActiveSupport::NumberHelper.number_to_currency(
+        cents / 100.0, unit: "€", format: "%n %u", precision: 0
+      )
+    end
+  end
+end

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -19,13 +19,26 @@
 # Toute méthode absente est traitée comme vide / zéro — le draft minimal n'a
 # besoin que de #lodging + #nights.
 class PricingModel
-  Line = Struct.new(:label, :amount_cents, keyword_init: true) do
+  # `category` (epic #55, Phase 1) tague la nature de la ligne (ex : `:experience`)
+  # pour permettre au devis d'isoler les activités du reste. `to_h` reste
+  # INCHANGÉ ({label:, amount_cents:}) — l'UI et l'email le consomment tel quel.
+  Line = Struct.new(:label, :amount_cents, :category, keyword_init: true) do
     def to_h
       { label: label, amount_cents: amount_cents }
     end
   end
 
-  Quote = Struct.new(:lines, :total_cents, :deposit_cents, :deposit_rate, keyword_init: true) do
+  # `experiences_cents` (epic #55, Phase 1) : part des activités dans le total.
+  # `total_cents` reste le total COMPLET (activités comprises) pour l'affichage
+  # funnel ; `total_excluding_experiences_cents` en retire les activités —
+  # c'est cette base qui pilote l'acompte et le montant persisté du Stay tant
+  # que les activités ne sont pas encore réservées (phases suivantes).
+  Quote = Struct.new(:lines, :total_cents, :deposit_cents, :deposit_rate,
+                     :experiences_cents, keyword_init: true) do
+    def total_excluding_experiences_cents
+      total_cents.to_i - experiences_cents.to_i
+    end
+
     def breakdown
       lines.map(&:to_h)
     end
@@ -62,9 +75,14 @@ class PricingModel
     lines.concat(dog_lines)
 
     total = lines.sum(&:amount_cents)
-    deposit = (total * @deposit_rate).round
+    # Les activités sont exclues de l'assiette de l'acompte (epic #55, Phase 1) :
+    # on ne demande pas d'acompte sur des activités pas encore confirmées par
+    # l'équipe. L'acompte porte donc sur le total HORS activités.
+    experiences = lines.select { |line| line.category == :experience }.sum(&:amount_cents)
+    deposit = ((total - experiences) * @deposit_rate).round
 
     Quote.new(lines: lines, total_cents: total,
+              experiences_cents: experiences,
               deposit_cents: deposit, deposit_rate: @deposit_rate)
   end
 
@@ -219,16 +237,19 @@ class PricingModel
   end
 
   # --- Expériences (Experience) : forfait fixe + €/pers ---
+  # Le calcul vit dans `Pricing::ExperienceLine` (source de vérité unique,
+  # epic #55). Les lignes sont taguées `category: :experience` pour que le
+  # devis puisse les isoler de l'assiette de l'acompte.
   def experience_lines
     Array(read(:experiences)).filter_map do |entry|
       exp = Experience.find_by(id: entry[:id])
       next if exp.nil?
       participants = entry[:participants].to_i
       next if participants < 1
-      amount = exp.fixed_price_cents.to_i + exp.price_cents.to_i * participants
+      amount = Pricing::ExperienceLine.amount_cents(exp, participants: participants)
       next if amount < 1
       label_parts = [exp.name, "#{participants} pers"]
-      Line.new(label: label_parts.join(" — "), amount_cents: amount)
+      Line.new(label: label_parts.join(" — "), amount_cents: amount, category: :experience)
     end
   end
 

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -47,13 +47,18 @@ module Reservations
         # via lodging_id + dates. Un séjour sans hébergement (camping, espaces)
         # n'en crée donc plus : le « Booking fantôme » disparaît.
         @booking = draft.lodging.present? ? build_booking!(quote) : nil
+        # Fix « montant fantôme » de l'acompte (epic #55, Phase 1) : le total
+        # persisté et l'acompte EXCLUENT les activités. Tant qu'aucun
+        # ExperienceBooking n'est créé (phases suivantes), les activités
+        # n'entrent NI dans l'acompte NI dans le total du Stay ; elles y
+        # entreront via `Stay#recompute_aggregates!` une fois réservées.
         @stay = Stay.create!(
           customer: @customer,
           source: "reservation",
           status: "pending",
           arrival_date: draft.arrival_date,
           departure_date: draft.departure_date,
-          total_amount_cents: quote.total_cents,
+          total_amount_cents: quote.total_excluding_experiences_cents,
           notes: internal_notes
         )
         @stay.stay_items.create!(bookable: @booking) if @booking
@@ -131,8 +136,11 @@ module Reservations
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
-        price_cents: quote.total_cents,
-        shown_price_cents: quote.total_cents
+        # Occupation d'hébergement : son prix suit le total HORS activités
+        # (fix montant fantôme, epic #55 Phase 1) — cohérent avec le
+        # `total_amount_cents` du Stay et l'assiette de l'acompte.
+        price_cents: quote.total_excluding_experiences_cents,
+        shown_price_cents: quote.total_excluding_experiences_cents
       )
       booking.generate_token
       booking.save!

--- a/app/views/public/reservations/activities.html.slim
+++ b/app/views/public/reservations/activities.html.slim
@@ -36,14 +36,7 @@
                 - if exp.summary.present?
                   .text-sm.text-gray-500 = exp.summary
                 .text-sm.text-emerald-700.mt-1
-                  - if exp.fixed_price_cents.to_i > 0 && exp.price_cents.to_i > 0
-                    = "#{number_to_currency(exp.fixed_price_cents / 100.0, unit: '€', format: '%n %u', precision: 0)} + #{number_to_currency(exp.price_cents / 100.0, unit: '€', format: '%n %u', precision: 0)}/pers"
-                  - elsif exp.price_cents.to_i > 0
-                    = "#{number_to_currency(exp.price_cents / 100.0, unit: '€', format: '%n %u', precision: 0)}/pers"
-                  - elsif exp.fixed_price_cents.to_i > 0
-                    = number_to_currency(exp.fixed_price_cents / 100.0, unit: '€', format: '%n %u', precision: 0)
-                  - else
-                    | Gratuit
+                  = Pricing::ExperienceLine.rate_label(exp)
                 - if exp.min_participants.present? || exp.max_participants.present?
                   .text-xs.text-gray-400
                     - if exp.min_participants.present? && exp.max_participants.present?

--- a/spec/models/stay_spec.rb
+++ b/spec/models/stay_spec.rb
@@ -179,4 +179,80 @@ RSpec.describe Stay, type: :model do
       expect(Stay.from_source(nil)).to include(reservation, tally)
     end
   end
+
+  describe "#recompute_aggregates! avec activités (epic #55, Phase 1)" do
+    let(:stay) { Stay.create!(customer: customer) }
+    let(:experience) { Experience.create!(name: "Atelier pain", fixed_price_cents: 5_000, price_cents: 1_500) }
+    let(:availability) do
+      # Date volontairement HORS de la fenêtre de l'hébergement pour prouver que
+      # les activités ne déplacent pas les bornes du séjour.
+      ExperienceAvailability.create!(experience: experience, available_on: Date.new(2026, 7, 10), starts_at: "10:00")
+    end
+
+    before do
+      stay.stay_items.create!(bookable: booking(from: Date.new(2026, 7, 1), to: Date.new(2026, 7, 3), price_cents: 20_000))
+    end
+
+    it "ajoute les activités ACTIVES au total, sans toucher aux dates" do
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 3)
+
+      stay.recompute_aggregates!
+
+      # 20 000 (hébergement) + 5 000 (forfait fixe) + 1 500 × 3 (participants) = 29 500
+      expect(stay.total_amount_cents).to eq(29_500)
+      # Dates dérivées des SEULS bookables — l'activité du 10/07 ne les bouge pas.
+      expect(stay.arrival_date).to eq(Date.new(2026, 7, 1))
+      expect(stay.departure_date).to eq(Date.new(2026, 7, 3))
+    end
+
+    it "exclut les activités annulées" do
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 3, status: "cancelled")
+
+      stay.recompute_aggregates!
+
+      expect(stay.total_amount_cents).to eq(20_000) # hébergement seul
+    end
+  end
+
+  describe "#amount_due_cents / #settled? (epic #55, Phase 1)" do
+    let(:stay) { Stay.create!(customer: customer, total_amount_cents: 20_000) }
+
+    def pay(cents, status)
+      b = booking(from: Date.new(2026, 7, 1), to: Date.new(2026, 7, 3), price_cents: 20_000)
+      stay.stay_items.create!(bookable: b)
+      Payment.create!(booking: b, stay: stay, amount_cents: cents, status: status, payment_method: "card")
+    end
+
+    it "montant dû = total tant que rien n'est encaissé" do
+      expect(stay.amount_paid_cents).to eq(0)
+      expect(stay.amount_due_cents).to eq(20_000)
+      expect(stay).not_to be_settled
+    end
+
+    it "réduit le dû du montant de l'acompte encaissé" do
+      pay(5_000, "paid")
+      expect(stay.amount_paid_cents).to eq(5_000)
+      expect(stay.amount_due_cents).to eq(15_000)
+      expect(stay).not_to be_settled
+    end
+
+    it "ignore les paiements non encaissés dans le calcul du dû" do
+      pay(20_000, "pending")
+      expect(stay.amount_paid_cents).to eq(0)
+      expect(stay.amount_due_cents).to eq(20_000)
+      expect(stay).not_to be_settled
+    end
+
+    it "est soldé quand l'encaissé couvre le total" do
+      pay(20_000, "paid")
+      expect(stay.amount_due_cents).to eq(0)
+      expect(stay).to be_settled
+    end
+
+    it "un séjour à 0 € sans paiement n'est PAS soldé (garde-fou 0 >= 0)" do
+      zero = Stay.create!(customer: customer, total_amount_cents: 0)
+      expect(zero.amount_due_cents).to eq(0)
+      expect(zero).not_to be_settled
+    end
+  end
 end

--- a/spec/services/pricing/experience_line_spec.rb
+++ b/spec/services/pricing/experience_line_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Pricing::ExperienceLine do
+  # Petite fabrique en ligne (pas de FactoryBot dans ce repo). `name` est
+  # requis + unique côté Experience ; on le rend distinct par cas.
+  def experience(fixed_cents: 0, per_cents: nil, name: "Atelier #{SecureRandom.hex(4)}")
+    Experience.create!(name: name, fixed_price_cents: fixed_cents, price_cents: per_cents)
+  end
+
+  describe ".amount_cents" do
+    it "additionne le forfait fixe et le prix par personne × participants" do
+      exp = experience(fixed_cents: 5_000, per_cents: 1_500)
+      expect(described_class.amount_cents(exp, participants: 3)).to eq(5_000 + 1_500 * 3) # 9 500
+    end
+
+    it "facture le seul forfait fixe quand il n'y a pas de prix par personne" do
+      exp = experience(fixed_cents: 4_000, per_cents: nil)
+      expect(described_class.amount_cents(exp, participants: 5)).to eq(4_000)
+    end
+
+    it "facture le seul prix par personne quand il n'y a pas de forfait fixe" do
+      exp = experience(fixed_cents: 0, per_cents: 1_500)
+      expect(described_class.amount_cents(exp, participants: 4)).to eq(6_000)
+    end
+
+    it "renvoie 0 pour une activité gratuite" do
+      exp = experience(fixed_cents: 0, per_cents: nil)
+      expect(described_class.amount_cents(exp, participants: 2)).to eq(0)
+    end
+  end
+
+  describe ".rate_label — les 4 variantes du barème" do
+    it "forfait fixe + prix par personne" do
+      exp = experience(fixed_cents: 4_000, per_cents: 1_500)
+      expect(described_class.rate_label(exp)).to eq("40 € + 15 €/pers")
+    end
+
+    it "prix par personne seul" do
+      exp = experience(fixed_cents: 0, per_cents: 1_500)
+      expect(described_class.rate_label(exp)).to eq("15 €/pers")
+    end
+
+    it "forfait fixe seul" do
+      exp = experience(fixed_cents: 4_000, per_cents: nil)
+      expect(described_class.rate_label(exp)).to eq("40 €")
+    end
+
+    it "gratuit quand ni forfait ni prix par personne" do
+      exp = experience(fixed_cents: 0, per_cents: nil)
+      expect(described_class.rate_label(exp)).to eq("Gratuit")
+    end
+  end
+end

--- a/spec/services/reservations/builder_spec.rb
+++ b/spec/services/reservations/builder_spec.rb
@@ -146,4 +146,36 @@ RSpec.describe Reservations::Builder do
       expect(Stay.count).to eq(0)
     end
   end
+
+  # ------------------------------------------------------------------------
+  # Epic #55, Phase 1 — Fondations composite : les activités n'entrent NI dans
+  # le total persisté du Stay NI dans l'acompte tant qu'aucun ExperienceBooking
+  # n'est créé (fix « montant fantôme »). Le devis funnel garde le total complet.
+  # ------------------------------------------------------------------------
+  describe "activités exclues du total persisté et de l'acompte (epic #55, Phase 1)" do
+    let!(:experience) { Experience.create!(name: "Atelier vannerie", fixed_price_cents: 5_000, price_cents: 1_500) }
+
+    def draft_with_activity
+      draft(experiences: [{ id: experience.id, participants: 2 }])
+    end
+
+    it "ne persiste aucun ExperienceBooking et exclut les activités du total + acompte" do
+      builder = described_class.new(draft: draft_with_activity)
+      expect(builder.run).to be(true)
+
+      # Phase 1 : le Builder ne crée pas encore les ExperienceBooking.
+      expect(builder.stay.experience_bookings).to be_empty
+      # Hulotte 2 nuits = 485 + 260 = 745 € ; les activités (8 000 c) n'y entrent pas.
+      expect(builder.stay.total_amount_cents).to eq(74_500)
+      # Acompte 50 % HORS activités = 372,50 €.
+      expect(builder.payment.amount_cents).to eq(37_250)
+    end
+
+    it "expose néanmoins le total complet (activités comprises) via le devis funnel" do
+      builder = described_class.new(draft: draft_with_activity)
+      # 745 € hébergement + (5 000 + 1 500×2) = 8 000 c d'activité = 82 500 c affichés.
+      expect(builder.quote.total_cents).to eq(82_500)
+      expect(builder.quote.total_excluding_experiences_cents).to eq(74_500)
+    end
+  end
 end


### PR DESCRIPTION
Phase 1 de l'epic #55 — **Activités intégrées au séjour-composite**.

## Ce que fait cette PR
- `Pricing::ExperienceLine` : **source unique** du barème activité (`amount_cents` + `rate_label`). `PricingModel`, `ExperienceBooking#price_cents` et la vue `activities.html.slim` y passent tous.
- `Stay#recompute_aggregates!` agrège désormais les `experience_bookings.active` dans `total_amount_cents` (**dates inchangées** — calendrier non touché).
- `Stay` expose `amount_paid_cents` / `amount_due_cents` / `settled?` ; `set_payment_status` réécrit via ces helpers, garde-fou « 0 € sans paiement → pending » préservé. Pas de 4e statut (« soldé » = `paid` existant, epic #26).
- **Fix montant fantôme** : l'acompte et le total persisté par `Reservations::Builder` excluent les activités (`total_excluding_experiences_cents`). Les activités entreront dans le total via `recompute_aggregates!` une fois réservées (phases suivantes).

## Vérification
- `bundle exec rspec` : **424 exemples, 0 failure**, 18 pending (placeholders préexistants). Nouveaux specs : `pricing/experience_line`, `stay` (total inclut activités actives, exclut cancelled, dates inchangées, montant dû/soldé), `reservations/builder` (acompte hors activités).
- ⚠️ **Vérif navigateur reportée** : la seule modif UI (libellé de barème dans `activities.html.slim`) n'est atteignable que par token email et sera vérifiée visuellement en **Phase 4**, quand l'écran de sélection d'activités sera branché dans le funnel. La logique de prix/statuts est couverte par les specs.

## Notes
- Implémentée par Engineer (Forge indisponible jusqu'au 19/07 : quota Codex épuisé + gpt-5.4 refusé). Blueprint en commentaire de #55.
- Déploiement Hatchbox manuel : merger ≠ déployer.

Refs #55