### PR TITLE
hotfix: mailer Devise (compte porteur) + modale séjour robuste aux activités supprimées

### DIFF
--- a/app/models/experience_availability.rb
+++ b/app/models/experience_availability.rb
@@ -39,9 +39,15 @@ class ExperienceAvailability < ApplicationRecord
   # qu'un porteur qui cible le créneau d'un autre porteur obtienne un `nil`
   # (jamais une création réussie hors périmètre).
   def self.for_user(user)
-    return all if user.nil? || user.global_admin?
+    # Toujours borné aux Experience VIVANTES : un créneau dont l'activité a été
+    # supprimée (soft-delete, `has_soft_deletion default_scope: true`) ne doit
+    # jamais être proposé — sinon `#label` fait `experience.name` sur `nil` et
+    # plante le rendu de la modale séjour (epic #55 Phase 6). Même filtre que le
+    # funnel `bookable_availabilities`.
+    scope = joins(:experience).where(experiences: { deleted_at: nil })
+    return scope if user.nil? || user.global_admin?
 
-    joins(:experience).where(experiences: { human_id: user.human_id })
+    scope.where(experiences: { human_id: user.human_id })
   end
 
   def ends_at

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'it@les4sources.be'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/spec/models/experience_availability_spec.rb
+++ b/spec/models/experience_availability_spec.rb
@@ -84,4 +84,25 @@ RSpec.describe ExperienceAvailability, type: :model do
       expect(block).to be_valid
     end
   end
+
+  # Epic #55 Phase 6 — les créneaux proposables à l'ajout d'activité sur un séjour
+  # ne doivent jamais inclure une activité SUPPRIMÉE : `experience` serait alors
+  # `nil` (soft-delete default_scope) et `#label` (→ `experience.name`) planterait
+  # le rendu de la modale séjour pour l'admin.
+  describe ".for_user" do
+    let(:admin) { User.create!(email: "staff@les4sources.be", password: "password123") }
+    let!(:avail) do
+      ExperienceAvailability.create!(experience: experience, available_on: Date.today + 7, starts_at: "10:00")
+    end
+
+    it "propose les créneaux d'une activité vivante à un admin global" do
+      expect(described_class.for_user(admin)).to include(avail)
+    end
+
+    it "EXCLUT les créneaux d'une activité supprimée (soft-delete) — #label ne plante pas" do
+      experience.destroy
+      expect(described_class.for_user(admin)).not_to include(avail)
+      expect { described_class.for_user(admin).map(&:label) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Deux correctifs post-epic #55, découverts en testant en prod.

## 1. Mail Devise — création de compte porteur (CLAUDY-74)
`config.mailer_sender` était resté sur le placeholder `please-change-me-…@example.com` → Postmark rejette l'envoi (`ApiInputError`, `HumansController#create_account`). Passé à **`it@les4sources.be`**.

## 2. Modale séjour robuste aux activités supprimées (bug latent Phase 6)
`ExperienceAvailability.for_user` (chemin **admin**) renvoyait `all` **sans** filtrer les `Experience` soft-deleted. Une availability `upcoming` dont l'activité a été supprimée → `experience` = `nil` (`has_soft_deletion default_scope: true`) → `#label` fait `experience.name` sur nil → **`NoMethodError` → 500 sur `stays#show` → la modale de détails ne s'ouvre plus** (pour n'importe quel séjour, dès qu'UNE activité supprimée a un créneau futur). Le porteur était protégé (il passait déjà par `joins(:experience)`).
**Fix** : `for_user` borne toujours aux activités vivantes (`joins(:experience).where(experiences: { deleted_at: nil })`), comme le funnel `bookable_availabilities`. Spec de non-régression ajouté (échoue sans le fix).

## Vérification
- `bundle exec rspec` : **503 ex, 0 failure**, 18 pending (+2 : `for_user` inclut le vivant / exclut le supprimé sans planter).

## À noter — le « rien au clic » que tu as vu N'ÉTAIT PAS ce bug
`/sejours/recents` est une **liste d'observation sans liens cliquables**. La modale séjour (CRUD activités) s'ouvre depuis la **fiche client** (`customers#show` → « Détails »). Le bug #2 ci-dessus est réel et **aurait** cassé la modale, mais il ne se déclenche que s'il existe une activité supprimée avec un créneau futur.

## Notes
- Déploiement Hatchbox manuel : merger ≠ déployer.

Refs #55