### PR TITLE
feat(activités): Phase 2 — validation porteur (double canal admin + email, statut refused)

### DIFF
--- a/app/controllers/experience_booking_validations_controller.rb
+++ b/app/controllers/experience_booking_validations_controller.rb
@@ -1,0 +1,53 @@
+# Canal JETON de validation des activités (epic #55, Phase 2).
+#
+# Le lien envoyé au porteur dans l'email `animateur_notification` porte un
+# `signed_id` Rails à portée d'UN seul `ExperienceBooking` (purpose +
+# expiration) — impossible à forger ou à rejouer ailleurs.
+#
+# Choix de sécurité :
+#   * VALIDER  = action bénigne mais mutante. On ne mute JAMAIS sur un GET
+#     (préchargeable par un antivirus / proxy mail). Le lien mène à une page de
+#     confirmation légère (`show`) dont le bouton POSTe vers `confirm` (protégé
+#     par CSRF). C'est le « 1 clic » côté porteur, sans mutation sur GET.
+#   * REFUSER = exige une raison, donc un compte. Le lien (`refuse`) force la
+#     connexion Devise puis renvoie vers le formulaire de refus du canal admin.
+#     Jamais de refus anonyme en 1 clic.
+class ExperienceBookingValidationsController < ActionController::Base
+  layout "public"
+
+  before_action :authenticate_user!, only: [:refuse]
+
+  # Page de confirmation de validation (GET, anonyme). Ne mute rien.
+  def show
+    @booking = ExperienceBooking.find_by_validation_token(params[:token])
+    return render :invalid, status: :not_found if @booking.nil?
+  end
+
+  # Applique la validation (POST, anonyme mais protégé CSRF via le formulaire
+  # de la page `show`). Idempotent : ne re-confirme pas une réservation déjà
+  # traitée.
+  def confirm
+    @booking = ExperienceBooking.find_by_validation_token(params[:token])
+    return render :invalid, status: :not_found if @booking.nil?
+
+    if @booking.pending?
+      @booking.confirm!
+      ActivitySelectionMailer.booking_confirmed(@booking).deliver_later
+    end
+    render :confirmed
+  end
+
+  # Amorce le refus depuis l'email : impose la connexion (Devise mémorise le
+  # lien et y revient après login), vérifie que le porteur connecté est bien
+  # propriétaire de l'activité, puis renvoie vers le formulaire de refus admin.
+  def refuse
+    booking = ExperienceBooking.find_by_validation_token(params[:token])
+    return render :invalid, status: :not_found if booking.nil?
+
+    unless ExperienceBooking.for_user(current_user).exists?(booking.id)
+      return render :forbidden, status: :forbidden
+    end
+
+    redirect_to new_refusal_experience_booking_path(booking)
+  end
+end

--- a/app/controllers/experience_bookings_controller.rb
+++ b/app/controllers/experience_bookings_controller.rb
@@ -1,18 +1,73 @@
-class ExperienceBookingsController < ApplicationController
-  before_action :authenticate_user!
+# Canal ADMIN de validation des activités (epic #55, Phase 2).
+#
+# Scoping d'autorisation : un porteur ne voit et n'agit que sur les
+# `ExperienceBooking` de ses propres `Experience` ; un admin global voit tout.
+# Toute la règle est centralisée dans `ExperienceBooking.for_user` — on charge
+# TOUJOURS via cette portée, si bien qu'un porteur qui cible l'ID d'une
+# réservation d'un autre porteur obtient un 404 (jamais une action réussie).
+class ExperienceBookingsController < BaseController
+  before_action :load_scoped_booking, only: [:update, :confirm, :new_refusal, :refuse]
 
   def index
-    @experience_bookings = ExperienceBooking.includes(experience_availability: :experience, stay: :customer)
+    @experience_bookings = ExperienceBooking.for_user(current_user)
+                                            .includes(experience_availability: :experience, stay: :customer)
                                             .order(created_at: :desc)
                                             .limit(100)
   end
 
+  # Toggle historique (Phase 1) conservé, mais scoppé. Le modèle interdit de
+  # passer en `refused` sans raison — ce chemin ne sert donc qu'à confirmer /
+  # annuler, jamais à refuser à la légère.
   def update
-    @booking = ExperienceBooking.find(params[:id])
     if @booking.update(status: params[:status])
       head :ok
     else
       head :unprocessable_entity
     end
+  end
+
+  # Validation (pending → confirmed) + notification au client.
+  def confirm
+    @booking.confirm!
+    ActivitySelectionMailer.booking_confirmed(@booking).deliver_later
+    redirect_to experience_bookings_path,
+                notice: "Activité « #{@booking.experience.name} » confirmée. Le client est prévenu."
+  end
+
+  # Formulaire de refus (raison obligatoire).
+  def new_refusal
+  end
+
+  # Application du refus (pending → refused) + notification au client avec la
+  # raison et une invitation à re-choisir un créneau.
+  def refuse
+    @booking.refuse!(params.dig(:experience_booking, :refusal_reason).to_s)
+    ActivitySelectionMailer.booking_refused(@booking).deliver_later
+    redirect_to experience_bookings_path,
+                notice: "Activité « #{@booking.experience.name} » refusée. Le client est prévenu."
+  rescue ActiveRecord::RecordInvalid
+    flash.now[:alert] = "Merci d'indiquer une raison pour le refus."
+    render :new_refusal, status: :unprocessable_entity
+  end
+
+  private
+
+  def load_scoped_booking
+    @booking = ExperienceBooking.for_user(current_user).find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    # Réservation inexistante OU hors du périmètre du porteur : même réponse,
+    # on ne divulgue pas l'existence de la réservation d'un autre porteur.
+    respond_to do |format|
+      format.html { redirect_to experience_bookings_path, alert: "Réservation introuvable." }
+      format.any  { head :not_found }
+    end
+  end
+
+  def set_presenters
+    @menu_presenter = Components::MenuPresenter.new(
+      active_primary: "settings",
+      active_secondary: "experiences"
+    )
+    @settings_view = true
   end
 end

--- a/app/mailers/activity_selection_mailer.rb
+++ b/app/mailers/activity_selection_mailer.rb
@@ -25,10 +25,40 @@ class ActivitySelectionMailer < ApplicationMailer
     )
   end
 
+  # Notification au client quand le porteur VALIDE son activité (epic #55, Phase 2).
+  def booking_confirmed(experience_booking)
+    @booking = experience_booking
+    @stay = experience_booking.stay
+    @experience = experience_booking.experience
+    mail(
+      to: @stay.customer.email,
+      subject: "Votre activité « #{@experience.name} » est confirmée"
+    )
+  end
+
+  # Notification au client quand le porteur REFUSE son activité (epic #55,
+  # Phase 2) : on transmet la raison et on invite à re-choisir un créneau via
+  # la page de sélection à jeton existante.
+  def booking_refused(experience_booking)
+    @booking = experience_booking
+    @stay = experience_booking.stay
+    @experience = experience_booking.experience
+    @reason = experience_booking.refusal_reason
+    @selection_url = public_activity_selection_url(@stay.activity_selection_token,
+                                                   host: ENV.fetch("APPLICATION_HOST", "app.les4sources.be"))
+    mail(
+      to: @stay.customer.email,
+      subject: "Votre activité « #{@experience.name} » n'a pas pu être retenue"
+    )
+  end
+
   # Email aux animateurs concernés (un par activité demandée).
   def animateur_notification(stay)
     @stay = stay
     @bookings = stay.experience_bookings.includes(experience_availability: :experience).active
+    # Hôte des liens de validation/refus à jeton (epic #55, Phase 2) — même
+    # source que les autres liens de ce mailer, pour rester stable en test.
+    @link_host = ENV.fetch("APPLICATION_HOST", "app.les4sources.be")
     return if @bookings.empty?
 
     animateur_emails = @bookings.filter_map { |b| b.experience.human&.email }.uniq.compact

--- a/app/models/experience_booking.rb
+++ b/app/models/experience_booking.rb
@@ -8,11 +8,19 @@
 #  participants                :integer
 #  status                      :string           default("pending")
 #  notes                       :text
+#  refusal_reason              :text
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #
 class ExperienceBooking < ApplicationRecord
-  STATUSES = %w[pending confirmed cancelled].freeze
+  # `refused` (epic #55, Phase 2) : le porteur de l'activité a décliné le
+  # créneau demandé. Un refus porte TOUJOURS une raison (cf. validation).
+  STATUSES = %w[pending confirmed refused cancelled].freeze
+
+  # Portée du jeton signé embarqué dans l'email au porteur : il ne vaut QUE
+  # pour la validation d'UN `ExperienceBooking` précis (cf. `#validation_token`).
+  TOKEN_PURPOSE = :validate_experience_booking
+  TOKEN_TTL = 30.days
 
   belongs_to :experience_availability
   belongs_to :stay
@@ -21,14 +29,65 @@ class ExperienceBooking < ApplicationRecord
 
   validates :participants, numericality: { greater_than: 0 }
   validates :status, inclusion: { in: STATUSES }
+  # Un refus n'existe jamais sans motif — c'est l'information que le client
+  # reçoit et qui justifie l'invitation à re-choisir un créneau.
+  validates :refusal_reason, presence: true, if: :refused?
 
   before_validation :set_default_status
 
-  scope :active, -> { where.not(status: "cancelled") }
+  # Une activité `refused` est morte au même titre qu'une `cancelled` : elle ne
+  # compte ni dans le montant du séjour (Phase 1) ni dans les listings actifs.
+  scope :active, -> { where.not(status: %w[cancelled refused]) }
+  scope :pending,   -> { where(status: "pending") }
+  scope :confirmed, -> { where(status: "confirmed") }
+  scope :refused,   -> { where(status: "refused") }
+
+  # Réservations rattachées aux activités d'un porteur donné (via
+  # `experience.human`). Base du scoping d'autorisation du canal admin.
+  scope :for_carrier, ->(human) {
+    joins(experience_availability: :experience)
+      .where(experiences: { human_id: human.id })
+  }
 
   def pending?   = status == "pending"
   def confirmed? = status == "confirmed"
+  def refused?   = status == "refused"
   def cancelled? = status == "cancelled"
+
+  # Réservations visibles/actionnables par un utilisateur : tout pour un admin
+  # global (staff sans activité rattachée), seulement les siennes pour un
+  # porteur. Centralisé ici pour que contrôleur admin ET canal jeton partagent
+  # exactement la même règle de scoping.
+  def self.for_user(user)
+    return all if user.nil? || user.global_admin?
+
+    for_carrier(user.human)
+  end
+
+  # Jeton signé, à portée d'UN seul `ExperienceBooking` et à durée limitée,
+  # transporté dans le lien de l'email au porteur. On s'appuie sur `signed_id`
+  # de Rails (HMAC + purpose) : impossible de le forger ou de le rejouer pour
+  # un autre enregistrement / une autre action.
+  def validation_token
+    signed_id(purpose: TOKEN_PURPOSE, expires_in: TOKEN_TTL)
+  end
+
+  # Résout un jeton en `ExperienceBooking`. Renvoie nil si le jeton est
+  # invalide, expiré, ou émis pour une autre portée — jamais d'exception.
+  def self.find_by_validation_token(token)
+    find_signed(token, purpose: TOKEN_PURPOSE)
+  end
+
+  # Transition pending → confirmed (validation du porteur).
+  def confirm!
+    update!(status: "confirmed")
+  end
+
+  # Transition pending → refused. La raison est obligatoire : un motif vide
+  # déclenche une `RecordInvalid` (la validation modèle fait foi).
+  def refuse!(reason)
+    update!(status: "refused", refusal_reason: reason)
+  end
 
   # Montant TVAC de l'activité réservée (epic #55, Phase 1). Délègue au service
   # `Pricing::ExperienceLine`, source de vérité unique du barème « forfait fixe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,21 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   belongs_to :human, optional: true
+
+  # Distinction porteur / admin global pour le scoping de la validation
+  # d'activités (epic #55, Phase 2). Le repo n'a PAS de rôle « admin » dédié
+  # (ni Pundit/CanCan), et le compte d'accueil générique n'est rattaché à aucun
+  # `Human` (cf. le fallback `current_user&.human || Human.first` de
+  # BaseController). On s'appuie donc sur ce fait établi :
+  #   * utilisateur SANS `human` = staff/accueil = admin global (voit tout) ;
+  #   * utilisateur AVEC `human` = porteur, cloisonné à SES activités.
+  # Règle « fail-closed » : un porteur ne voit jamais que les siennes, même s'il
+  # n'en porte aucune (liste vide) — jamais toutes par accident.
+  def porteur?
+    human_id.present?
+  end
+
+  def global_admin?
+    human_id.blank?
+  end
 end

--- a/app/views/activity_selection_mailer/animateur_notification.html.slim
+++ b/app/views/activity_selection_mailer/animateur_notification.html.slim
@@ -31,7 +31,17 @@ p
           td = b.experience_availability.available_on.strftime("%-d %B %Y")
           td = "#{b.experience_availability.starts_at}#{b.experience_availability.ends_at ? " → #{b.experience_availability.ends_at}" : ""}"
           td = "#{b.participants} participant#{"s" if b.participants.to_i > 1}"
+          - if b.pending?
+            td
+              = link_to "Valider", activity_validation_url(b.validation_token, host: @link_host)
+              | &nbsp;·&nbsp;
+              = link_to "Refuser", activity_validation_refuse_url(b.validation_token, host: @link_host)
+
+  p
+    em
+      | « Valider » confirme le créneau en un clic. « Refuser » vous demandera
+      | de vous connecter et d'indiquer une raison (transmise au client).
 
 p
   em
-    | Répondez directement à cet email. Malau est en copie.
+    | Vous pouvez aussi tout gérer depuis votre compte porteur. Malau est en copie.

--- a/app/views/activity_selection_mailer/booking_confirmed.html.slim
+++ b/app/views/activity_selection_mailer/booking_confirmed.html.slim
@@ -1,0 +1,15 @@
+p Bonjour #{@stay.customer.first_name.presence || ""},
+
+p
+  | Bonne nouvelle&nbsp;: votre activité «&nbsp;
+  strong = @experience.name
+  | &nbsp;» est confirmée par l'animateur·ice.
+
+p
+  strong Créneau&nbsp;:
+  = " #{@booking.experience_availability.available_on.strftime('%-d/%m/%Y')} à #{@booking.experience_availability.starts_at}"
+  br
+  strong Participants&nbsp;:
+  = " #{@booking.participants}"
+
+p À très bientôt aux 4 Sources !

--- a/app/views/activity_selection_mailer/booking_refused.html.slim
+++ b/app/views/activity_selection_mailer/booking_refused.html.slim
@@ -1,0 +1,21 @@
+p Bonjour #{@stay.customer.first_name.presence || ""},
+
+p
+  | Malheureusement, votre activité «&nbsp;
+  strong = @experience.name
+  | &nbsp;» n'a pas pu être retenue sur le créneau demandé.
+
+p
+  strong Raison&nbsp;:
+  = " #{@reason}"
+
+p
+  | Vous pouvez re-choisir un autre créneau à tout moment via votre page de
+  | sélection d'activités&nbsp;:
+
+p
+  = link_to "Choisir un autre créneau", @selection_url
+
+p
+  | En cas de question, contactez Malau au +32(0)490/46.77.10 ou à
+  = link_to "sejours@les4sources.be", "mailto:sejours@les4sources.be"

--- a/app/views/experience_booking_validations/confirmed.html.slim
+++ b/app/views/experience_booking_validations/confirmed.html.slim
@@ -1,0 +1,6 @@
+.max-w-lg.mx-auto.bg-white.p-6.rounded-lg.shadow-sm.mt-6
+  h1.text-xl.font-bold.mb-4.text-green-700 Activité confirmée
+  p.mb-2
+    | Merci ! L'activité «&nbsp;
+    strong = @booking.experience.name
+    | &nbsp;» est confirmée. Le client vient d'en être informé.

--- a/app/views/experience_booking_validations/forbidden.html.slim
+++ b/app/views/experience_booking_validations/forbidden.html.slim
@@ -1,0 +1,5 @@
+.max-w-lg.mx-auto.bg-white.p-6.rounded-lg.shadow-sm.mt-6
+  h1.text-xl.font-bold.mb-4 Accès refusé
+  p.text-gray-600
+    | Cette activité ne fait pas partie de vos activités. Seul le porteur
+    | concerné peut la valider ou la refuser.

--- a/app/views/experience_booking_validations/invalid.html.slim
+++ b/app/views/experience_booking_validations/invalid.html.slim
@@ -1,0 +1,6 @@
+.max-w-lg.mx-auto.bg-white.p-6.rounded-lg.shadow-sm.mt-6
+  h1.text-xl.font-bold.mb-4 Lien invalide
+  p.text-gray-600
+    | Ce lien de validation n'est plus valide (il a peut-être expiré). Merci de
+    | vous connecter à votre compte porteur pour valider vos activités, ou de
+    | contacter l'équipe des 4 Sources.

--- a/app/views/experience_booking_validations/show.html.slim
+++ b/app/views/experience_booking_validations/show.html.slim
@@ -1,0 +1,23 @@
+.max-w-lg.mx-auto.bg-white.p-6.rounded-lg.shadow-sm.mt-6
+  h1.text-xl.font-bold.mb-4 Confirmer votre activité
+
+  - if @booking.pending?
+    p.mb-2 Vous êtes sur le point de confirmer&nbsp;:
+    .p-4.bg-gray-50.rounded.mb-4
+      .font-semibold = @booking.experience.name
+      .text-sm.text-gray-600
+        = @booking.experience_availability.available_on.strftime("%-d/%m/%Y")
+        | &nbsp;à&nbsp;
+        = @booking.experience_availability.starts_at
+        | &nbsp;—&nbsp;
+        = "#{@booking.participants} participant#{"s" if @booking.participants.to_i > 1}"
+    = button_to "Confirmer cette activité", activity_validation_confirm_path(params[:token]), method: :post, class: "px-4 py-2 bg-green-600 text-white rounded font-medium hover:bg-green-700"
+    p.mt-4.text-sm.text-gray-500
+      | Pour refuser ce créneau, utilisez le lien « Refuser » de l'email
+      | (une connexion et une raison vous seront demandées).
+  - elsif @booking.confirmed?
+    p.text-green-700 Cette activité est déjà confirmée. Merci !
+  - elsif @booking.refused?
+    p.text-red-700 Cette activité a déjà été refusée.
+  - else
+    p.text-gray-600 Cette activité n'est plus en attente de validation.

--- a/app/views/experience_bookings/index.html.slim
+++ b/app/views/experience_bookings/index.html.slim
@@ -1,0 +1,33 @@
+- content_for :page_header do
+  h1.text-2xl.font-bold Activités réservées
+
+.max-w-4xl.mx-auto
+  - if @experience_bookings.empty?
+    p.text-gray-500 Aucune activité réservée pour le moment.
+  - else
+    .space-y-3
+      - @experience_bookings.each do |booking|
+        .flex.items-center.justify-between.gap-4.p-4.bg-white.rounded-lg.shadow-sm border=1
+          .min-w-0
+            .font-semibold = booking.experience.name
+            .text-sm.text-gray-600
+              = booking.experience_availability.available_on.strftime("%-d/%m/%Y")
+              | &nbsp;à&nbsp;
+              = booking.experience_availability.starts_at
+              | &nbsp;—&nbsp;
+              = "#{booking.participants} participant#{"s" if booking.participants.to_i > 1}"
+            .text-sm.text-gray-500 = booking.stay.customer.name
+            - if booking.refused? && booking.refusal_reason.present?
+              .text-sm.text-red-600.mt-1
+                strong Raison du refus :
+                | &nbsp;#{booking.refusal_reason}
+          .flex.items-center.gap-2.shrink-0
+            - if booking.pending?
+              = button_to "Valider", confirm_experience_booking_path(booking), method: :patch, class: "px-3 py-1.5 bg-green-600 text-white rounded text-sm font-medium hover:bg-green-700"
+              = link_to "Refuser", new_refusal_experience_booking_path(booking), class: "px-3 py-1.5 bg-red-100 text-red-700 rounded text-sm font-medium hover:bg-red-200"
+            - elsif booking.confirmed?
+              span.px-3.py-1.5.bg-green-100.text-green-800.rounded.text-sm.font-medium Confirmée
+            - elsif booking.refused?
+              span.px-3.py-1.5.bg-red-100.text-red-800.rounded.text-sm.font-medium Refusée
+            - else
+              span.px-3.py-1.5.bg-gray-100.text-gray-700.rounded.text-sm.font-medium = booking.status

--- a/app/views/experience_bookings/new_refusal.html.slim
+++ b/app/views/experience_bookings/new_refusal.html.slim
@@ -1,0 +1,22 @@
+- content_for :page_header do
+  h1.text-2xl.font-bold Refuser une activité
+
+.max-w-xl.mx-auto.bg-white.p-6.rounded-lg.shadow-sm
+  .mb-4
+    .font-semibold = @booking.experience.name
+    .text-sm.text-gray-600
+      = @booking.experience_availability.available_on.strftime("%-d/%m/%Y")
+      | &nbsp;à&nbsp;
+      = @booking.experience_availability.starts_at
+      | &nbsp;—&nbsp;
+      = "#{@booking.participants} participant#{"s" if @booking.participants.to_i > 1}"
+    .text-sm.text-gray-500 = @booking.stay.customer.name
+
+  = form_with url: refuse_experience_booking_path(@booking), method: :patch, local: true do |f|
+    .mb-4
+      label.block.text-sm.font-medium.mb-1 for="experience_booking_refusal_reason" Raison du refus (obligatoire)
+      = f.text_area "experience_booking[refusal_reason]", id: "experience_booking_refusal_reason", rows: 4, required: true, class: "w-full border rounded p-2"
+      p.text-xs.text-gray-500.mt-1 Cette raison sera transmise au client avec une invitation à re-choisir un créneau.
+    .flex.gap-2
+      = f.submit "Confirmer le refus", class: "px-4 py-2 bg-red-600 text-white rounded font-medium hover:bg-red-700"
+      = link_to "Annuler", experience_bookings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded font-medium hover:bg-gray-200"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,21 @@ Rails.application.routes.draw do
 
   # Détails d'un séjour (chargé dans une modale Turbo Frame depuis la page client).
   resources :stays, only: [:show]
-  resources :experience_bookings, only: [:index, :update]
+  resources :experience_bookings, only: [:index, :update] do
+    member do
+      patch :confirm         # validation par le porteur (canal admin)
+      get   :new_refusal     # formulaire de refus (raison obligatoire)
+      patch :refuse          # application du refus avec raison
+    end
+  end
+
+  # Canal jeton — validation d'activité par le porteur depuis l'email (epic #55,
+  # Phase 2). La VALIDATION passe par une page de confirmation légère (GET) puis
+  # un POST : jamais de mutation sur simple GET préchargeable. Le REFUS exige une
+  # raison, donc une connexion : le lien renvoie vers le formulaire admin.
+  get  "activites/valider/:token",  to: "experience_booking_validations#show",    as: :activity_validation
+  post "activites/valider/:token",  to: "experience_booking_validations#confirm", as: :activity_validation_confirm
+  get  "activites/refuser/:token",  to: "experience_booking_validations#refuse",  as: :activity_validation_refuse
 
   # Espace client activités (token-based, sans Devise).
   get  "mon-sejour/:token/activites", to: "public/activity_selections#show",   as: :public_activity_selection

--- a/db/migrate/20260716120000_add_refusal_reason_to_experience_bookings.rb
+++ b/db/migrate/20260716120000_add_refusal_reason_to_experience_bookings.rb
@@ -1,0 +1,14 @@
+class AddRefusalReasonToExperienceBookings < ActiveRecord::Migration[7.0]
+  # Epic #55 — Phase 2 : validation des activités par les porteurs.
+  # Le statut `refused` est une nouvelle valeur applicative de la colonne
+  # `status` (pas de contrainte SQL à ajouter). Un refus exige toujours une
+  # raison : d'où cette colonne texte. Nullable — les `ExperienceBooking`
+  # existants (pending/confirmed/cancelled) restent valides sans raison.
+  def up
+    add_column :experience_bookings, :refusal_reason, :text
+  end
+
+  def down
+    remove_column :experience_bookings, :refusal_reason
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_16_011705) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_16_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -269,6 +269,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_16_011705) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "refusal_reason"
     t.index ["experience_availability_id"], name: "index_experience_bookings_on_experience_availability_id"
     t.index ["stay_id"], name: "index_experience_bookings_on_stay_id"
   end

--- a/spec/mailers/activity_selection_mailer_spec.rb
+++ b/spec/mailers/activity_selection_mailer_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+# Epic #55 — Phase 2 : notifications client (validation/refus) + liens porteur.
+RSpec.describe ActivitySelectionMailer, type: :mailer do
+  let(:customer)   { Customer.create!(email: "client@example.com", first_name: "Léa", customer_type: "individual") }
+  let(:stay)       { Stay.create!(customer: customer, arrival_date: Date.today + 20, departure_date: Date.today + 22) }
+  let(:porteur)    { Human.create!(name: "Porteuse Balade", email: "porteuse@example.com") }
+  let(:experience) { Experience.create!(name: "Balade avec les ânes", human: porteur) }
+  let(:availability) do
+    ExperienceAvailability.create!(experience: experience, available_on: Date.today + 21, starts_at: "10:00")
+  end
+  let(:booking) do
+    ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2)
+  end
+
+  describe "#booking_refused" do
+    subject(:mail) { described_class.booking_refused(booking.tap { |b| b.refuse!("Créneau déjà complet") }) }
+
+    it "adresse le mail au client" do
+      expect(mail.to).to eq(["client@example.com"])
+    end
+
+    it "porte la raison du refus et un lien de re-sélection" do
+      body = mail.body.encoded
+      expect(body).to include("Créneau déjà complet")
+      expect(body).to include(stay.activity_selection_token)
+    end
+  end
+
+  describe "#booking_confirmed" do
+    subject(:mail) { described_class.booking_confirmed(booking.tap(&:confirm!)) }
+
+    it "adresse le mail au client et nomme l'activité" do
+      expect(mail.to).to eq(["client@example.com"])
+      expect(mail.body.encoded).to include("Balade avec les ânes")
+    end
+  end
+
+  describe "#animateur_notification" do
+    subject(:mail) { described_class.animateur_notification(stay) }
+
+    before { booking } # crée une réservation pending
+
+    it "contient un lien de validation (jeton) et un lien de refus pour chaque activité pending" do
+      body = mail.body.encoded
+      expect(body).to include("/activites/valider/")
+      expect(body).to include("/activites/refuser/")
+    end
+  end
+end

--- a/spec/models/experience_booking_spec.rb
+++ b/spec/models/experience_booking_spec.rb
@@ -1,0 +1,122 @@
+# == Schema Information
+#
+# Table name: experience_bookings
+#
+#  id                          :bigint           not null, primary key
+#  experience_availability_id  :bigint           not null
+#  stay_id                     :bigint           not null
+#  participants                :integer
+#  status                      :string           default("pending")
+#  notes                       :text
+#  refusal_reason              :text
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#
+require "rails_helper"
+
+# Epic #55 — Phase 2 : validation/refus des activités par les porteurs.
+RSpec.describe ExperienceBooking, type: :model do
+  let(:customer)   { Customer.create!(email: "eb@example.com", customer_type: "individual") }
+  let(:stay)       { Stay.create!(customer: customer) }
+  let(:porteur)    { Human.create!(name: "Porteuse Balade", email: "porteuse@example.com") }
+  let(:experience) { Experience.create!(name: "Balade avec les ânes", human: porteur, fixed_price_cents: 3_000) }
+  let(:availability) do
+    ExperienceAvailability.create!(experience: experience, available_on: Date.today + 20, starts_at: "10:00")
+  end
+
+  def booking(status: "pending", reason: nil)
+    ExperienceBooking.create!(
+      experience_availability: availability, stay: stay, participants: 2,
+      status: status, refusal_reason: reason
+    )
+  end
+
+  describe "statut refused + raison obligatoire" do
+    it "accepte refused avec une raison" do
+      eb = booking
+      expect(eb.refuse!("Créneau déjà complet")).to be_truthy
+      expect(eb.reload).to be_refused
+      expect(eb.refusal_reason).to eq("Créneau déjà complet")
+    end
+
+    it "refuse un refused sans raison" do
+      eb = booking
+      expect { eb.refuse!("") }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(eb.reload).to be_pending
+    end
+
+    it "n'exige pas de raison pour les autres statuts" do
+      expect(booking(status: "confirmed")).to be_valid
+      expect(booking(status: "cancelled")).to be_valid
+      expect(booking(status: "pending")).to be_valid
+    end
+  end
+
+  describe "transitions" do
+    it "pending → confirmed via #confirm!" do
+      eb = booking
+      eb.confirm!
+      expect(eb.reload).to be_confirmed
+    end
+
+    it "pending → refused via #refuse!(reason)" do
+      eb = booking
+      eb.refuse!("Indisponible ce jour-là")
+      expect(eb.reload).to be_refused
+    end
+  end
+
+  describe "scope .active" do
+    it "exclut les activités annulées ET refusées" do
+      keep    = booking(status: "confirmed")
+      booking(status: "cancelled")
+      booking(status: "refused", reason: "non")
+
+      expect(ExperienceBooking.active).to contain_exactly(keep)
+    end
+  end
+
+  describe "scoping porteur" do
+    let(:autre_porteur)   { Human.create!(name: "Autre Porteur", email: "autre@example.com") }
+    let(:autre_experience){ Experience.create!(name: "Poterie", human: autre_porteur) }
+    let(:autre_avail) do
+      ExperienceAvailability.create!(experience: autre_experience, available_on: Date.today + 21, starts_at: "14:00")
+    end
+
+    it ".for_carrier ne renvoie que les réservations des activités du porteur" do
+      mine   = booking
+      theirs = ExperienceBooking.create!(experience_availability: autre_avail, stay: stay, participants: 1)
+
+      expect(ExperienceBooking.for_carrier(porteur)).to include(mine)
+      expect(ExperienceBooking.for_carrier(porteur)).not_to include(theirs)
+    end
+
+    it ".for_user renvoie tout pour un admin global, ses activités pour un porteur" do
+      mine   = booking
+      theirs = ExperienceBooking.create!(experience_availability: autre_avail, stay: stay, participants: 1)
+
+      admin_user   = User.create!(email: "staff@les4sources.be", password: "password123")
+      porteur_user = User.create!(email: "porteuse@example.com", password: "password123", human: porteur)
+
+      expect(ExperienceBooking.for_user(admin_user)).to include(mine, theirs)
+      expect(ExperienceBooking.for_user(porteur_user)).to contain_exactly(mine)
+    end
+  end
+
+  describe "jeton de validation" do
+    it "résout le bon enregistrement" do
+      eb = booking
+      expect(ExperienceBooking.find_by_validation_token(eb.validation_token)).to eq(eb)
+    end
+
+    it "ne vaut que pour cette portée (purpose)" do
+      eb = booking
+      forged = eb.signed_id(purpose: :autre_chose)
+      expect(ExperienceBooking.find_by_validation_token(forged)).to be_nil
+    end
+
+    it "renvoie nil pour un jeton bidon" do
+      expect(ExperienceBooking.find_by_validation_token("n-importe-quoi")).to be_nil
+    end
+  end
+end

--- a/spec/requests/experience_booking_validations_spec.rb
+++ b/spec/requests/experience_booking_validations_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+# Epic #55 — Phase 2 : canal JETON (lien email) de validation d'activité.
+RSpec.describe "ExperienceBookingValidations — canal jeton", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:customer) { Customer.create!(email: "client@example.com", customer_type: "individual") }
+  let(:stay)     { Stay.create!(customer: customer, arrival_date: Date.today + 20, departure_date: Date.today + 22) }
+
+  let(:porteur_a) { Human.create!(name: "Porteuse A", email: "a@example.com") }
+  let(:user_a)    { User.create!(email: "a@example.com", password: "password123", human: porteur_a) }
+  let(:exp_a)     { Experience.create!(name: "Balade ânes", human: porteur_a) }
+  let(:avail_a)   { ExperienceAvailability.create!(experience: exp_a, available_on: Date.today + 21, starts_at: "10:00") }
+  let(:booking)   { ExperienceBooking.create!(experience_availability: avail_a, stay: stay, participants: 2) }
+
+  describe "GET show (page de confirmation)" do
+    it "affiche un bouton de confirmation SANS muter la réservation" do
+      get activity_validation_path(booking.validation_token)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Confirmer cette activité")
+      expect(booking.reload).to be_pending # aucune mutation sur GET
+    end
+
+    it "renvoie 404 pour un jeton invalide" do
+      get activity_validation_path("jeton-bidon")
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST confirm (validation 1 clic)" do
+    it "valide LA bonne réservation et notifie le client" do
+      token = booking.validation_token
+      expect {
+        post activity_validation_confirm_path(token)
+      }.to have_enqueued_mail(ActivitySelectionMailer, :booking_confirmed)
+      expect(booking.reload).to be_confirmed
+    end
+
+    it "ne re-valide pas une réservation déjà traitée (idempotent)" do
+      booking.confirm!
+      token = booking.validation_token
+      expect {
+        post activity_validation_confirm_path(token)
+      }.not_to have_enqueued_mail(ActivitySelectionMailer, :booking_confirmed)
+    end
+  end
+
+  describe "GET refuse (amorce du refus)" do
+    it "exige une connexion (redirige vers le login) quand anonyme" do
+      get activity_validation_refuse_path(booking.validation_token)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "connecté et propriétaire : renvoie vers le formulaire de refus admin" do
+      sign_in user_a
+      get activity_validation_refuse_path(booking.validation_token)
+      expect(response).to redirect_to(new_refusal_experience_booking_path(booking))
+    end
+
+    it "connecté mais NON propriétaire : accès refusé" do
+      autre = Human.create!(name: "Autre", email: "autre@example.com")
+      autre_user = User.create!(email: "autre@example.com", password: "password123", human: autre)
+      sign_in autre_user
+      get activity_validation_refuse_path(booking.validation_token)
+      expect(response).to have_http_status(:forbidden)
+      expect(booking.reload).to be_pending
+    end
+  end
+end

--- a/spec/requests/experience_bookings_spec.rb
+++ b/spec/requests/experience_bookings_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+# Epic #55 — Phase 2 : canal ADMIN de validation/refus des activités, avec
+# scoping d'autorisation par porteur.
+RSpec.describe "ExperienceBookings — canal admin", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:customer) { Customer.create!(email: "client@example.com", customer_type: "individual") }
+  let(:stay)     { Stay.create!(customer: customer, arrival_date: Date.today + 20, departure_date: Date.today + 22) }
+
+  # Porteuse A + son compte
+  let(:porteur_a)  { Human.create!(name: "Porteuse A", email: "a@example.com") }
+  let(:user_a)     { User.create!(email: "a@example.com", password: "password123", human: porteur_a) }
+  let(:exp_a)      { Experience.create!(name: "Balade ânes", human: porteur_a) }
+  let(:avail_a)    { ExperienceAvailability.create!(experience: exp_a, available_on: Date.today + 21, starts_at: "10:00") }
+  let(:booking_a)  { ExperienceBooking.create!(experience_availability: avail_a, stay: stay, participants: 2) }
+
+  # Porteur B + son compte (pour prouver le cloisonnement)
+  let(:porteur_b)  { Human.create!(name: "Porteur B", email: "b@example.com") }
+  let(:user_b)     { User.create!(email: "b@example.com", password: "password123", human: porteur_b) }
+  let(:exp_b)      { Experience.create!(name: "Poterie", human: porteur_b) }
+  let(:avail_b)    { ExperienceAvailability.create!(experience: exp_b, available_on: Date.today + 21, starts_at: "14:00") }
+  let(:booking_b)  { ExperienceBooking.create!(experience_availability: avail_b, stay: stay, participants: 1) }
+
+  describe "GET /experience_bookings (index)" do
+    it "un porteur ne voit que ses propres activités" do
+      booking_a; booking_b
+      sign_in user_a
+      get experience_bookings_path
+      expect(response.body).to include("Balade ânes")
+      expect(response.body).not_to include("Poterie")
+    end
+
+    it "un admin global voit toutes les activités" do
+      booking_a; booking_b
+      admin = User.create!(email: "staff@les4sources.be", password: "password123")
+      sign_in admin
+      get experience_bookings_path
+      expect(response.body).to include("Balade ânes")
+      expect(response.body).to include("Poterie")
+    end
+  end
+
+  describe "PATCH /experience_bookings/:id/confirm" do
+    it "le porteur valide SA réservation et le client est notifié" do
+      sign_in user_a
+      expect {
+        patch confirm_experience_booking_path(booking_a)
+      }.to have_enqueued_mail(ActivitySelectionMailer, :booking_confirmed)
+      expect(booking_a.reload).to be_confirmed
+    end
+
+    it "un porteur ne peut PAS valider l'activité d'un autre porteur" do
+      target = booking_b
+      sign_in user_a
+      patch confirm_experience_booking_path(target)
+      expect(target.reload).to be_pending # inchangé
+    end
+  end
+
+  describe "refus (formulaire + application)" do
+    it "GET new_refusal affiche le formulaire de raison" do
+      sign_in user_a
+      get new_refusal_experience_booking_path(booking_a)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Raison du refus")
+    end
+
+    it "PATCH refuse avec raison refuse et notifie le client" do
+      sign_in user_a
+      expect {
+        patch refuse_experience_booking_path(booking_a), params: { experience_booking: { refusal_reason: "Complet" } }
+      }.to have_enqueued_mail(ActivitySelectionMailer, :booking_refused)
+      expect(booking_a.reload).to be_refused
+      expect(booking_a.refusal_reason).to eq("Complet")
+    end
+
+    it "PATCH refuse SANS raison ré-affiche le formulaire et ne refuse pas" do
+      sign_in user_a
+      patch refuse_experience_booking_path(booking_a), params: { experience_booking: { refusal_reason: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(booking_a.reload).to be_pending
+    end
+
+    it "un porteur ne peut pas refuser l'activité d'un autre porteur" do
+      target = booking_b
+      sign_in user_a
+      patch refuse_experience_booking_path(target), params: { experience_booking: { refusal_reason: "Non" } }
+      expect(target.reload).to be_pending
+    end
+  end
+end


### PR DESCRIPTION
Phase 2 de l'epic #55. **Empilée sur la PR #56 (Phase 1)** — à merger après elle (GitHub re-cible sur main automatiquement).

## Ce que fait cette PR
- **Statut `refused` + `refusal_reason`** (migration réversible, colonne nullable → EB existants valides). Validation : un `refused` porte toujours une raison non vide.
- **Scoping porteur/admin** : `User` avec `human` lié = porteur (cloisonné à ses `Experience`, fail-closed) ; sans `human` = staff/admin global. Toute la règle dans `ExperienceBooking.for_user`, partagée par les deux canaux.
- **Canal admin** : le porteur voit ses activités réservées, valide (POST) / refuse (formulaire raison obligatoire).
- **Canal email** : lien `signed_id` (purpose scopé, exp. 30j) → **page de confirmation** avec bouton POST (jamais de mutation sur GET, anti-prefetch). Refus jamais anonyme : force login + raison.
- **Notifications client** : `booking_confirmed` et `booking_refused` (porte la raison + lien de re-sélection token).

## Vérification
- `bundle exec rspec` : **454 ex, 0 failure**, 18 pending (+30 specs : modèle, mailer, canal admin, canal token). Le scope `active` exclut désormais `refused` → une activité refusée n'est pas facturée dans le total du Stay.

## ⚠️ Dette de vérification navigateur (à solder avant déploiement)
Les nouvelles vues (index admin, formulaire de refus, pages token) sont couvertes par des **request specs** (rendu HTML + assertions) mais **PAS ouvertes dans un vrai navigateur**. À valider visuellement avant merge/déploiement — penser à redémarrer `bin/vite dev` (nouvelles variantes Tailwind). *Cette dette s'ajoute à celle de Phase 1 (vue activités). Je propose une passe navigateur groupée sur toutes les UI activités une fois la Phase 4 (funnel) posée.*

## Gaps assumés (hors périmètre Phase 2)
- **Capacité créneaux** : `ExperienceAvailability#booked_participants` compte encore les `refused` → un refus ne libère pas la place (domaine Phase 4).
- **Lien menu admin** vers `/experience_bookings` non ajouté (hors AC).

## Notes
- Implémentée par Engineer. Déploiement Hatchbox manuel : merger ≠ déployer.

Refs #55