### PR TITLE
feat(admin): URL séjours en anglais (/stays/recents) + accès au séjour depuis la liste

### DIFF
--- a/app/views/stays/recent.html.slim
+++ b/app/views/stays/recent.html.slim
@@ -20,8 +20,12 @@
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Créé le
       tbody.divide-y.divide-gray-200.bg-white
         - @stays.each do |stay|
-          tr
-            td.px-4.py-2.text-sm = stay.contact_line
+          tr.hover:bg-gray-50
+            td.px-4.py-2.text-sm
+              - if stay.customer
+                = link_to stay.contact_line, customer_path(stay.customer), class: "text-indigo-600 hover:text-indigo-800 font-medium hover:underline"
+              - else
+                = stay.contact_line
             td.px-4.py-2.text-sm = stay.date_range
             td.px-4.py-2.text-sm
               span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.py-0.5.text-xs.font-medium.text-gray-700 = stay.source

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,11 @@ Rails.application.routes.draw do
     end
   end
 
+  # Vue admin Pôle Accueil — index des Stays récents filtrable par source (Devise).
+  # URLs admin en anglais. Déclarée AVANT `resources :stays` pour que
+  # /stays/recents ne soit pas capté par la route /stays/:id.
+  get "stays/recents", to: "stays#recent", as: :recent_stays
+
   # Détails d'un séjour (chargé dans une modale Turbo Frame depuis la page client).
   # Le CRUD admin d'une activité SUR un séjour (epic #55, Phase 6) est imbriqué
   # sous cette ressource : la création porte TOUJOURS le séjour dans l'URL, si
@@ -154,9 +159,6 @@ Rails.application.routes.draw do
   get  "reservation/coordonnees",  to: "public/reservations#contact",            as: :public_reservation_contact
   post "reservation/coordonnees",  to: "public/reservations#create",             as: :public_reservation_create
   get  "reservation/calendrier",   to: "public/reservations#availability_calendar", as: :public_reservation_availability_calendar
-
-  # Vue admin Pôle Accueil — index des Stays récents filtrable par source (Devise).
-  get "sejours/recents", to: "stays#recent", as: :recent_stays
 
   # Page client du séjour-composite (epic #26, Phase 1) — jeton, sans Devise.
   # Route à la racine (et non sous /public) : c'est l'URL envoyée aux clients et

--- a/spec/requests/stays_recent_spec.rb
+++ b/spec/requests/stays_recent_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Vue admin — Stays récents (/sejours/recents)", type: :request do
+RSpec.describe "Vue admin — Stays récents (/stays/recents)", type: :request do
   include Devise::Test::IntegrationHelpers
 
   let(:customer) { Customer.create!(email: "recent@example.com", customer_type: "individual") }
@@ -43,6 +43,11 @@ RSpec.describe "Vue admin — Stays récents (/sejours/recents)", type: :request
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Rémi Direct")     # canal reservation
       expect(response.body).to include("Tilda Legacy")    # canal tally_legacy
+    end
+
+    it "lie le nom du client vers sa fiche (accès au détail du séjour)" do
+      get recent_stays_path
+      expect(response.body).to include(%(href="#{customer_path(customer)}"))
     end
 
     it "restreint la liste au canal demandé" do


### PR DESCRIPTION
Suite au test en prod : rendre les séjours accessibles depuis la liste, et aligner l'URL admin sur l'anglais.

## Ce que fait cette PR
- **Route** : `/sejours/recents` → **`/stays/recents`** (URLs admin en anglais). Déclarée **avant** `resources :stays` pour ne pas être captée par `/stays/:id`. Le helper `recent_stays_path` est inchangé → aucun lien interne cassé.
- **Liste cliquable** : dans `/stays/recents`, le **nom du client** est désormais un lien vers sa **fiche** (`customers#show`), d'où s'ouvre la modale de détails du séjour (avec le CRUD activités de la Phase 6). Ligne survolée mise en évidence.

## Vérification
- `bundle exec rspec` : **502 ex, 0 failure**, 18 pending (+1 : le nom du client pointe vers `customer_path`). Route `/stays/recents` confirmée ordonnée avant `/stays/:id`.

## À savoir
- L'ancienne URL `/sejours/recents` renvoie maintenant 404 (bookmark à mettre à jour).
- Les URLs **publiques/client restent en français** (funnel `/reservation/…`, `/sejour/:token`) — volontaire (clients francophones + SEO). Préférence « URLs admin en anglais » notée pour la suite.
- Indépendante de la PR #62 (fichiers différents) — les deux se mergent sans conflit.

## Notes
- Déploiement Hatchbox manuel : merger ≠ déployer.