### PR TITLE
feat(activités): Phase 3 — paiement du solde exigible sur la page client (Stripe)

### DIFF
--- a/app/controllers/public/stay_balance_payments_controller.rb
+++ b/app/controllers/public/stay_balance_payments_controller.rb
@@ -1,0 +1,28 @@
+module Public
+  # Paiement du SOLDE exigible d'un séjour (epic #55, Phase 3). Canal PUBLIC :
+  # l'autorisation repose entièrement sur le JETON du séjour — pas de Devise.
+  # Seul le détenteur du lien /sejour/:token peut déclencher le paiement de SON
+  # séjour ; un jeton inconnu tombe en 404 (jamais d'énumération d'IDs).
+  #
+  # Action POST (elle écrit : crée/rafraîchit un Payment `pending`), puis
+  # redirige vers la session Stripe Checkout produite par `PayService`.
+  class StayBalancePaymentsController < Public::BaseController
+    layout "public_sheet"
+
+    def create
+      stay = Stay.find_by!(token: params[:token])
+      service = Payments::CreateBalanceService.new(stay: stay)
+
+      if service.run
+        redirect_to service.checkout_session_url,
+                    allow_other_host: true,
+                    data: { turbo: false }
+      else
+        redirect_to public_stay_path(stay.token),
+                    alert: service.error_message(default: "Le paiement du solde n'a pas pu être initialisé. Veuillez nous contacter à sejours@les4sources.be.")
+      end
+    rescue ActiveRecord::RecordNotFound
+      raise ActionController::RoutingError, "Not Found"
+    end
+  end
+end

--- a/app/decorators/stay_decorator.rb
+++ b/app/decorators/stay_decorator.rb
@@ -100,4 +100,58 @@ class StayDecorator < ApplicationDecorator
     group = primary_bookable.try(:group_name).presence
     [person.presence, group].compact.join(" · ").presence || "—"
   end
+
+  # --- Ventilation du montant exigible (epic #55, Phase 3) ---------------
+  # Montants formatés en euros pour la page client. On lit l'arithmétique du
+  # modèle (source unique de vérité « total prévu vs exigible »).
+
+  def formatted_amount_paid
+    money(object.amount_paid_cents)
+  end
+
+  def formatted_lodging_and_spaces
+    money(object.lodging_and_spaces_amount_cents)
+  end
+
+  def formatted_experiences_confirmed
+    money(object.experiences_confirmed_amount_cents)
+  end
+
+  def formatted_experiences_pending
+    money(object.experiences_pending_amount_cents)
+  end
+
+  def formatted_balance_due
+    money(object.balance_due_cents)
+  end
+
+  def has_confirmed_experiences?
+    object.experiences_confirmed_amount_cents.positive?
+  end
+
+  def has_pending_experiences?
+    object.experiences_pending_amount_cents.positive?
+  end
+
+  # Faut-il afficher le bloc de ventilation du solde ? Dès qu'il y a quelque
+  # chose à dire : un exigible à régler, un encaissé à créditer, ou des
+  # activités en attente à signaler.
+  def show_balance_section?
+    object.payable_now? ||
+      object.amount_paid_cents.positive? ||
+      has_pending_experiences?
+  end
+
+  # Bouton « Payer le solde » : un exigible strictement positif ET aucun
+  # paiement `pending` déjà en cours (l'acompte non réglé, par exemple, est déjà
+  # couvert par son propre CTA — on n'empile pas deux boutons pour la même dette).
+  def show_balance_cta?
+    object.payable_now? && object.payments.pending.none?
+  end
+
+  private
+
+  def money(cents)
+    h.humanized_money_with_symbol(Money.new(cents.to_i))
+  end
 end

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -84,19 +84,78 @@ class Stay < ApplicationRecord
   # Séjour soldé : au moins un paiement encaissé ET plus rien à devoir. La
   # condition `amount_paid_cents.positive?` préserve le garde-fou « 0 € sans
   # paiement ne bascule pas en soldé par l'effet de bord d'un 0 >= 0 ».
+  # Adossé au TOTAL PRÉVU (activités pending incluses) : « tout est couvert, y
+  # compris ce qui reste à valider ». Le STATUT de paiement, lui, s'appuie sur
+  # l'EXIGIBLE (voir plus bas / `set_payment_status`).
   def settled?
     amount_paid_cents.positive? && amount_due_cents <= 0
+  end
+
+  # --- Total prévu vs montant exigible (epic #55, Phase 3) ----------------
+  # Deux notions DISTINCTES cohabitent, à ne pas confondre :
+  #
+  #   • « TOTAL PRÉVU » = `total_amount_cents` = hébergement/espaces + activités
+  #     ACTIVES (pending + confirmed). Ce que le séjour coûtera si tout est
+  #     validé. Sémantique Phase 1 — `amount_due_cents` et `settled?` s'y adossent
+  #     et restent inchangés.
+  #
+  #   • « EXIGIBLE » (payable now) = ce que le client peut/doit régler MAINTENANT
+  #     = total prévu MOINS les activités encore `pending` (pas encore validées
+  #     par le porteur, donc non facturables). On l'exprime comme un DELTA du
+  #     total prévu — et non recalculé depuis les bookables — pour rester
+  #     rigoureusement cohérent avec `total_amount_cents` en toute circonstance
+  #     (y compris un séjour dont le total a été posé directement, sans items).
+  #
+  # `price_cents` d'une activité est CALCULÉ (délègue au barème Pricing) : on
+  # somme donc en Ruby (bloc), jamais en SQL — comme `recompute_aggregates!`.
+
+  # Activités en attente de validation — NON exigibles.
+  def experiences_pending_amount_cents
+    experience_bookings.pending.sum(&:price_cents)
+  end
+
+  # Activités validées par le porteur — exigibles.
+  def experiences_confirmed_amount_cents
+    experience_bookings.confirmed.sum(&:price_cents)
+  end
+
+  # Part hébergement/espaces (bookables) = total prévu − activités actives.
+  def lodging_and_spaces_amount_cents
+    total_amount_cents.to_i -
+      experiences_confirmed_amount_cents -
+      experiences_pending_amount_cents
+  end
+
+  # Assiette EXIGIBLE = hébergement/espaces + activités CONFIRMED
+  #                   = total prévu − activités pending.
+  def payable_amount_cents
+    total_amount_cents.to_i - experiences_pending_amount_cents
+  end
+
+  # Reste dû EXIGIBLE = assiette exigible − encaissé. Peut être négatif en cas
+  # de trop-perçu ; le bouton « Payer le solde » ne s'affiche que s'il est > 0.
+  def balance_due_cents
+    payable_amount_cents - amount_paid_cents
+  end
+
+  # Reste-t-il un solde exigible à encaisser maintenant ?
+  def payable_now?
+    balance_due_cents.positive?
   end
 
   # Recompute aggregate dates / amount from the attached items (min arrival,
   # max departure, sum of prices). Booking and SpaceBooking both expose
   # from_date/to_date/price_cents.
-  # Recalcule le statut de paiement à partir des paiements encaissés. Même
-  # sémantique que `Booking#set_payment_status`, à une nuance près : un séjour
-  # dont le total est à 0 € et sans paiement reste « pending » (et ne bascule
-  # pas en « paid » par l'effet de bord d'un `0 >= 0`).
+  # Recalcule le statut de paiement à partir des paiements encaissés. Il s'adosse
+  # à l'EXIGIBLE (`balance_due_cents`) et NON au total prévu : un séjour dont les
+  # seules dettes restantes sont des activités `pending` (non validées, donc non
+  # facturables) est « paid » dès que l'exigible est couvert (epic #55, Phase 3).
+  # Le garde-fou Phase 1 tient toujours : un séjour à 0 € sans paiement reste
+  # « pending » (pas de bascule par effet de bord d'un `0 >= 0`).
+  # NB : sans activité `pending`, `balance_due_cents == amount_due_cents` — le
+  # comportement est donc identique à la Phase 1 pour tous les séjours existants.
   def set_payment_status
-    status = if settled?
+    status = if amount_paid_cents.positive? && balance_due_cents <= 0
       "paid"
     elsif amount_paid_cents.positive?
       "partially_paid"

--- a/app/services/payments/create_balance_service.rb
+++ b/app/services/payments/create_balance_service.rb
@@ -1,0 +1,65 @@
+module Payments
+  # Création (ou réutilisation) du paiement de SOLDE d'un séjour, puis ouverture
+  # d'une session Stripe Checkout du montant EXIGIBLE (epic #55, Phase 3).
+  #
+  # Montant réglé = `stay.balance_due_cents` = (hébergement/espaces + activités
+  # CONFIRMED) − encaissé. Les activités `pending` (non validées par le porteur)
+  # n'y entrent JAMAIS. Payable à tout moment tant que l'exigible est positif :
+  # l'assiette est recalculée à chaque initiation, ce qui tolère naturellement
+  # les paiements partiels/successifs.
+  #
+  # On réutilise un éventuel paiement `pending` déjà rattaché au séjour (garde-fou
+  # anti-doublon contre une double soumission) en réalignant son montant sur
+  # l'exigible courant ; sinon on en crée un, ANCRÉ sur le Stay (`stay_id`). Le
+  # Checkout et le webhook réutilisent tels quels le mécanisme de l'acompte
+  # (epic #26) : `PayService` pour la session, `Webhooks::StripeService` +
+  # `StripeEvent` pour l'idempotence côté retour.
+  class CreateBalanceService < ServiceBase
+    attr_reader :stay, :payment, :checkout_session_url
+
+    def initialize(stay:)
+      @stay = stay
+      @report_errors = true
+    end
+
+    def run
+      catch_error { run! }
+    end
+
+    def run!
+      amount_cents = stay.balance_due_cents
+      unless amount_cents.positive?
+        set_error_message("Ce séjour est déjà soldé : aucun montant n'est exigible.")
+        return false
+      end
+
+      @payment = upsert_pending_payment!(amount_cents)
+
+      pay = Payments::PayService.new(payment_id: @payment.id)
+      raise pay.error_message(default: "Le paiement en ligne n'a pas pu être initialisé.") unless pay.run
+
+      @checkout_session_url = pay.checkout_session_url
+      true
+    end
+
+    private
+
+    # Un seul paiement `pending` vivant à la fois pour ce séjour : on réutilise
+    # celui déjà présent (double-clic) en réalignant son montant, sinon on crée
+    # un paiement neuf rattaché au Stay.
+    def upsert_pending_payment!(amount_cents)
+      existing = stay.payments.pending.order(:created_at).last
+      if existing
+        existing.update!(amount_cents: amount_cents)
+        existing
+      else
+        Payment.create!(
+          stay: stay,
+          amount_cents: amount_cents,
+          status: "pending",
+          payment_method: "card"
+        )
+      end
+    end
+  end
+end

--- a/app/views/public/stays/_balance.html.slim
+++ b/app/views/public/stays/_balance.html.slim
@@ -1,0 +1,41 @@
+/ Ventilation du montant EXIGIBLE + bouton « Payer le solde » (epic #55, Phase 3).
+/ « Exigible » = hébergement/espaces + activités VALIDÉES − encaissé. Les activités
+/ EN ATTENTE de validation sont affichées mais NON facturées (non exigibles).
+- if @stay.show_balance_section?
+  .mt-8.border-t.border-gray-200.pt-6(data-stay-balance="true")
+    h3.text-base.font-semibold.leading-6.text-gray-900.mb-4
+      = t("public.stays.balance.heading")
+
+    dl.space-y-2.text-sm
+      .flex.items-center.justify-between
+        dt.text-gray-600 = t("public.stays.balance.lodging_and_spaces")
+        dd.text-gray-900 = @stay.formatted_lodging_and_spaces
+
+      - if @stay.has_confirmed_experiences?
+        .flex.items-center.justify-between
+          dt.text-gray-600 = t("public.stays.balance.experiences_confirmed")
+          dd.text-gray-900 = @stay.formatted_experiences_confirmed
+
+      - if @stay.has_pending_experiences?
+        .flex.items-center.justify-between.text-gray-400(data-balance-pending="true")
+          dt
+            = t("public.stays.balance.experiences_pending")
+            span.ml-1.text-xs.italic = t("public.stays.balance.experiences_pending_note")
+          dd = @stay.formatted_experiences_pending
+
+      - if @stay.amount_paid_cents.positive?
+        .flex.items-center.justify-between.text-green-700
+          dt = t("public.stays.balance.amount_paid")
+          dd = "− #{@stay.formatted_amount_paid}"
+
+      .flex.items-center.justify-between.border-t.border-gray-200.pt-2.mt-2
+        dt.text-base.font-semibold.text-gray-900 = t("public.stays.balance.balance_due")
+        dd.text-lg.font-bold.text-gray-900(data-balance-due="true") = @stay.formatted_balance_due
+
+    - if @stay.show_balance_cta?
+      .mt-5(data-stay-balance-cta="true")
+        = button_to t("public.stays.balance.pay_balance_cta", amount: @stay.formatted_balance_due),
+                    public_stay_balance_payment_path(@stay.token),
+                    method: :post,
+                    data: { turbo: false },
+                    class: "inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"

--- a/app/views/public/stays/show.html.slim
+++ b/app/views/public/stays/show.html.slim
@@ -42,4 +42,6 @@
         p.text-base.font-semibold.text-gray-900 = t(".total")
         p.text-lg.font-bold.text-gray-900 = @stay.formatted_total
 
+    = render "public/stays/balance"
+
     = render "public/stays/payments"

--- a/config/locales/public.en.yml
+++ b/config/locales/public.en.yml
@@ -30,3 +30,12 @@ en:
         stripe_notice: "This payment is handled by Stripe: we never have access to your payment details."
         pay_cta: "Payment →"
         received_heading: "Payments received"
+      balance:
+        heading: "Balance of your stay"
+        lodging_and_spaces: "Accommodation & spaces"
+        experiences_confirmed: "Confirmed activities"
+        experiences_pending: "Activities awaiting confirmation"
+        experiences_pending_note: "(not due until confirmed)"
+        amount_paid: "Already paid"
+        balance_due: "Balance due"
+        pay_balance_cta: "Pay the balance of %{amount}"

--- a/config/locales/public.fr.yml
+++ b/config/locales/public.fr.yml
@@ -26,3 +26,12 @@ fr:
         stripe_notice: "Ce paiement est géré par Stripe : nous n'avons à aucun moment accès à vos données de paiement."
         pay_cta: "Paiement →"
         received_heading: "Paiements reçus"
+      balance:
+        heading: "Solde de votre séjour"
+        lodging_and_spaces: "Hébergement & espaces"
+        experiences_confirmed: "Activités validées"
+        experiences_pending: "Activités en attente de validation"
+        experiences_pending_note: "(non exigible tant que non validée)"
+        amount_paid: "Déjà payé"
+        balance_due: "Reste dû"
+        pay_balance_cta: "Payer le solde de %{amount}"

--- a/config/locales/public.nl.yml
+++ b/config/locales/public.nl.yml
@@ -30,3 +30,12 @@ nl:
         stripe_notice: "Deze betaling wordt beheerd door Stripe: wij hebben op geen enkel moment toegang tot uw betaalgegevens."
         pay_cta: "Betaling →"
         received_heading: "Ontvangen betalingen"
+      balance:
+        heading: "Saldo van uw verblijf"
+        lodging_and_spaces: "Verblijf & ruimtes"
+        experiences_confirmed: "Bevestigde activiteiten"
+        experiences_pending: "Activiteiten in afwachting van bevestiging"
+        experiences_pending_note: "(niet verschuldigd zolang niet bevestigd)"
+        amount_paid: "Reeds betaald"
+        balance_due: "Nog te betalen"
+        pay_balance_cta: "Betaal het saldo van %{amount}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,11 @@ Rails.application.routes.draw do
   # la cible des redirections Stripe, on la garde courte, comme /reservation/sejour.
   get "sejour/:token", to: "public/stays#show", as: :public_stay
 
+  # Paiement du solde exigible du séjour (epic #55, Phase 3) — POST scellé par le
+  # même jeton que la page client ; crée/rafraîchit le paiement puis part sur
+  # Stripe Checkout.
+  post "sejour/:token/payer-le-solde", to: "public/stay_balance_payments#create", as: :public_stay_balance_payment
+
   namespace :public do
     resources :bookings, only: [:new, :create] do
       get "edit_estimated_arrival", on: :member

--- a/spec/models/stay_spec.rb
+++ b/spec/models/stay_spec.rb
@@ -255,4 +255,52 @@ RSpec.describe Stay, type: :model do
       expect(zero).not_to be_settled
     end
   end
+
+  describe "#balance_due_cents / montant exigible (epic #55, Phase 3)" do
+    let(:experience) { Experience.create!(name: "Atelier pain", fixed_price_cents: 5_000, price_cents: 1_500) }
+    let(:availability) do
+      ExperienceAvailability.create!(experience: experience, available_on: Date.new(2026, 7, 10), starts_at: "10:00")
+    end
+
+    # Total prévu posé directement = hébergement 20 000 + confirmée 8 000 + pending 6 500.
+    let(:stay) { Stay.create!(customer: customer, total_amount_cents: 34_500) }
+
+    before do
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "confirmed") # 8 000
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 1, status: "pending")   # 6 500
+    end
+
+    it "exclut les activités pending de l'assiette exigible, inclut les confirmed" do
+      expect(stay.experiences_pending_amount_cents).to eq(6_500)
+      expect(stay.experiences_confirmed_amount_cents).to eq(8_000)
+      # Assiette exigible = total prévu − pending = 34 500 − 6 500 = 28 000.
+      expect(stay.payable_amount_cents).to eq(28_000)
+    end
+
+    it "déduit l'encaissé du reste dû exigible" do
+      Payment.create!(stay: stay, amount_cents: 10_000, status: "paid", payment_method: "card")
+      expect(stay.balance_due_cents).to eq(18_000) # 28 000 − 10 000
+      expect(stay).to be_payable_now
+    end
+
+    it "n'est plus exigible quand l'encaissé couvre l'assiette exigible (pending exclue)" do
+      Payment.create!(stay: stay, amount_cents: 28_000, status: "paid", payment_method: "card")
+      expect(stay.balance_due_cents).to eq(0)
+      expect(stay).not_to be_payable_now
+    end
+
+    it "distingue TOTAL PRÉVU (amount_due, pending inclus) et EXIGIBLE (balance_due, pending exclu)" do
+      Payment.create!(stay: stay, amount_cents: 28_000, status: "paid", payment_method: "card")
+      # Exigible couvert…
+      expect(stay.balance_due_cents).to eq(0)
+      # …mais le total prévu (qui compte la pending) montre encore 6 500 à venir.
+      expect(stay.amount_due_cents).to eq(6_500)
+    end
+
+    it "marque le séjour paid dès que l'exigible est couvert, malgré une activité pending restante" do
+      Payment.create!(stay: stay, amount_cents: 28_000, status: "paid", payment_method: "card")
+      stay.set_payment_status
+      expect(stay.reload.payment_status).to eq("paid")
+    end
+  end
 end

--- a/spec/requests/public/stay_balance_payments_spec.rb
+++ b/spec/requests/public/stay_balance_payments_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+# Epic #55, Phase 3 — POST /sejour/:token/payer-le-solde.
+# Canal public scellé par le JETON du séjour (pas de Devise). Réutilise le
+# mécanisme Stripe Checkout de l'acompte : on stubbe la session et on vérifie
+# la redirection + le Payment créé.
+RSpec.describe "Public::StayBalancePayments (POST /sejour/:token/payer-le-solde)", type: :request do
+  let(:customer) { Customer.create!(email: "solde-req@example.com", customer_type: "individual") }
+
+  let(:booking) do
+    Booking.create!(firstname: "Sol", lastname: "Débiteur", from_date: Date.today + 10,
+                    to_date: Date.today + 12, adults: 2, status: "confirmed",
+                    booking_type: "lodging", price_cents: 40_000)
+  end
+
+  let(:stay) do
+    s = Stay.create!(customer: customer, status: "pending", total_amount_cents: 40_000,
+                     arrival_date: Date.today + 10, departure_date: Date.today + 12)
+    s.stay_items.create!(bookable: booking)
+    s
+  end
+
+  before do
+    allow(StripeService.instance).to receive(:create_checkout_session)
+      .and_return(OpenStruct.new(url: "https://checkout.stripe.test/solde-req"))
+  end
+
+  it "crée un paiement du solde exigible et redirige vers Stripe Checkout" do
+    expect {
+      post "/sejour/#{stay.token}/payer-le-solde"
+    }.to change { stay.payments.pending.count }.by(1)
+
+    expect(response).to redirect_to("https://checkout.stripe.test/solde-req")
+    expect(stay.payments.pending.order(:created_at).last.amount_cents).to eq(40_000)
+  end
+
+  it "ne facture que l'exigible : activités confirmées incluses, pending exclues" do
+    experience = Experience.create!(name: "Sauna", fixed_price_cents: 3_000, price_cents: 0)
+    availability = ExperienceAvailability.create!(experience: experience, available_on: Date.today + 11, starts_at: "18:00")
+    ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "confirmed") # 3 000
+    ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "pending")   # 3 000 exclu
+    stay.recompute_aggregates! # total prévu = 40 000 + 3 000 + 3 000 = 46 000
+
+    post "/sejour/#{stay.token}/payer-le-solde"
+
+    # Exigible = 40 000 (héberg.) + 3 000 (confirmée) = 43 000 (pending 3 000 exclue).
+    expect(stay.payments.pending.order(:created_at).last.amount_cents).to eq(43_000)
+  end
+
+  it "redirige vers la page séjour avec une alerte quand rien n'est exigible" do
+    Payment.create!(stay: stay, amount_cents: 40_000, status: "paid", payment_method: "card")
+
+    post "/sejour/#{stay.token}/payer-le-solde"
+
+    expect(response).to redirect_to(public_stay_path(stay.token))
+    expect(flash[:alert]).to be_present
+  end
+
+  it "renvoie 404 sur un jeton inconnu (pas d'énumération d'IDs)" do
+    post "/sejour/jeton-bidon/payer-le-solde"
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/public/stays_spec.rb
+++ b/spec/requests/public/stays_spec.rb
@@ -59,4 +59,46 @@ RSpec.describe "Public::Stays (/sejour/:token)", type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  # Epic #55, Phase 3 — ventilation exigible + bouton « Payer le solde ».
+  describe "solde exigible (/sejour/:token)" do
+    it "affiche le bouton « Payer le solde » quand l'exigible > 0 et aucun paiement en attente" do
+      get "/sejour/#{stay.token}"
+
+      expect(response.body).to include('data-stay-balance="true"')
+      expect(response.body).to include('data-stay-balance-cta="true"')
+      expect(response.body).to include(public_stay_balance_payment_path(stay.token))
+    end
+
+    it "masque le bouton quand l'exigible est nul (séjour soldé)" do
+      Payment.create!(booking: booking, stay: stay, amount_cents: 48_500, status: "paid", payment_method: "card")
+
+      get "/sejour/#{stay.token}"
+
+      expect(response.body).not_to include('data-stay-balance-cta="true"')
+    end
+
+    it "masque le bouton quand un paiement est déjà en attente (l'acompte a son propre CTA)" do
+      Payment.create!(booking: booking, stay: stay, amount_cents: 24_250, status: "pending", payment_method: "card")
+
+      get "/sejour/#{stay.token}"
+
+      expect(response.body).not_to include('data-stay-balance-cta="true"')
+      # Le CTA générique de l'acompte, lui, reste présent.
+      expect(response.body).to include('data-stay-payments="pending"')
+    end
+
+    it "distingue les activités validées (exigibles) des activités en attente (non exigibles)" do
+      experience = Experience.create!(name: "Sauna", fixed_price_cents: 3_000, price_cents: 0)
+      availability = ExperienceAvailability.create!(experience: experience, available_on: Date.today + 11, starts_at: "18:00")
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "confirmed")
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "pending")
+      stay.recompute_aggregates!
+
+      get "/sejour/#{stay.token}"
+
+      expect(response.body).to include('data-balance-pending="true"')
+      expect(response.body).to include(I18n.t("public.stays.balance.experiences_confirmed"))
+    end
+  end
 end

--- a/spec/services/payments/create_balance_service_spec.rb
+++ b/spec/services/payments/create_balance_service_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+# Epic #55, Phase 3 — paiement du SOLDE exigible du séjour.
+#
+# Le montant réglé = montant EXIGIBLE = (hébergement/espaces + activités
+# CONFIRMED) − encaissé. Les activités `pending` (non validées) en sont exclues.
+# On n'appelle jamais Stripe : on stubbe la session de checkout (même mécanisme
+# que l'acompte, epic #26) et on inspecte le Payment créé + le montant transmis.
+#
+# NB : on pose `total_amount_cents` DIRECTEMENT (= « total prévu » = hébergement
+# + activités actives) plutôt que via `recompute_aggregates!`, pour tester le
+# calcul de l'exigible sans dépendre d'items d'hébergement réels.
+RSpec.describe Payments::CreateBalanceService do
+  let(:customer) { Customer.create!(email: "solde@example.com", customer_type: "individual") }
+
+  let(:experience) { Experience.create!(name: "Atelier pain", fixed_price_cents: 5_000, price_cents: 1_500) }
+  let(:availability) do
+    ExperienceAvailability.create!(experience: experience, available_on: Date.new(2026, 7, 10), starts_at: "10:00")
+  end
+
+  def build_stay(total_cents:)
+    Stay.create!(customer: customer, source: "reservation", status: "pending",
+                 total_amount_cents: total_cents,
+                 arrival_date: Date.new(2026, 7, 1), departure_date: Date.new(2026, 7, 3))
+  end
+
+  def stub_checkout!
+    fake_session = double("checkout_session", url: "https://checkout.stripe.test/solde")
+    allow(StripeService.instance).to receive(:create_checkout_session).and_return(fake_session)
+  end
+
+  describe "calcul du montant exigible" do
+    it "facture hébergement + activités CONFIRMED, exclut les PENDING, déduit l'encaissé" do
+      # Total prévu = 20 000 (héberg.) + 8 000 (confirmée) + 6 500 (pending) = 34 500.
+      stay = build_stay(total_cents: 34_500)
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "confirmed") # 5 000 + 1 500×2 = 8 000
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 1, status: "pending")   # 5 000 + 1 500   = 6 500
+      Payment.create!(stay: stay, amount_cents: 10_000, status: "paid", payment_method: "card")
+
+      stub_checkout!
+      service = described_class.new(stay: stay.reload)
+      expect(service.run).to be(true)
+
+      # Exigible = (34 500 − 6 500 pending) − 10 000 encaissé = 18 000.
+      expect(service.payment.amount_cents).to eq(18_000)
+      expect(service.payment.stay_id).to eq(stay.id)
+      expect(service.payment.status).to eq("pending")
+      expect(service.checkout_session_url).to eq("https://checkout.stripe.test/solde")
+    end
+
+    it "n'exige rien quand seules des activités PENDING restent une fois l'exigible réglé" do
+      # Total prévu = 20 000 (héberg.) + 6 500 (pending) = 26 500.
+      stay = build_stay(total_cents: 26_500)
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 1, status: "pending")
+      Payment.create!(stay: stay, amount_cents: 20_000, status: "paid", payment_method: "card")
+
+      # Exigible = (26 500 − 6 500 pending) − 20 000 encaissé = 0.
+      expect(stay.reload.balance_due_cents).to eq(0)
+
+      service = described_class.new(stay: stay)
+      expect(service.run).to be(false)
+      expect(service.error_message).to match(/soldé|exigible/i)
+    end
+  end
+
+  describe "réutilisation / création du paiement" do
+    it "crée un unique paiement pending ancré sur le Stay" do
+      stay = build_stay(total_cents: 30_000)
+      stub_checkout!
+
+      expect {
+        expect(described_class.new(stay: stay).run).to be(true)
+      }.to change { stay.payments.pending.count }.by(1)
+    end
+
+    it "réutilise le paiement pending existant en réalignant son montant (anti-doublon)" do
+      stay = build_stay(total_cents: 30_000)
+      existing = Payment.create!(stay: stay, amount_cents: 12_000, status: "pending", payment_method: "card")
+      stub_checkout!
+
+      expect {
+        described_class.new(stay: stay.reload).run
+      }.not_to change { stay.payments.pending.count }
+
+      expect(existing.reload.amount_cents).to eq(30_000)
+    end
+  end
+end

--- a/spec/services/webhooks/stripe_service_spec.rb
+++ b/spec/services/webhooks/stripe_service_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+# Epic #55, Phase 3 — le webhook Stripe encaisse le SOLDE d'un séjour.
+#
+# Le paiement du solde réutilise TEL QUEL le mécanisme de l'acompte (epic #26) :
+# `checkout.session.completed` → `Webhooks::StripeService` → marque le Payment
+# `paid` et recalcule le statut du séjour. L'idempotence est garantie par
+# `StripeEvent` (dédup sur `webhook_id`) : un même événement rejoué n'a aucun
+# effet de bord (Stripe rejoue en cas de timeout/retry).
+RSpec.describe Webhooks::StripeService do
+  let(:customer) { Customer.create!(email: "hook-solde@example.com", customer_type: "individual") }
+
+  let(:booking) do
+    Booking.create!(firstname: "Sol", from_date: Date.today + 10, to_date: Date.today + 12,
+                    adults: 2, status: "confirmed", price_cents: 40_000, payment_status: "pending")
+  end
+
+  let(:stay) do
+    s = Stay.create!(customer: customer, source: "reservation", status: "pending",
+                     total_amount_cents: 40_000)
+    s.stay_items.create!(bookable: booking)
+    s
+  end
+
+  # Paiement du SOLDE (ancré sur le Stay), en attente d'encaissement.
+  let(:balance_payment) do
+    Payment.create!(stay: stay, booking: booking, amount_cents: 40_000,
+                    status: "pending", payment_method: "card")
+  end
+
+  # Fabrique un faux événement Stripe. `data.object` doit répondre à la fois à
+  # `[:client_reference_id]` (accès hash) ET à `.id` / `.payment_intent`
+  # (méthodes) — c'est ce que le service consomme.
+  def fake_event(webhook_id:, client_reference_id:)
+    object = double("object", id: "cs_test_#{webhook_id}", payment_intent: "pi_test_#{webhook_id}")
+    allow(object).to receive(:[]).with(:client_reference_id).and_return(client_reference_id)
+    data = double("data", object: object)
+    double("event", id: webhook_id, type: "checkout.session.completed", data: data)
+  end
+
+  it "encaisse le solde : Payment payé + séjour marqué payé" do
+    event = fake_event(webhook_id: "evt_solde_1", client_reference_id: balance_payment.id)
+
+    described_class.new(event: event).run!
+
+    expect(balance_payment.reload.status).to eq("paid")
+    expect(balance_payment.stripe_payment_intent_id).to eq("pi_test_evt_solde_1")
+    expect(stay.reload.payment_status).to eq("paid")
+    expect(StripeEvent.where(webhook_id: "evt_solde_1").count).to eq(1)
+  end
+
+  it "est idempotent : un même événement rejoué n'a aucun effet de bord" do
+    event = fake_event(webhook_id: "evt_solde_dup", client_reference_id: balance_payment.id)
+
+    described_class.new(event: event).run!
+    first_paid_at = balance_payment.reload.updated_at
+
+    # Rejeu du MÊME webhook_id.
+    expect {
+      described_class.new(event: event).run!
+    }.not_to change { StripeEvent.where(webhook_id: "evt_solde_dup").count }
+
+    # Le paiement n'est pas re-traité (pas de nouvelle écriture).
+    expect(balance_payment.reload.updated_at).to eq(first_paid_at)
+    expect(StripeEvent.where(webhook_id: "evt_solde_dup").count).to eq(1)
+  end
+
+  it "marque partially_paid quand le solde encaissé ne couvre pas encore l'exigible" do
+    partial = Payment.create!(stay: stay, booking: booking, amount_cents: 25_000,
+                              status: "pending", payment_method: "card")
+    event = fake_event(webhook_id: "evt_partiel", client_reference_id: partial.id)
+
+    described_class.new(event: event).run!
+
+    expect(stay.reload.payment_status).to eq("partially_paid")
+  end
+end


### PR DESCRIPTION
Phase 3 de l'epic #55. **Empilée sur #57 (Phase 2)**. ⚠️ **Touche le paiement Stripe — review attentive requise avant merge/déploiement.**

## Ce que fait cette PR
- **Sémantique « total prévu » vs « exigible »** (dans `Stay`) : `payable_amount_cents` = total prévu − activités `pending` (exclues) ; les `confirmed` sont incluses. `balance_due_cents` = exigible − encaissé. `set_payment_status` passe `paid` dès `balance_due_cents ≤ 0`. **Non-régression epic #26 prouvée** : sans activité pending, `balance_due_cents == amount_due_cents`.
- **Page `/sejour/:token`** : bloc `_balance` (ventilation acompte payé / solde hébergement / activités validées / pending non exigibles) + bouton « Payer le solde » (visible si exigible > 0 et pas de pending déjà en attente).
- **Checkout Stripe du solde** : réutilise **intégralement** l'acompte existant — `Payments::CreateBalanceService` → `Payments::PayService` → `StripeService.create_checkout_session`. Le `Payment` est ancré au Stay (`stay_id`). **Aucun code webhook neuf** : `checkout.session.completed` retrouve le Payment via `client_reference_id` et recalcule le statut. Pas de migration.
- **Sécurité** : autorisation par token seul (`find_by!(token:)`, 404 sinon, pas d'énumération d'ID) ; montant recalculé côté serveur ; idempotence webhook via dédup `StripeEvent`.

## Vérification
- `bundle exec rspec` : **474 ex, 0 failure**, 18 pending (+20 specs : exigible, page client, checkout solde, webhook idempotent + paiement partiel). Parité i18n fr/nl/en verte.

## ⚠️ Limites honnêtes (paiement — à valider avant prod)
- **Redirection Stripe réelle + retour** : stubbée dans les specs (comme l'acompte existant), pas exercée end-to-end.
- **Webhook signé réel** : la vérif de signature + le POST HTTP réel ne sont pas couverts (inchangés, déjà en prod pour l'acompte). Les specs testent `Webhooks::StripeService` avec événement doublé.
- **Concurrence webhook** : idempotence applicative via `StripeEvent` (robuste au rejeu séquentiel Stripe), pas de contrainte DB unique sur `webhook_id` → non blindé contre un double-traitement strictement concurrent.
- **Non vérifié au navigateur** : request specs assertent le HTML réel, mais le rendu visuel/mobile du bloc solde et le clic réel restent à valider (recommandé sur compte Stripe test). *S'ajoute à la dette navigateur Phases 1-2.*

## Notes
- Implémentée par Engineer. Déploiement Hatchbox manuel : merger ≠ déployer.

Refs #55