### PR TITLE
feat(activités): Phase 4 — sélection d'activités dans le funnel /reservation (4 étapes)

### DIFF
--- a/app/controllers/public/reservations_controller.rb
+++ b/app/controllers/public/reservations_controller.rb
@@ -1,16 +1,17 @@
 module Public
-  # Funnel B2C natif /reservation — 3 étapes (tranche 2).
-  #   1. dates     — dates du séjour + groupe + animal
-  #   2. compose   — composition : hébergement, espaces, camping, hamacs
-  #   3. contact   — coordonnées client → commit + Stripe
+  # Funnel B2C natif /reservation — 4 étapes (tranche 2 + epic #55 Phase 4).
+  #   1. dates      — dates du séjour + groupe + animal
+  #   2. compose    — composition : hébergement, espaces, camping, hamacs
+  #   3. activities — activités : créneaux datés dans la fenêtre du séjour (Phase 4)
+  #   4. contact    — coordonnées client → commit + Stripe
   class ReservationsController < Public::BaseController
     layout "public_sheet"
 
     DRAFT_SESSION_KEY = :reservation_draft
     HALL_SLOT_COUNT   = 6
 
-    before_action :load_draft, only: %i[dates advance_dates compose quote advance_contact activities contact create]
-    skip_before_action :verify_authenticity_token, only: %i[advance_contact]
+    before_action :load_draft, only: %i[dates advance_dates compose quote advance_compose activities advance_activities contact create]
+    skip_before_action :verify_authenticity_token, only: %i[advance_compose]
 
     def start
       redirect_to public_reservation_dates_path
@@ -55,14 +56,31 @@ module Public
       @lodging_availability  = build_stay_availability(@lodgings, @stay_nights)
     end
 
-    # Étape activités (accès via email token — pas dans le funnel direct).
+    # Étape 3 — activités (epic #55, Phase 4). Contrairement au rail email
+    # (ActivitySelections), l'utilisateur choisit ici un CRÉNEAU précis
+    # (`ExperienceAvailability`) dans la fenêtre `[arrivée, départ)` de son
+    # séjour : un `ExperienceBooking` exige un créneau daté (NOT NULL). On
+    # n'affiche donc que les Experiences ayant au moins un créneau non complet
+    # dans cette fenêtre. Étape toujours franchissable — la relance email
+    # (Phase 5) couvrira les activités hors fenêtre / ajoutées après coup.
     def activities
-      @experiences = bookable_experiences
-      @quote = @draft.quote
+      @availabilities = bookable_availabilities.reject(&:full?)
+      @quote          = @draft.quote
     end
 
-    # Transition étape 2 → 3 (advance depuis le Stimulus quote controller).
-    def advance_contact
+    # Transition étape 2 → 3 (advance depuis le Stimulus quote controller ou le
+    # fallback noscript). Le draft est déjà persisté par le POST /devis à chaque
+    # changement ; on reçoit ici l'ultime état de composition avant les activités.
+    def advance_compose
+      persist_draft(merged_draft_params)
+      redirect_to public_reservation_activities_path
+    end
+
+    # Transition étape 3 → 4 : persiste les sélections de créneau (chaque entrée
+    # porte `id` = experience_id, `availability_id` = créneau daté et
+    # `participants`) puis passe aux coordonnées. Les entrées sans participant
+    # sont écartées par `merged_draft_params`.
+    def advance_activities
       persist_draft(merged_draft_params)
       redirect_to public_reservation_contact_path
     end
@@ -166,7 +184,7 @@ module Public
         meals: [:kind, :people], halls: [:kind, :date, :period],
         campings: [:kind, :people, :nights], vans: [:nights],
         pizza_parties: [:people], hamacs: [:kind, :count],
-        experiences: [:id, :participants]
+        experiences: [:id, :availability_id, :participants]
       ).to_h
       %i[meals halls campings vans pizza_parties hamacs experiences].each do |key|
         next unless permitted[key].is_a?(Hash)
@@ -200,13 +218,25 @@ module Public
       end
     end
 
-    def bookable_experiences
-      Experience.where(deleted_at: nil).where.not(name: "Pizza Party").order(:name)
-    end
-
     def bookable_lodgings
       names = ["La Hulotte", "La Chevêche", "Le Grand-Duc"]
       Lodging.where(name: names).sort_by { |l| names.index(l.name) || 99 }
+    end
+
+    # Créneaux d'activité réservables au funnel : ceux qui tombent dans la
+    # fenêtre `[arrivée, départ)` du séjour en cours, hors « Pizza Party » (gérée
+    # à part) et hors activités supprimées. Le tri experience/date/heure permet
+    # de les regrouper par activité dans la vue. Sans dates, aucune activité.
+    def bookable_availabilities
+      return ExperienceAvailability.none if @draft.arrival_date.blank? || @draft.departure_date.blank?
+
+      ExperienceAvailability
+        .includes(:experience, :experience_bookings)
+        .where(available_on: @draft.arrival_date...@draft.departure_date)
+        .joins(:experience)
+        .where(experiences: { deleted_at: nil })
+        .where.not(experiences: { name: "Pizza Party" })
+        .order(:available_on, :starts_at)
     end
 
     # Construit les données pour le Gantt calendrier des disponibilités (1 mois).

--- a/app/frontend/controllers/public/reservation_quote_controller.js
+++ b/app/frontend/controllers/public/reservation_quote_controller.js
@@ -5,7 +5,7 @@ import { Controller } from "@hotwired/stimulus"
 // formulaire de devis qui répond en Turbo Stream et remplace le panneau.
 export default class extends Controller {
   static targets = ["form"]
-  static values  = { url: String, contactUrl: String }
+  static values  = { url: String, nextUrl: String }
 
   refresh() {
     if (this.hasFormTarget) {
@@ -14,12 +14,12 @@ export default class extends Controller {
   }
 
   // Sauvegarde le draft via quote (même token CSRF que le formulaire) puis
-  // navigue vers l'étape coordonnées. Évite le problème per-form CSRF token
-  // que poserait un formaction vers un endpoint différent.
+  // navigue vers l'étape suivante (les activités — epic #55 Phase 4). Évite le
+  // problème per-form CSRF token que poserait un formaction vers un autre endpoint.
   advance(event) {
     event.preventDefault()
     if (!this.hasFormTarget) {
-      window.location.href = this.contactUrlValue
+      window.location.href = this.nextUrlValue
       return
     }
     const form = this.formTarget
@@ -28,9 +28,9 @@ export default class extends Controller {
       body: new FormData(form),
       headers: { "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content }
     }).then(() => {
-      window.location.href = this.contactUrlValue
+      window.location.href = this.nextUrlValue
     }).catch(() => {
-      window.location.href = this.contactUrlValue
+      window.location.href = this.nextUrlValue
     })
   }
 }

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -47,11 +47,12 @@ module Reservations
         # via lodging_id + dates. Un séjour sans hébergement (camping, espaces)
         # n'en crée donc plus : le « Booking fantôme » disparaît.
         @booking = draft.lodging.present? ? build_booking!(quote) : nil
-        # Fix « montant fantôme » de l'acompte (epic #55, Phase 1) : le total
-        # persisté et l'acompte EXCLUENT les activités. Tant qu'aucun
-        # ExperienceBooking n'est créé (phases suivantes), les activités
-        # n'entrent NI dans l'acompte NI dans le total du Stay ; elles y
-        # entreront via `Stay#recompute_aggregates!` une fois réservées.
+        # Assiette de l'acompte (epic #55, Phase 1) : l'acompte EXCLUT toujours
+        # les activités — on ne demande pas d'avance sur des créneaux pas encore
+        # validés par le porteur (Phase 2). Le TOTAL PRÉVU du Stay, lui, agrège
+        # l'hébergement/espaces + les activités `pending` créées ci-dessous
+        # (sémantique `total_amount_cents` du modèle Stay). Le solde des activités
+        # partira au paiement du solde (Phase 3), une fois le porteur validé.
         @stay = Stay.create!(
           customer: @customer,
           source: "reservation",
@@ -62,8 +63,17 @@ module Reservations
           notes: internal_notes
         )
         @stay.stay_items.create!(bookable: @booking) if @booking
+        # Sélections d'activités du funnel (epic #55, Phase 4) : chaque créneau
+        # choisi devient un ExperienceBooking `pending` rattaché au Stay — de la
+        # MÊME nature que ceux du rail email, donc soumis à la validation porteur.
+        # On réintègre leur montant au total prévu (mais JAMAIS à l'acompte).
+        experiences_total = create_experience_bookings!(@stay)
+        if experiences_total.positive?
+          @stay.update!(total_amount_cents: quote.total_excluding_experiences_cents + experiences_total)
+        end
         # Le paiement est rattaché au Stay dans tous les cas ; le booking n'est
-        # plus qu'une référence de commodité pour le canal historique.
+        # plus qu'une référence de commodité pour le canal historique. Son montant
+        # reste l'acompte HORS activités (`quote.deposit_cents`).
         @payment = Payment.create!(
           booking: @booking,
           stay: @stay,
@@ -119,6 +129,29 @@ module Reservations
       customer.phone = draft.phone if customer.phone.blank?
       customer.save!
       customer
+    end
+
+    # Persiste les sélections de créneau du draft (epic #55, Phase 4) en
+    # `ExperienceBooking` `pending`, dans la transaction courante. Chaque entrée
+    # porte `availability_id` = `ExperienceAvailability` (créneau daté, NOT NULL)
+    # et `participants`. Les entrées sans créneau (ancienne forme
+    # `experiences: [{id, participants}]`, rétrocompat / pricing) sont ignorées :
+    # un ExperienceBooking exige un créneau. Retourne la somme des montants TVAC
+    # des activités créées, pour réintégration au total prévu du Stay.
+    def create_experience_bookings!(stay)
+      Array(draft.experiences).sum(0) do |entry|
+        avail_id     = entry[:availability_id].presence
+        participants = entry[:participants].to_i
+        next 0 if avail_id.blank? || participants < 1
+
+        booking = ExperienceBooking.create!(
+          stay_id: stay.id,
+          experience_availability_id: avail_id,
+          participants: participants,
+          status: "pending"
+        )
+        booking.price_cents
+      end
     end
 
     def build_booking!(quote)

--- a/app/views/public/reservations/_quote_panel.html.slim
+++ b/app/views/public/reservations/_quote_panel.html.slim
@@ -1,4 +1,9 @@
-/ Panneau devis — sticky sur desktop, visible sur mobile avant le CTA
+/ Panneau devis — sticky sur desktop, visible sur mobile avant le CTA.
+/ `continue_path` / `continue_label` (optionnels) pilotent le CTA « Continuer » :
+/ vers les activités depuis la composition, vers les coordonnées depuis les
+/ activités. Passer `continue_path: nil` masque le CTA (ex. sur l'étape finale).
+- continue_path  = local_assigns.fetch(:continue_path, public_reservation_contact_path)
+- continue_label = local_assigns.fetch(:continue_label, "Continuer vers mes coordonnées →")
 - includes_nye = draft.arrival_date.present? && draft.departure_date.present? && (draft.arrival_date..draft.departure_date).any? { |d| d.month == 12 && d.day == 31 }
 
 .sticky.top-6
@@ -35,7 +40,7 @@
       .px-5.pb-4
         p.text-xs.text-gray-400 Tous les prix sont TVAC 0 % — aucune TVA supplémentaire.
 
-  - if quote.total_cents.positive?
-    = link_to "Continuer vers mes coordonnées →", public_reservation_contact_path,
+  - if quote.total_cents.positive? && continue_path
+    = link_to continue_label, continue_path,
         class: "mt-4 block text-center rounded-xl bg-emerald-600 text-white px-4 py-3 text-sm font-semibold hover:bg-emerald-700 shadow-sm transition-colors",
         data: { turbo_frame: "_top" }

--- a/app/views/public/reservations/_step_indicator.html.slim
+++ b/app/views/public/reservations/_step_indicator.html.slim
@@ -1,0 +1,21 @@
+/ Step indicator partagé du funnel /reservation — 4 étapes (epic #55, Phase 4).
+/ `current` = numéro de l'étape active (1..4). Les étapes déjà franchies sont
+/ cliquables (retour en arrière) ; l'étape active et les suivantes ne le sont pas.
+- steps = [{ n: 1, label: "Votre séjour", path: public_reservation_dates_path }, { n: 2, label: "Composition", path: public_reservation_compose_path }, { n: 3, label: "Activités", path: public_reservation_activities_path }, { n: 4, label: "Coordonnées", path: public_reservation_contact_path }]
+.flex.items-center.mb-10
+  - steps.each_with_index do |step, idx|
+    - unless idx.zero?
+      .flex-1.h-px.mx-4 class=(step[:n] <= current ? "bg-emerald-200" : "bg-gray-200")
+    - if step[:n] < current
+      .flex.items-center.flex-shrink-0
+        = link_to step[:path], class: "flex items-center group relative before:content-[''] before:absolute before:-inset-1" do
+          .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-100.text-emerald-700.border-2.border-emerald-400.group-hover:border-emerald-600.transition-colors ✓
+          span.ml-2.text-sm.text-emerald-600.hidden.sm:inline.group-hover:underline = step[:label]
+    - elsif step[:n] == current
+      .flex.items-center.flex-shrink-0
+        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-600.text-white.shadow-sm = step[:n]
+        span.ml-2.text-sm.font-semibold.text-emerald-700.hidden.sm:inline = step[:label]
+    - else
+      .flex.items-center.flex-shrink-0
+        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.border-2.border-gray-200.bg-white.text-gray-400 = step[:n]
+        span.ml-2.text-sm.text-gray-400.hidden.sm:inline = step[:label]

--- a/app/views/public/reservations/activities.html.slim
+++ b/app/views/public/reservations/activities.html.slim
@@ -1,54 +1,82 @@
-.max-w-4xl.mx-auto.py-8
-  .mb-4
-    = link_to "← Modifier ma réservation", public_reservation_compose_path, class: "text-sm text-gray-500 hover:text-gray-700"
+/ Étape 3/4 — Activités (epic #55, Phase 4)
+.min-h-screen.bg-gray-50
+  .max-w-5xl.mx-auto.px-4.py-10
 
-  h1.text-2xl.font-semibold.mb-2 Activités
+    / ── Step indicator ───────────────────────────────────────
+    = render "public/reservations/step_indicator", current: 3
 
-  p.text-sm.text-gray-500.mb-6 Vous pouvez ajouter des activités à votre séjour. Notre équipe vous confirmera les disponibilités.
+    / ── Titre ────────────────────────────────────────────────
+    .mb-8
+      h1.text-2xl.font-bold.text-gray-900 Des activités pendant votre séjour ?
+      p.text-sm.text-gray-500.mt-1
+        | Choisissez un créneau dans les dates de votre séjour. Notre équipe confirmera
+        | les disponibilités avec les animateurs·ices — les activités ne sont pas comprises
+        | dans l'acompte.
 
-  = render "public/reservations/stay_summary", draft: @draft
+    / ── Résumé dates ─────────────────────────────────────────
+    - if @draft.arrival_date && @draft.departure_date
+      .flex.items-center.gap-2.mb-6.text-sm.text-gray-600.bg-white.rounded-xl.px-4.py-3.border.border-gray-100.shadow-sm.w-fit
+        span 📅
+        strong = l(@draft.arrival_date, format: :long)
+        span.text-gray-400 →
+        strong = l(@draft.departure_date, format: :long)
+        = link_to "Modifier", public_reservation_compose_path, class: "ml-2 text-xs text-gray-400 hover:text-gray-600 underline"
 
-  .grid.gap-8.lg:grid-cols-3
-    .lg:col-span-2
-      = form_with url: public_reservation_advance_contact_path, method: :post do |f|
+    .grid.gap-8.lg:grid-cols-3
+      .lg:col-span-2
 
-        - if @experiences.empty?
-          p.text-sm.text-gray-400.italic Aucune activité disponible actuellement.
+        - if @availabilities.empty?
+          / ── Aucun créneau dans la fenêtre — étape franchissable ──
+          .rounded-2xl.border.border-gray-200.bg-white.p-8.text-center
+            p.text-gray-500 Aucune activité n'est programmée sur vos dates pour le moment.
+            p.text-sm.text-gray-400.mt-2
+              | Pas d'inquiétude : nous vous enverrons un lien pour choisir vos activités
+              | avant votre arrivée.
+          .mt-6.flex.justify-end
+            = link_to "Continuer vers mes coordonnées →", public_reservation_contact_path,
+                class: "rounded-lg bg-emerald-600 text-white px-6 py-3 text-sm font-medium hover:bg-emerald-700"
 
-        - @experiences.each_with_index do |exp, i|
-          - selected_entry = @draft.experiences.find { |e| e[:id].to_s == exp.id.to_s }
-          - selected_participants = selected_entry&.dig(:participants).to_i
+        - else
+          = form_with url: public_reservation_advance_activities_path, method: :post do |f|
+            - idx = 0
+            - @availabilities.group_by(&:experience).each do |experience, slots|
+              .rounded-2xl.border.border-gray-100.bg-white.shadow-sm.p-5.mb-4
+                .mb-3
+                  h2.text-base.font-semibold.text-gray-900 = experience.name
+                  - if experience.summary.present?
+                    p.text-sm.text-gray-500 = experience.summary
+                  .text-sm.text-emerald-700.mt-1 = Pricing::ExperienceLine.rate_label(experience)
 
-          .rounded-lg.border.border-gray-200.p-4.mb-3
-            .flex.items-start.gap-3
-              input(
-                type="number"
-                name="reservation[experiences][#{i}][participants]"
-                value="#{selected_participants > 0 ? selected_participants : ''}"
-                min="#{exp.min_participants.presence || 1}"
-                max="#{exp.max_participants.presence || ''}"
-                placeholder="0"
-                class="w-20 rounded border-gray-300 text-center mt-0.5 shrink-0"
-              )
-              = hidden_field_tag "reservation[experiences][#{i}][id]", exp.id
-              div
-                .font-medium = exp.name
-                - if exp.summary.present?
-                  .text-sm.text-gray-500 = exp.summary
-                .text-sm.text-emerald-700.mt-1
-                  = Pricing::ExperienceLine.rate_label(exp)
-                - if exp.min_participants.present? || exp.max_participants.present?
-                  .text-xs.text-gray-400
-                    - if exp.min_participants.present? && exp.max_participants.present?
-                      = "#{exp.min_participants}–#{exp.max_participants} participants"
-                    - elsif exp.min_participants.present?
-                      = "Min. #{exp.min_participants} participants"
-                    - else
-                      = "Max. #{exp.max_participants} participants"
+                .space-y-2
+                  - slots.each do |av|
+                    - selected_entry = @draft.experiences.find { |e| e[:availability_id].to_s == av.id.to_s }
+                    - selected_participants = selected_entry&.dig(:participants).to_i
+                    label.flex.items-center.gap-3.rounded-lg.border.border-gray-200.p-3
+                      input(
+                        type="number"
+                        name="reservation[experiences][#{idx}][participants]"
+                        value="#{selected_participants > 0 ? selected_participants : ''}"
+                        min="#{experience.min_participants.presence || 1}"
+                        max="#{av.effective_max_participants || ''}"
+                        placeholder="0"
+                        class="w-20 rounded border-gray-300 text-center shrink-0"
+                      )
+                      = hidden_field_tag "reservation[experiences][#{idx}][id]", av.experience_id
+                      = hidden_field_tag "reservation[experiences][#{idx}][availability_id]", av.id
+                      div.flex-1
+                        .text-sm.font-medium.text-gray-900
+                          = l(av.available_on, format: :long).capitalize
+                        .text-sm.text-gray-600
+                          span.font-medium = av.starts_at
+                          - if av.ends_at
+                            | → #{av.ends_at}
+                          - if av.effective_max_participants
+                            span.text-gray-400.ml-2 = "(max #{av.effective_max_participants} pers.)"
+                    - idx += 1
 
-        .mt-6.flex.justify-between.items-center
-          = link_to "Passer cette étape", public_reservation_contact_path, class: "text-sm text-gray-400 hover:text-gray-600"
-          = f.submit "Continuer →", class: "rounded-lg bg-emerald-600 text-white px-6 py-3 text-sm font-medium hover:bg-emerald-700 cursor-pointer"
+            .mt-6.flex.justify-between.items-center
+              = link_to "Passer cette étape", public_reservation_contact_path, class: "text-sm text-gray-400 hover:text-gray-600"
+              = f.submit "Continuer vers mes coordonnées →", class: "rounded-lg bg-emerald-600 text-white px-6 py-3 text-sm font-medium hover:bg-emerald-700 cursor-pointer"
 
-    aside.lg:col-span-1
-      = render "public/reservations/quote_panel", quote: @quote, draft: @draft
+      aside.lg:col-span-1
+        = render "public/reservations/quote_panel", quote: @quote, draft: @draft, continue_path: nil

--- a/app/views/public/reservations/compose.html.slim
+++ b/app/views/public/reservations/compose.html.slim
@@ -2,22 +2,10 @@
 .min-h-screen.bg-gray-50(data-controller="public--avail-modal")
   .max-w-3xl.mx-auto.px-4.py-10(data-controller="public--reservation-quote"
     data-public--reservation-quote-url-value=public_reservation_quote_path
-    data-public--reservation-quote-contact-url-value=public_reservation_contact_path)
+    data-public--reservation-quote-next-url-value=public_reservation_activities_path)
 
     / ── Step indicator ───────────────────────────────────────
-    .flex.items-center.mb-10
-      .flex.items-center.flex-shrink-0
-        = link_to public_reservation_dates_path, class: "flex items-center group relative before:content-[''] before:absolute before:-inset-1" do
-          .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-100.text-emerald-700.border-2.border-emerald-400.group-hover:border-emerald-600.transition-colors ✓
-          span.ml-2.text-sm.text-emerald-600.hidden.sm:inline.group-hover:underline Votre séjour
-      .flex-1.h-px.mx-4.bg-emerald-200
-      .flex.items-center.flex-shrink-0
-        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-600.text-white.shadow-sm 2
-        span.ml-2.text-sm.font-semibold.text-emerald-700.hidden.sm:inline Composition
-      .flex-1.h-px.mx-4.bg-gray-200
-      .flex.items-center.flex-shrink-0
-        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.border-2.border-gray-200.bg-white.text-gray-400 3
-        span.ml-2.text-sm.text-gray-400.hidden.sm:inline Coordonnées
+    = render "public/reservations/step_indicator", current: 2
 
     / ── Résumé dates ─────────────────────────────────────────
     - if @draft.arrival_date && @draft.departure_date
@@ -71,9 +59,9 @@
         / CTA
         .flex.justify-end.mt-2
           button type="button" data-action="public--reservation-quote#advance" class="rounded-xl bg-emerald-600 text-white px-8 py-3 text-sm font-semibold hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 shadow-sm transition-colors"
-            | Continuer vers mes coordonnées →
+            | Continuer vers les activités →
         noscript
-          = f.submit "Continuer (sans JS)", formaction: public_reservation_advance_contact_path, formmethod: :post, class: "rounded-xl bg-emerald-600 text-white px-8 py-3 text-sm font-semibold"
+          = f.submit "Continuer (sans JS)", formaction: public_reservation_advance_compose_path, formmethod: :post, class: "rounded-xl bg-emerald-600 text-white px-8 py-3 text-sm font-semibold"
 
     / ── Infos complémentaires ────────────────────────────────
     .mt-8.grid.grid-cols-1.sm:grid-cols-2.lg:grid-cols-3.gap-4
@@ -133,4 +121,4 @@
             path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"
       .p-6
         = turbo_frame_tag "reservation_quote"
-          = render "public/reservations/quote_panel", quote: @quote, draft: @draft
+          = render "public/reservations/quote_panel", quote: @quote, draft: @draft, continue_path: public_reservation_activities_path, continue_label: "Continuer vers les activités →"

--- a/app/views/public/reservations/contact.html.slim
+++ b/app/views/public/reservations/contact.html.slim
@@ -3,20 +3,7 @@
   .max-w-5xl.mx-auto.px-4.py-10
 
     / ── Step indicator ───────────────────────────────────────
-    .flex.items-center.mb-10
-      .flex.items-center.flex-shrink-0
-        = link_to public_reservation_dates_path, class: "flex items-center group relative before:content-[''] before:absolute before:-inset-1" do
-          .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-100.text-emerald-700.border-2.border-emerald-400.group-hover:border-emerald-600.transition-colors ✓
-          span.ml-2.text-sm.text-emerald-600.hidden.sm:inline.group-hover:underline Votre séjour
-      .flex-1.h-px.mx-4.bg-emerald-200
-      .flex.items-center.flex-shrink-0
-        = link_to public_reservation_compose_path, class: "flex items-center group relative before:content-[''] before:absolute before:-inset-1" do
-          .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-100.text-emerald-700.border-2.border-emerald-400.group-hover:border-emerald-600.transition-colors ✓
-          span.ml-2.text-sm.text-emerald-600.hidden.sm:inline.group-hover:underline Composition
-      .flex-1.h-px.mx-4.bg-emerald-200
-      .flex.items-center.flex-shrink-0
-        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-600.text-white.shadow-sm 3
-        span.ml-2.text-sm.font-semibold.text-emerald-700.hidden.sm:inline Coordonnées
+    = render "public/reservations/step_indicator", current: 4
 
     / ── Titre ────────────────────────────────────────────────
     .mb-8
@@ -91,4 +78,4 @@
 
       / ── Devis sidebar ──────────────────────────────────────
       aside.lg:col-span-1
-        = render "public/reservations/quote_panel", quote: @quote, draft: @draft
+        = render "public/reservations/quote_panel", quote: @quote, draft: @draft, continue_path: nil

--- a/app/views/public/reservations/dates.html.slim
+++ b/app/views/public/reservations/dates.html.slim
@@ -3,18 +3,7 @@
   .max-w-2xl.mx-auto.px-4.py-10
 
     / ── Step indicator ───────────────────────────────────────
-    .flex.items-center.mb-10
-      .flex.items-center.flex-shrink-0
-        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.bg-emerald-600.text-white.shadow-sm 1
-        span.ml-2.text-sm.font-semibold.text-emerald-700.hidden.sm:inline Votre séjour
-      .flex-1.h-px.mx-4.bg-gray-200
-      .flex.items-center.flex-shrink-0
-        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.border-2.border-gray-200.bg-white.text-gray-400 2
-        span.ml-2.text-sm.text-gray-400.hidden.sm:inline Composition
-      .flex-1.h-px.mx-4.bg-gray-200
-      .flex.items-center.flex-shrink-0
-        .w-9.h-9.rounded-full.flex.items-center.justify-center.text-sm.font-bold.border-2.border-gray-200.bg-white.text-gray-400 3
-        span.ml-2.text-sm.text-gray-400.hidden.sm:inline Coordonnées
+    = render "public/reservations/step_indicator", current: 1
 
     / ── Titre ────────────────────────────────────────────────
     .mb-8

--- a/app/views/public/reservations/quote.turbo_stream.slim
+++ b/app/views/public/reservations/quote.turbo_stream.slim
@@ -1,6 +1,6 @@
 = turbo_stream.replace "reservation_quote" do
   = turbo_frame_tag "reservation_quote"
-    = render "public/reservations/quote_panel", quote: @quote, draft: @draft
+    = render "public/reservations/quote_panel", quote: @quote, draft: @draft, continue_path: public_reservation_activities_path, continue_label: "Continuer vers les activités →"
 
 = turbo_stream.replace "quote_total_badge" do
   span id="quote_total_badge"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,15 +135,17 @@ Rails.application.routes.draw do
 
   get "reports/lodging/:id", to: "reports#lodging", as: :lodging_reports
 
-  # Funnel B2C natif /reservation — 3 étapes (tranche 2).
-  # Étape 1 : dates + groupe + animal  →  Étape 2 : composition  →  Étape 3 : coordonnées
+  # Funnel B2C natif /reservation — 4 étapes (tranche 2 + epic #55 Phase 4).
+  # Étape 1 : dates + groupe + animal  →  Étape 2 : composition  →  Étape 3 :
+  # activités  →  Étape 4 : coordonnées
   get  "reservation",              to: "public/reservations#start",              as: :public_reservation_start
   get  "reservation/sejour",       to: "public/reservations#dates",              as: :public_reservation_dates
   post "reservation/sejour",       to: "public/reservations#advance_dates",      as: :public_reservation_advance_dates
   get  "reservation/composer",     to: "public/reservations#compose",            as: :public_reservation_compose
   post "reservation/devis",        to: "public/reservations#quote",              as: :public_reservation_quote
-  post "reservation/composer",     to: "public/reservations#advance_contact",    as: :public_reservation_advance_contact
+  post "reservation/composer",     to: "public/reservations#advance_compose",    as: :public_reservation_advance_compose
   get  "reservation/activites",    to: "public/reservations#activities",         as: :public_reservation_activities
+  post "reservation/activites",    to: "public/reservations#advance_activities", as: :public_reservation_advance_activities
   get  "reservation/coordonnees",  to: "public/reservations#contact",            as: :public_reservation_contact
   post "reservation/coordonnees",  to: "public/reservations#create",             as: :public_reservation_create
   get  "reservation/calendrier",   to: "public/reservations#availability_calendar", as: :public_reservation_availability_calendar

--- a/spec/requests/public/reservation_activities_spec.rb
+++ b/spec/requests/public/reservation_activities_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+# Epic #55, Phase 4 — étape « Activités » du funnel public /reservation, insérée
+# entre la composition et les coordonnées. L'utilisateur choisit un CRÉNEAU daté
+# (ExperienceAvailability) dans la fenêtre [arrivée, départ) de son séjour ; la
+# sélection survit en session jusqu'au commit, où elle devient un
+# ExperienceBooking `pending` rattaché au Stay.
+RSpec.describe "Public::Reservations — étape activités (/reservation/activites)", type: :request do
+  let!(:hulotte) do
+    l = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    l.rooms << Room.create!(name: "Chambre 1", level: 1)
+    l
+  end
+
+  # Fenêtre du séjour : [today+40, today+43) → nuits 40, 41, 42.
+  let(:arrival)   { Date.today + 40 }
+  let(:departure) { Date.today + 43 }
+
+  let!(:experience)       { Experience.create!(name: "Balade avec les ânes", fixed_price_cents: 2_000, price_cents: 1_000, max_participants: 8) }
+  let!(:other_experience) { Experience.create!(name: "Atelier forge", price_cents: 4_000) }
+
+  # Créneau DANS la fenêtre (jour intermédiaire).
+  let!(:slot_in)  { ExperienceAvailability.create!(experience: experience, available_on: arrival + 1, starts_at: "10:00", max_participants: 8) }
+  # Créneau HORS fenêtre : le jour du départ est exclu ([arrivée, départ)).
+  let!(:slot_out) { ExperienceAvailability.create!(experience: other_experience, available_on: departure, starts_at: "10:00") }
+
+  # Amorce le draft en session avec les dates du séjour (étape 1).
+  def seed_dates
+    post "/reservation/sejour", params: { reservation: { arrival_date: arrival.iso8601, departure_date: departure.iso8601, adults: 2 } }
+  end
+
+  describe "GET /reservation/activites (affichage selon la fenêtre)" do
+    it "affiche l'étape et les activités ayant un créneau dans la fenêtre" do
+      seed_dates
+      get "/reservation/activites"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Balade avec les ânes")
+      # Le créneau dans la fenêtre est proposé (champ availability_id caché).
+      expect(response.body).to include('name="reservation[experiences][0][availability_id]"')
+    end
+
+    it "n'affiche PAS un créneau hors fenêtre (jour du départ exclu)" do
+      seed_dates
+      get "/reservation/activites"
+
+      expect(response.body).not_to include("Atelier forge")
+    end
+  end
+
+  describe "GET /reservation/activites — aucun créneau dans la fenêtre" do
+    before { slot_in.destroy && slot_out.destroy }
+
+    it "reste franchissable et l'indique clairement" do
+      seed_dates
+      get "/reservation/activites"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Aucune activité")
+      # Un chemin de sortie vers les coordonnées reste offert.
+      expect(response.body).to include(public_reservation_contact_path)
+    end
+  end
+
+  describe "la sélection de créneau survit jusqu'au commit" do
+    before do
+      allow(StripeService.instance).to receive(:create_checkout_session)
+        .and_return(OpenStruct.new(url: "https://checkout.stripe.test/session/act"))
+    end
+
+    it "persiste le créneau puis crée un ExperienceBooking pending rattaché au Stay" do
+      seed_dates
+
+      # Étape activités : on choisit le créneau dans la fenêtre.
+      post "/reservation/activites", params: {
+        reservation: { experiences: { "0" => { id: experience.id, availability_id: slot_in.id, participants: "4" } } }
+      }
+      expect(response).to redirect_to("/reservation/coordonnees")
+
+      # Commit final : les coordonnées ne re-portent PAS les activités — c'est le
+      # draft en session qui les conserve d'une étape à l'autre.
+      expect {
+        post "/reservation/coordonnees", params: {
+          reservation: {
+            lodging_id: hulotte.id, arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+            dogs_count: 0, first_name: "Nina", last_name: "Test",
+            email: "nina@example.com", phone: "+32470111222"
+          }
+        }
+      }.to change(ExperienceBooking, :count).by(1)
+
+      eb = ExperienceBooking.last
+      expect(eb).to be_pending
+      expect(eb.experience_availability).to eq(slot_in)
+      expect(eb.participants).to eq(4)
+      expect(eb.stay).to eq(Stay.last)
+    end
+  end
+end

--- a/spec/services/reservations/builder_spec.rb
+++ b/spec/services/reservations/builder_spec.rb
@@ -178,4 +178,47 @@ RSpec.describe Reservations::Builder do
       expect(builder.quote.total_excluding_experiences_cents).to eq(74_500)
     end
   end
+
+  # ------------------------------------------------------------------------
+  # Epic #55, Phase 4 — Sélection d'activités DANS le funnel : chaque créneau
+  # choisi (experience_availability_id + participants) devient un
+  # ExperienceBooking `pending` rattaché au Stay. Le montant réintègre le total
+  # prévu du séjour mais JAMAIS l'acompte initial (garanti Phase 1).
+  # ------------------------------------------------------------------------
+  describe "activités réservées au funnel (epic #55, Phase 4)" do
+    let!(:experience) { Experience.create!(name: "Balade avec les ânes", fixed_price_cents: 2_000, price_cents: 1_000, max_participants: 8) }
+    let!(:slot) { ExperienceAvailability.create!(experience: experience, available_on: arrival, starts_at: "10:00", max_participants: 8) }
+
+    def draft_with_slot(participants: 3)
+      draft(experiences: [{ id: experience.id, availability_id: slot.id, participants: participants }])
+    end
+
+    it "crée un ExperienceBooking pending rattaché au Stay, avec le bon nombre de participants" do
+      builder = described_class.new(draft: draft_with_slot(participants: 3))
+      expect(builder.run).to be(true)
+
+      bookings = builder.stay.experience_bookings
+      expect(bookings.count).to eq(1)
+      eb = bookings.first
+      expect(eb).to be_pending
+      expect(eb.experience_availability).to eq(slot)
+      expect(eb.participants).to eq(3)
+    end
+
+    it "réintègre les activités au total prévu du Stay mais JAMAIS à l'acompte" do
+      builder = described_class.new(draft: draft_with_slot(participants: 3))
+      builder.run
+
+      # Hulotte 2 nuits = 745 € ; activité = 2 000 + 1 000×3 = 5 000 c.
+      expect(builder.stay.total_amount_cents).to eq(74_500 + 5_000)
+      # Acompte 50 % HORS activités = 372,50 € (inchangé Phase 1).
+      expect(builder.payment.amount_cents).to eq(37_250)
+    end
+
+    it "ignore une entrée sans créneau (rétrocompat de l'ancienne forme experiences)" do
+      builder = described_class.new(draft: draft(experiences: [{ id: experience.id, participants: 2 }]))
+      expect(builder.run).to be(true)
+      expect(builder.stay.experience_bookings).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Phase 4 de l'epic #55. **Empilée sur #58 (Phase 3).**

## Ce que fait cette PR
- **Étape « Activités »** insérée entre `compose` et `contact` (funnel à **4 étapes**, step indicator mutualisé `_step_indicator`, navigation avant/arrière, sélection persistée dans le draft en session).
- **Affichage** : Experiences ayant ≥1 créneau `ExperienceAvailability` dans la fenêtre `[arrivée, départ)`, créneaux datés sélectionnables (participants). Cas « aucun créneau » → encart + étape franchissable (la relance email J-14 couvrira le reste).
- **Draft étendu** : `{id, availability_id, participants}` (le créneau rend l'`ExperienceBooking` créable — NOT NULL). Rétrocompat : ancienne forme `{id, participants}` reste valide pour le devis, ne crée aucun EB.
- **Builder** persiste les `ExperienceBooking` (`pending`, rattachés au Stay, **même nature** que le rail email → soumis à validation porteur). Acompte **hors activités** (AC-4, testé).

## Vérification
- `bundle exec rspec` : **481 ex, 0 failure**, 18 pending (+7 : builder + request funnel). Parité i18n verte (vues funnel FR-only, cohérent avec l'existant). Pas de migration.

## ⚠️ À valider / points ouverts (honnête)
- **Non vérifié au navigateur** — request specs OK, mais le rendu visuel, le JS Stimulus (`advance` → navigation vers activités, refresh devis Turbo) et le tactile mobile restent à valider. *Une passe navigateur groupée (funnel + validation porteur + page solde) est lancée juste après cette PR.*
- **Fenêtre `[arrivée, départ)` exclusive** (jour de départ exclu) — suit l'AC à la lettre, mais le rail email est inclusif. **À confirmer produit** (activité le matin du départ ?).
- **UX des créneaux** (regroupés par Experience) à faire valider côté design (cohérence avec l'étape 2 ; pas de passe design mobile dessus).
- **Capacité concurrente** non verrouillée à l'affichage (cohérent avec le rail email : EB `pending`, le porteur arbitre).

## Notes
- Implémentée par Engineer. Déploiement Hatchbox manuel : merger ≠ déployer.

Refs #55