### PR TITLE
feat(auth): rendre accessible le flux mot de passe oublié / définition de mot de passe

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -33,14 +33,9 @@
                             autocomplete: "current-password",
                             class: "block w-full rounded-md border-0 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" \
                           }
-            / .flex.items-center.justify-between
-              .flex.items-center
-                input#remember-me.h-4.w-4.rounded.border-gray-300.text-indigo-600.focus:ring-indigo-600[name="remember-me" type="checkbox" checked="checked"]
-                label.ml-3.block.text-sm.leading-6.text-gray-700[for="remember-me"]
-                  | Se souvenir de moi
+            .flex.items-center.justify-end
               .text-sm.leading-6
-                a.font-semibold.text-indigo-600.hover:text-indigo-500[href="#"]
-                  | Mot de passe oublié?
+                = link_to "Mot de passe oublié ?", new_password_path(resource_name), class: "font-semibold text-indigo-600 hover:text-indigo-500"
             div
               button.flex.w-full.justify-center.rounded-md.bg-indigo-600.px-3.py-1.5.text-sm.font-semibold.leading-6.text-white.shadow-sm.hover:bg-indigo-500.focus-visible:outline.focus-visible:outline-2.focus-visible:outline-offset-2.focus-visible:outline-indigo-600[type="submit"]
                 | Me connecter

--- a/spec/requests/login_password_reset_spec.rb
+++ b/spec/requests/login_password_reset_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+# Le flux Devise `recoverable` existait (module actif, colonnes, vues, mailer)
+# mais était INACCESSIBLE : le lien « Mot de passe oublié ? » de la page de
+# login était commenté et pointait vers `#`. Il sert à la fois à la perte de
+# mot de passe ET à la définition initiale du mot de passe d'un compte porteur
+# (l'email d'invitation `send_reset_password_instructions`).
+RSpec.describe "Connexion — accès au flux mot de passe oublié", type: :request do
+  it "la page de login expose un lien vers la réinitialisation du mot de passe" do
+    get new_user_session_path
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(new_user_password_path)
+    expect(response.body).to include("Mot de passe oublié")
+  end
+
+  it "la page de réinitialisation est accessible" do
+    get new_user_password_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "demander une réinitialisation envoie l'email d'instructions" do
+    user = User.create!(email: "porteur@example.com", password: "password123")
+    expect {
+      post user_password_path, params: { user: { email: user.email } }
+    }.to change { ActionMailer::Base.deliveries.size }.by(1)
+    expect(ActionMailer::Base.deliveries.last.to).to include("porteur@example.com")
+  end
+end


### PR DESCRIPTION
Suite au test en prod : le compte porteur `michael@les4sources.be` ne pouvait pas définir son mot de passe.

## Cause
Le flux Devise `recoverable` était **complet mais invisible** : module actif (`user.rb`), colonnes `reset_password_*`, vues `devise/passwords/{new,edit}`, mailer, et `Humans::CreateAccountService` appelle bien `send_reset_password_instructions`. **MAIS** le lien « Mot de passe oublié ? » de la page de login était **commenté** et pointait vers `href="#"`. Et l'email d'invitation initial avait de toute façon échoué (bug Postmark `From` — corrigé dans #62).

## Ce que fait cette PR
- Active un vrai lien **« Mot de passe oublié ? »** sur `devise/sessions/new.html.slim`, pointant vers `new_password_path(resource_name)`.
- Ce flux couvre **les deux besoins** : perte de mot de passe **et** définition initiale du mot de passe d'un compte porteur (même mécanisme `reset_password_instructions`).

## Vérification
- `bundle exec rspec` : **507 ex, 0 failure**, 18 pending (+3 : lien présent sur le login, page reset accessible, la demande de reset envoie bien l'email). Vérifié par request spec ; rendu visuel trivial (un lien), non ouvert au navigateur (daemon screenshot cassé).

## Rappel
- Aucune migration. Déploiement Hatchbox manuel.
- Une fois déployé : le lien est visible sur le login. En attendant, `/users/password/new` fonctionne déjà (Postmark réparé).

Refs #55