### PR TITLE
feat(porteur): bouton "Renvoyer l'invitation" sur la fiche d'un porteur

### DIFF
--- a/app/controllers/humans_controller.rb
+++ b/app/controllers/humans_controller.rb
@@ -74,6 +74,20 @@ class HumansController < BaseController
     end
   end
 
+  # Renvoie l'email de définition / réinitialisation du mot de passe à un porteur
+  # qui a déjà un compte (utile si l'invitation initiale a échoué, ex. Postmark).
+  def resend_invitation
+    @human = Human.unscoped.find(params[:id])
+    if @human.user
+      @human.user.send_reset_password_instructions
+      redirect_to human_path(@human),
+                  notice: "Invitation renvoyée à #{@human.email} — le lien pour définir/réinitialiser le mot de passe a été envoyé."
+    else
+      redirect_to human_path(@human),
+                  alert: "#{@human.name} n'a pas encore de compte d'accès — créez-en un d'abord."
+    end
+  end
+
   def destroy
     if @human.soft_delete!(validate: false)
       redirect_to humans_path,

--- a/app/views/humans/show.html.slim
+++ b/app/views/humans/show.html.slim
@@ -49,10 +49,14 @@
         .border-t.border-gray-200
           .px-4.py-5.sm:px-6
             - if @human.account?
-              p.text-sm.text-gray-700
+              p.text-sm.text-gray-700.mb-4
                 | Connexion à Claudy avec l'adresse
                 |
                 span.font-medium = @human.user.email
+              = button_to "Renvoyer l'invitation",
+                          resend_invitation_human_path(@human),
+                          method: :post,
+                          class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
             - elsif @human.email.present?
               p.text-sm.text-gray-700.mb-4
                 | Aucun compte d'accès pour l'instant. Créez-en un pour permettre à #{@human.name} de se connecter à Claudy et de gérer ses activités et disponibilités.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
     member do
       patch :toggle_cycle_active
       post :create_account
+      post :resend_invitation
     end
   end
   resources :human_roles

--- a/spec/requests/humans_resend_invitation_spec.rb
+++ b/spec/requests/humans_resend_invitation_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+# Bouton « Renvoyer l'invitation » sur la fiche porteur : re-déclenche l'email de
+# définition / réinitialisation du mot de passe pour un compte existant (utile si
+# l'invitation initiale a échoué, ex. bug Postmark).
+RSpec.describe "Humans — renvoyer l'invitation d'accès", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { User.create!(email: "staff@les4sources.be", password: "password123") }
+  before { sign_in admin }
+
+  it "renvoie l'email d'invitation à un porteur qui a déjà un compte" do
+    porteur = Human.create!(name: "Porteur", email: "porteur@example.com")
+    Humans::CreateAccountService.new(human: porteur, send_invitation: false).run
+    expect(porteur.reload.user).to be_present
+
+    expect {
+      post resend_invitation_human_path(porteur)
+    }.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+    expect(response).to redirect_to(human_path(porteur))
+    expect(ActionMailer::Base.deliveries.last.to).to include("porteur@example.com")
+  end
+
+  it "refuse (sans email) si le porteur n'a pas encore de compte" do
+    porteur = Human.create!(name: "Sans compte", email: "sanscompte@example.com")
+
+    expect {
+      post resend_invitation_human_path(porteur)
+    }.not_to change { ActionMailer::Base.deliveries.size }
+
+    expect(response).to redirect_to(human_path(porteur))
+    expect(flash[:alert]).to be_present
+  end
+end


### PR DESCRIPTION
Demandé après le déploiement : pouvoir re-déclencher l'email d'invitation d'un porteur (utile quand l'invitation initiale a échoué, ex. le bug Postmark).

## Ce que fait cette PR
- Nouvelle action `HumansController#resend_invitation` (route `member` `POST /humans/:id/resend_invitation`, en anglais) : si le porteur a un compte → `send_reset_password_instructions` (même email que « définir le mot de passe ») ; sinon → alerte « créez d'abord un compte ».
- Bouton **« Renvoyer l'invitation »** sur la fiche du porteur, dans la branche « compte existant » (à côté de l'email de connexion).

## Vérification
- `bundle exec rspec` : **509 ex, 0 failure**, 18 pending (+2 : renvoi effectif de l'email si compte, refus sans email sinon). Rendu visuel trivial (un bouton), non ouvert au navigateur.

## Notes
- Aucune migration. Déploiement Hatchbox manuel.