### PR TITLE
feat(activités): Phase 5 — relance J-14 du solde (sans blocage) + rail email confirmé cohérent

### DIFF
--- a/app/mailers/stay_balance_reminder_mailer.rb
+++ b/app/mailers/stay_balance_reminder_mailer.rb
@@ -1,0 +1,17 @@
+class StayBalanceReminderMailer < ApplicationMailer
+  # Relance de paiement du solde exigible ~14 jours avant l'arrivée (epic #55,
+  # Phase 5). Purement incitative : AUCUNE réservation n'est bloquée ni annulée.
+  # Le lien pointe vers la page séjour à jeton où le client règle le solde
+  # (Phase 3). L'hôte des liens est résolu comme dans ActivitySelectionMailer,
+  # pour rester stable en test comme en prod.
+  def reminder(stay)
+    @stay = stay
+    @balance = Money.new(stay.balance_due_cents, "EUR")
+    @stay_url = public_stay_url(stay.token,
+                                host: ENV.fetch("APPLICATION_HOST", "app.les4sources.be"))
+    mail(
+      to: stay.customer.email,
+      subject: "Il reste un solde à régler pour votre séjour aux 4 Sources"
+    )
+  end
+end

--- a/app/views/stay_balance_reminder_mailer/reminder.html.slim
+++ b/app/views/stay_balance_reminder_mailer/reminder.html.slim
@@ -1,0 +1,23 @@
+p Bonjour #{@stay.customer.first_name.presence || ""},
+
+p
+  | Votre séjour aux 4 Sources approche. Il reste
+  strong = " #{@balance.format(symbol: '€')} "
+  | à régler pour finaliser votre réservation.
+
+- if @stay.arrival_date && @stay.departure_date
+  p
+    strong Votre séjour :
+    | = " #{l(@stay.arrival_date, format: :long)} → #{l(@stay.departure_date, format: :long)}"
+
+p = link_to "→ Régler le solde de mon séjour", @stay_url
+
+p
+  | Votre réservation reste bien confirmée : ce message est un simple rappel,
+  | rien n'est annulé. Vous pouvez régler le solde en ligne, en toute sécurité.
+
+p
+  | En cas de question, contactez Malau au +32(0)490/46.77.10 ou à
+  = link_to "sejours@les4sources.be", "mailto:sejours@les4sources.be"
+
+p À très bientôt aux 4 Sources !

--- a/db/migrate/20260716130000_add_balance_reminder_sent_at_to_stays.rb
+++ b/db/migrate/20260716130000_add_balance_reminder_sent_at_to_stays.rb
@@ -1,0 +1,9 @@
+class AddBalanceReminderSentAtToStays < ActiveRecord::Migration[7.0]
+  # Idempotence de la relance solde J-14 (epic #55, Phase 5) : on horodate le
+  # dernier envoi pour ne jamais renvoyer la relance à chaque passage du cron.
+  # Colonne nullable → tous les séjours existants restent valides (aucune
+  # relance encore émise = NULL). `add_column` est réversible automatiquement.
+  def change
+    add_column :stays, :balance_reminder_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_16_120000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_16_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -602,6 +602,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_16_120000) do
     t.datetime "activity_email_sent_at"
     t.string "token"
     t.string "payment_status", default: "pending", null: false
+    t.datetime "balance_reminder_sent_at"
     t.index ["activity_selection_token"], name: "index_stays_on_activity_selection_token"
     t.index ["customer_id"], name: "index_stays_on_customer_id"
     t.index ["legacy_origin"], name: "index_stays_on_legacy_origin_unique_live", unique: true, where: "((legacy_origin IS NOT NULL) AND (deleted_at IS NULL))"

--- a/lib/tasks/activity_emails.rake
+++ b/lib/tasks/activity_emails.rake
@@ -30,4 +30,41 @@ namespace :activity_emails do
       puts "  ↳ #{stay.id} (#{stay.customer.email}) : email envoyé ✓"
     end
   end
+
+  desc "Relance le solde exigible ~14 jours avant l'arrivée (sans blocage, idempotent)"
+  task balance_reminder: :environment do
+    # Fenêtre J-14 avec une marge de rattrapage : un cron qui saute un jour
+    # récupère quand même le séjour. L'idempotence (colonne
+    # `balance_reminder_sent_at`) empêche tout second envoi, la fenêtre large
+    # est donc sans risque de doublon.
+    window_start = Date.today + 12
+    window_end   = Date.today + 14
+
+    stays = Stay.where(balance_reminder_sent_at: nil)
+                .where(arrival_date: window_start..window_end)
+                .where.not(status: %w[cancelled])
+                .includes(:customer)
+
+    # `balance_due_cents` est CALCULÉ en Ruby (barème activités) : on filtre en
+    # mémoire, jamais en SQL. Ne relance QUE les séjours dont l'EXIGIBLE reste
+    # impayé (activités `pending` non facturables déjà exclues, cf. Phase 3).
+    eligible = stays.select(&:payable_now?)
+
+    puts "#{eligible.size} séjour(s) avec solde exigible sur #{stays.count} dans la fenêtre J-14."
+
+    eligible.each do |stay|
+      if stay.customer.email.blank? || stay.customer.email == Customer::CATCH_ALL_EMAIL
+        # Pas d'horodatage : rien n'a été envoyé, on reste éligible au prochain
+        # passage (au cas où l'email du client serait corrigé entre-temps).
+        puts "  ↳ #{stay.id} : email client absent/catch-all → skip"
+        next
+      end
+
+      # AUCUN blocage : on relance vers la page de paiement existante, sans
+      # toucher aux réservations (aucune annulation).
+      StayBalanceReminderMailer.reminder(stay).deliver_later
+      stay.update_column(:balance_reminder_sent_at, Time.current)
+      puts "  ↳ #{stay.id} (#{stay.customer.email}) : relance solde envoyée ✓ (reste #{stay.balance_due_cents} c.)"
+    end
+  end
 end

--- a/spec/mailers/stay_balance_reminder_mailer_spec.rb
+++ b/spec/mailers/stay_balance_reminder_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+# Epic #55, Phase 5 — mailer de relance du solde exigible (client).
+RSpec.describe StayBalanceReminderMailer, type: :mailer do
+  let(:customer) do
+    Customer.create!(email: "solde@example.com", first_name: "Léa", customer_type: "individual")
+  end
+  let(:stay) do
+    Stay.create!(customer: customer, status: "pending", total_amount_cents: 15_000,
+                 arrival_date: Date.today + 14, departure_date: Date.today + 16)
+  end
+
+  subject(:mail) { described_class.reminder(stay) }
+
+  it "adresse la relance au client" do
+    expect(mail.to).to eq(["solde@example.com"])
+  end
+
+  it "pointe vers la page séjour à jeton (paiement du solde)" do
+    # Le lien de la relance porte le jeton public du séjour → /sejour/:token.
+    expect(mail.body.encoded).to include(stay.token)
+  end
+
+  it "rassure explicitement : aucun blocage ni annulation" do
+    expect(mail.body.encoded).to match(/rien n'est annulé|reste bien confirmée/)
+  end
+end

--- a/spec/requests/public/activity_selections_spec.rb
+++ b/spec/requests/public/activity_selections_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+# Epic #55, Phase 5 — cohérence du rail email de sélection.
+# Les réservations d'activités créées par le client via le lien à jeton doivent
+# entrer en `pending` (soumises à la validation porteur, Phase 2) et NON
+# `confirmed` d'office. Tant qu'elles sont `pending`, elles restent HORS de
+# l'exigible (Phase 3) : elles gonflent le total prévu mais pas ce que le client
+# doit régler maintenant.
+RSpec.describe "Public::ActivitySelections (POST /mon-sejour/:token/activites)", type: :request do
+  let(:customer)   { Customer.create!(email: "sel@example.com", customer_type: "individual") }
+  let(:stay)       { Stay.create!(customer: customer, status: "pending", arrival_date: Date.today + 20, departure_date: Date.today + 22) }
+  let(:porteur)    { Human.create!(name: "Porteuse", email: "porteuse@example.com") }
+  let(:experience) { Experience.create!(name: "Balade ânes", human: porteur, fixed_price_cents: 3_000, price_cents: 0) }
+  let(:availability) do
+    ExperienceAvailability.create!(experience: experience, available_on: Date.today + 21, starts_at: "10:00")
+  end
+
+  def post_selection(participants: "2")
+    post "/mon-sejour/#{stay.activity_selection_token}/activites",
+         params: { activities: { "0" => { availability_id: availability.id, participants: participants } } }
+  end
+
+  it "crée les ExperienceBooking en statut pending (validation porteur requise)" do
+    expect { post_selection }.to change(ExperienceBooking, :count).by(1)
+
+    eb = ExperienceBooking.last
+    expect(eb.stay).to eq(stay)
+    expect(eb).to be_pending
+    expect(eb).not_to be_confirmed
+  end
+
+  it "laisse l'activité pending hors de l'exigible tant qu'elle n'est pas validée" do
+    booking = Booking.create!(firstname: "Sel", email: "sel@example.com",
+                              from_date: Date.today + 20, to_date: Date.today + 22,
+                              adults: 2, status: "confirmed", booking_type: "lodging",
+                              price_cents: 40_000)
+    stay.stay_items.create!(bookable: booking)
+
+    post_selection
+    stay.recompute_aggregates! # total prévu = 40 000 (héberg.) + 3 000 (activité pending)
+
+    expect(stay.experiences_pending_amount_cents).to eq(3_000)
+    # Exigible = total prévu − pending → l'activité pending n'entre PAS dans le solde.
+    expect(stay.payable_amount_cents).to eq(40_000)
+  end
+end

--- a/spec/tasks/activity_emails_balance_reminder_spec.rb
+++ b/spec/tasks/activity_emails_balance_reminder_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+require "rake"
+
+# Epic #55, Phase 5 — relance du solde exigible à J-14 (sans blocage).
+# On vérifie le CIBLAGE (J-14 + solde impayé, hors soldés/annulés) et
+# l'IDEMPOTENCE (pas de second envoi).
+RSpec.describe "activity_emails:balance_reminder", type: :task do
+  include ActiveJob::TestHelper
+
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("activity_emails:balance_reminder")
+  end
+
+  def run_task
+    task = Rake::Task["activity_emails:balance_reminder"]
+    task.reenable
+    # La tâche imprime un rapport : on le silence pour garder la sortie propre.
+    original = $stdout
+    $stdout = StringIO.new
+    task.invoke
+  ensure
+    $stdout = original
+  end
+
+  # Un séjour minimal (sans bookables) suffit : `payable_amount_cents` dérive
+  # de `total_amount_cents` moins les activités pending, et l'exigible impayé
+  # se pilote donc via le total et les paiements encaissés.
+  def build_stay(email:, arrival_offset:, total_cents: 40_000, paid_cents: 0, status: "pending")
+    customer = Customer.create!(email: email, customer_type: "individual")
+    stay = Stay.create!(customer: customer, status: status, total_amount_cents: total_cents,
+                        arrival_date: Date.today + arrival_offset,
+                        departure_date: Date.today + arrival_offset + 2)
+    if paid_cents.positive?
+      Payment.create!(stay: stay, amount_cents: paid_cents, status: "paid", payment_method: "card")
+    end
+    stay
+  end
+
+  it "relance les séjours à J-14 avec un solde exigible impayé" do
+    stay = build_stay(email: "due@example.com", arrival_offset: 14)
+
+    expect { run_task }
+      .to have_enqueued_mail(StayBalanceReminderMailer, :reminder).exactly(1).times
+
+    expect(stay.reload.balance_reminder_sent_at).to be_present
+  end
+
+  it "ignore les séjours hors fenêtre J-14 (arrivée dans ~30 jours)" do
+    stay = build_stay(email: "far@example.com", arrival_offset: 30)
+
+    expect { run_task }.not_to have_enqueued_mail(StayBalanceReminderMailer, :reminder)
+    expect(stay.reload.balance_reminder_sent_at).to be_nil
+  end
+
+  it "ignore les séjours déjà soldés (aucun solde exigible)" do
+    stay = build_stay(email: "paid@example.com", arrival_offset: 14, paid_cents: 40_000)
+
+    expect { run_task }.not_to have_enqueued_mail(StayBalanceReminderMailer, :reminder)
+    expect(stay.reload.balance_reminder_sent_at).to be_nil
+  end
+
+  it "ignore les séjours annulés même avec un solde" do
+    stay = build_stay(email: "cancel@example.com", arrival_offset: 14, status: "cancelled")
+
+    expect { run_task }.not_to have_enqueued_mail(StayBalanceReminderMailer, :reminder)
+    expect(stay.reload.balance_reminder_sent_at).to be_nil
+  end
+
+  it "est idempotente : un second passage ne renvoie pas la relance" do
+    stay = build_stay(email: "once@example.com", arrival_offset: 14)
+
+    run_task
+    first_sent_at = stay.reload.balance_reminder_sent_at
+    expect(first_sent_at).to be_present
+
+    expect { run_task }.not_to have_enqueued_mail(StayBalanceReminderMailer, :reminder)
+    expect(stay.reload.balance_reminder_sent_at).to eq(first_sent_at)
+  end
+end


### PR DESCRIPTION
Phase 5 de l'epic #55. **Empilée sur #59 (Phase 4).**

## Ce que fait cette PR
- **Relance solde J-14** : tâche `activity_emails:balance_reminder` ciblant les séjours à arrivée J-12→J-14 avec **solde exigible impayé** (`payable_now?`), envoi d'un mail de relance vers `/sejour/:token`. **Aucun blocage** — les réservations restent valides, rien n'est annulé (le mail le dit explicitement).
- **Idempotence** : colonne `balance_reminder_sent_at` (migration réversible, nullable) → un seul envoi par séjour. Email absent/catch-all sauté sans horodatage (reste éligible si corrigé).
- **Nouveau mailer** `StayBalanceReminderMailer` + vue slim FR (mécanisme d'hôte identique à `ActivitySelectionMailer`).
- **Critère 3 — constat** : le rail email de sélection (`Public::ActivitySelectionsController#create`) crée **déjà** des `ExperienceBooking` `pending` (soumis à validation porteur Phase 2, exclus de l'exigible tant que pending). Rien à corriger — **ancré par un nouveau spec**.

## Vérification
- `bundle exec rspec` : **491 ex, 0 failure**, 18 pending (+10 : rake relance, mailer, cohérence rail sélection). Migration `up`/`down` testée dans les deux sens.

## Notes
- Pas de scheduler installé (le repo lance ces rakes en externe, comme `activity_emails:send`).
- Implémentée par Engineer. Déploiement Hatchbox manuel : merger ≠ déployer.

Refs #55