### PR TITLE
Epic #66 Phase 1 — CRUD Séjour admin composable (hébergement + activités)

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -1,5 +1,6 @@
 class StaysController < BaseController
   before_action :set_accounting_view, only: :show
+  before_action :set_stay, only: %i[edit update destroy]
 
   # Rendu sans layout : le fragment HTML est injecté dans la modale de détails
   # par le contrôleur Stimulus stay-details (fetch + innerHTML). [tranche 1]
@@ -22,10 +23,191 @@ class StaysController < BaseController
     @stays = Stay.from_source(@source).recent.includes(:customer).limit(100).decorate
   end
 
+  # --- CRUD Séjour admin (epic #66, Phase 1) --------------------------------
+  # Le séjour devient le point d'entrée de création composable côté admin
+  # (hébergement + activités), en réutilisant `Reservations::Builder` en mode
+  # admin (aucun Stripe, aucun email forcé, force-dispo, statut au choix).
+
+  def new
+    @stay  = Stay.new(status: "pending")
+    @draft = Reservations::Draft.new
+    prepare_form
+  end
+
+  def create
+    @draft  = build_draft
+    builder = Reservations::Builder.new(
+      draft:             @draft,
+      admin:             true,
+      status:            requested_status,
+      source:            "manual",
+      skip_availability: force_availability?
+    )
+
+    if builder.run
+      flash[:notice] = "Séjour créé."
+      flash[:alert]  = builder.availability_warning if builder.availability_warning
+      redirect_to recent_stays_path
+    else
+      @stay  = Stay.new(status: requested_status.presence || "pending")
+      @quote = safe_quote(@draft)
+      flash.now[:alert] = builder.error_message(default: "Le séjour n'a pas pu être créé.")
+      prepare_form
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @draft = draft_from_stay(@stay)
+    prepare_form
+  end
+
+  def update
+    @draft  = build_draft
+    updater = Stays::AdminUpdater.new(
+      stay:              @stay,
+      draft:             @draft,
+      status:            requested_status,
+      skip_availability: force_availability?,
+      user:              current_user
+    )
+
+    if updater.run
+      flash[:notice] = "Séjour mis à jour."
+      flash[:alert]  = updater.availability_warning if updater.availability_warning
+      redirect_to recent_stays_path
+    else
+      @quote = safe_quote(@draft)
+      flash.now[:alert] = updater.error_message(default: "Le séjour n'a pas pu être mis à jour.")
+      prepare_form
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # Suppression = soft-delete (soft_deletion + PaperTrail), jamais de hard destroy.
+  def destroy
+    @stay.soft_delete!(validate: false)
+    redirect_to recent_stays_path, notice: "Séjour supprimé."
+  end
+
   private
+
+  def set_stay
+    @stay = Stay.find(params[:id])
+  end
 
   def set_accounting_view
     @accounting_view = true
+  end
+
+  # Données partagées par les vues new/edit.
+  def prepare_form
+    @lodgings  = bookable_lodgings
+    @customers = Customer.order(:organization_name, :last_name, :first_name).limit(1_000)
+    @assignable_availabilities = ExperienceAvailability.for_user(current_user)
+                                                       .upcoming
+                                                       .includes(:experience)
+    @statuses = Stay::STATUSES_ADMIN_CREATABLE
+    @quote  ||= safe_quote(@draft)
+  end
+
+  # Hébergements tarifables (barème B2C forfaitaire, `Pricing::Catalog`), dans
+  # l'ordre du catalogue. Même barème que le funnel public — surtout PAS le
+  # barème admin par tier (décision figée epic #66).
+  def bookable_lodgings
+    names = Pricing::Catalog::LODGING_RATES.keys
+    Lodging.where(name: names).sort_by { |l| names.index(l.name) || 99 }
+  end
+
+  # Construit un `Reservations::Draft` (contrat commun Builder/PricingModel)
+  # depuis les paramètres du formulaire admin.
+  def build_draft
+    p = stay_params
+    contact = customer_contact(p)
+    Reservations::Draft.new(
+      lodging_id:     p[:lodging_id],
+      arrival_date:   p[:arrival_date],
+      departure_date: p[:departure_date],
+      adults:         p[:adults],
+      children:       p[:children],
+      dogs_count:     p[:dogs_count],
+      group_name:     p[:group_name],
+      first_name:     contact[:first_name],
+      last_name:      contact[:last_name],
+      email:          contact[:email],
+      phone:          contact[:phone],
+      experiences:    activity_entries(p)
+    )
+  end
+
+  # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
+  def draft_from_stay(stay)
+    booking = stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    Reservations::Draft.new(
+      lodging_id:     booking&.lodging_id,
+      arrival_date:   stay.arrival_date,
+      departure_date: stay.departure_date,
+      adults:         booking&.adults,
+      children:       booking&.children,
+      group_name:     booking&.group_name,
+      first_name:     stay.customer&.first_name,
+      last_name:      stay.customer&.last_name,
+      email:          stay.customer&.email,
+      phone:          stay.customer&.phone,
+      experiences:    stay.experience_bookings.active.map { |eb|
+        { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
+      }
+    )
+  end
+
+  # Coordonnées client : soit un client existant sélectionné (on lit ses
+  # coordonnées pour que le Builder/Updater le retrouve par email), soit un
+  # nouveau client saisi à la volée.
+  def customer_contact(p)
+    if p[:customer_mode].to_s == "new"
+      nc = p[:new_customer] || {}
+      { first_name: nc[:first_name], last_name: nc[:last_name], email: nc[:email], phone: nc[:phone] }
+    elsif (customer = Customer.find_by(id: p[:customer_id]))
+      { first_name: customer.first_name, last_name: customer.last_name, email: customer.email, phone: customer.phone }
+    else
+      {}
+    end
+  end
+
+  # Entrées d'activités : chaque ligne porte un créneau (`availability_id`) et un
+  # nombre de participants. On borne au périmètre de l'utilisateur et on résout
+  # l'`experience_id` (nécessaire au devis B2C via `PricingModel`).
+  def activity_entries(p)
+    rows = p[:experiences]
+    rows = rows.respond_to?(:values) ? rows.values : Array(rows)
+    allowed = ExperienceAvailability.for_user(current_user).index_by(&:id)
+
+    rows.filter_map do |row|
+      availability_id = row[:availability_id].to_i
+      participants    = row[:participants].to_i
+      next if availability_id < 1 || participants < 1
+      avail = allowed[availability_id]
+      next unless avail
+      { id: avail.experience_id, availability_id: availability_id, participants: participants }
+    end
+  end
+
+  def requested_status
+    stay_params[:status]
+  end
+
+  def force_availability?
+    ActiveModel::Type::Boolean.new.cast(stay_params[:force_availability])
+  end
+
+  def safe_quote(draft)
+    draft&.quote
+  rescue StandardError
+    nil
+  end
+
+  def stay_params
+    params.fetch(:stay, {})
   end
 
   def set_presenters; end

--- a/app/frontend/controllers/stay_form_controller.js
+++ b/app/frontend/controllers/stay_form_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Formulaire CRUD Séjour admin (epic #66, Phase 1). Bascule client existant /
+// nouveau client : seul le panneau actif est visible (les deux restent dans le
+// DOM, le contrôleur ne soumet pas côté client — c'est `customer_mode` qui dit
+// au serveur quel panneau lire).
+//
+// Usage (dans stays/_form) :
+//   form(data-controller="stay-form")
+//     input[type=radio name="stay[customer_mode]"] (data-action="change->stay-form#toggleCustomer")
+//     div(data-stay-form-target="existingPanel")
+//     div(data-stay-form-target="newPanel")
+export default class extends Controller {
+  static targets = ["existingPanel", "newPanel"]
+
+  connect() {
+    this.toggleCustomer()
+  }
+
+  toggleCustomer() {
+    const mode =
+      this.element.querySelector('input[name="stay[customer_mode]"]:checked')?.value ||
+      "existing"
+    this.togglePanel(this.existingPanelTarget, mode === "existing")
+    this.togglePanel(this.newPanelTarget, mode === "new")
+  }
+
+  togglePanel(panel, active) {
+    if (!panel) return
+    panel.classList.toggle("hidden", !active)
+  }
+}

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -24,6 +24,12 @@ class Stay < ApplicationRecord
   # de paiement ; Booking garde le sien tant que la colonne existe.
   PAYMENT_STATUSES = %w[pending partially_paid paid].freeze
 
+  # Statuts qu'un admin peut POSER à la création d'un séjour (epic #66, Phase 1).
+  # `status` reste une chaîne libre au niveau modèle (valeurs historiques :
+  # pending / confirmed / canceled) ; on borne seulement ce que le CRUD admin
+  # accepte de créer — jamais un `canceled` par le formulaire de création.
+  STATUSES_ADMIN_CREATABLE = %w[pending confirmed].freeze
+
   belongs_to :customer
   has_many :stay_items, dependent: :destroy
   has_many :experience_bookings, dependent: :destroy

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -16,11 +16,34 @@ module Reservations
   class Builder < ServiceBase
     class DraftInvalid < StandardError; end
 
-    attr_reader :draft, :stay, :customer, :booking, :payment
+    attr_reader :draft, :stay, :customer, :booking, :payment, :availability_warning
 
-    def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE)
+    # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
+    # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
+    # `skip_availability` n'affectent QUE le canal admin ; le funnel public
+    # (`admin: false`) garde exactement le comportement historique.
+    #
+    #   - admin: true           → ne crée AUCUN Payment (le solde se règle après,
+    #                             via la page client /sejour/:token) ; c'est aussi
+    #                             au contrôleur de NE PAS envoyer d'email client.
+    #   - status:               → statut du Stay à la création (`pending`/`confirmed`),
+    #                             au choix de l'admin. Défaut : `pending` (jamais
+    #                             d'auto-confirm côté public — Q5/AC-T2-19).
+    #   - source:               → canal d'attribution du Stay. Défaut `reservation`
+    #                             (public) ; l'admin passe `manual`.
+    #   - skip_availability:    → force la disponibilité : la dispo reste VÉRIFIÉE
+    #                             (le veto Grand-Duc de `Lodging#available_between?`
+    #                             fait foi) mais l'indisponibilité n'échoue plus —
+    #                             elle est exposée via `availability_warning`
+    #                             (surbooking / saisie a posteriori autorisés).
+    def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE,
+                   admin: false, status: nil, source: nil, skip_availability: false)
       @draft = draft
       @deposit_rate = deposit_rate
+      @admin = admin
+      @requested_status = status
+      @requested_source = source
+      @skip_availability = skip_availability
       @report_errors = true
     end
 
@@ -55,8 +78,8 @@ module Reservations
         # partira au paiement du solde (Phase 3), une fois le porteur validé.
         @stay = Stay.create!(
           customer: @customer,
-          source: "reservation",
-          status: "pending",
+          source: stay_source,
+          status: stay_status,
           arrival_date: draft.arrival_date,
           departure_date: draft.departure_date,
           total_amount_cents: quote.total_excluding_experiences_cents,
@@ -74,13 +97,10 @@ module Reservations
         # Le paiement est rattaché au Stay dans tous les cas ; le booking n'est
         # plus qu'une référence de commodité pour le canal historique. Son montant
         # reste l'acompte HORS activités (`quote.deposit_cents`).
-        @payment = Payment.create!(
-          booking: @booking,
-          stay: @stay,
-          amount_cents: quote.deposit_cents,
-          status: "pending",
-          payment_method: "card"
-        )
+        #
+        # Canal admin (epic #66) : AUCUN paiement n'est créé à l'enregistrement —
+        # le solde se règle après coup depuis la page client /sejour/:token.
+        @payment = build_payment!(quote) unless @admin
       end
       true
     end
@@ -107,7 +127,16 @@ module Reservations
       raise_invalid("Veuillez préciser votre prénom.") if draft.first_name.blank?
       raise_invalid("Veuillez préciser une adresse email valide.") unless Customer.exploitable_email?(draft.email)
       if draft.lodging.present? && !draft.lodging.available_between?(draft.arrival_date, draft.departure_date)
-        raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+        # Force-dispo admin (epic #66) : on n'échoue pas, on consigne un
+        # avertissement que le contrôleur remonte à l'admin. Hors force, le
+        # comportement historique tient (l'indisponibilité bloque la création).
+        if @skip_availability
+          @availability_warning =
+            "Ces dates ne sont plus disponibles pour #{draft.lodging.name} — " \
+            "séjour enregistré en forçant la disponibilité (surbooking / saisie a posteriori)."
+        else
+          raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+        end
       end
     end
 
@@ -165,7 +194,7 @@ module Reservations
         to_date: draft.departure_date,
         adults: [draft.adults, 1].max,
         children: draft.children.to_i,
-        status: "pending",
+        status: stay_status,
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
@@ -178,6 +207,27 @@ module Reservations
       booking.generate_token
       booking.save!
       booking
+    end
+
+    def build_payment!(quote)
+      Payment.create!(
+        booking: @booking,
+        stay: @stay,
+        amount_cents: quote.deposit_cents,
+        status: "pending",
+        payment_method: "card"
+      )
+    end
+
+    # Statut du Stay (et du Booking d'occupation) à la création. Le public reste
+    # sur `pending` (jamais d'auto-confirm — Q5) ; l'admin choisit explicitement.
+    def stay_status
+      return "pending" unless @admin
+      Stay::STATUSES_ADMIN_CREATABLE.include?(@requested_status) ? @requested_status : "pending"
+    end
+
+    def stay_source
+      @requested_source.presence || "reservation"
     end
 
     # Multi-chiens hors flow auto (Q2) : on consigne pour traitement manuel.

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -1,0 +1,192 @@
+module Stays
+  # Mise à jour de la composition d'un séjour existant depuis le CRUD admin
+  # (epic #66, Phase 1). Symétrique de `Reservations::Builder` (création) mais
+  # côté édition : on RÉCONCILIE l'occupation d'hébergement et les activités du
+  # séjour à partir d'un `Reservations::Draft` reconstruit depuis le formulaire —
+  # toujours SANS Stripe et sans email de confirmation forcé.
+  #
+  # Choix de conception :
+  #   - Le CLIENT est upserté par email (même mécanisme que le Builder) : que
+  #     l'admin sélectionne un client existant ou en crée un à la volée, le
+  #     formulaire remplit les coordonnées du draft, et on retrouve/complète le
+  #     `Customer` par son email normalisé.
+  #   - L'HÉBERGEMENT : on met à jour le `Booking` d'occupation existant, ou on en
+  #     crée un s'il n'y en a pas. On NE TOUCHE PAS au `status`/`email` du Booking
+  #     à l'édition (ces deux changements déclenchent l'email client via
+  #     `Booking#notify_customer_on_update`) — l'admin ne doit jamais spammer le
+  #     client en éditant la compo. Le statut fait foi au niveau du Stay.
+  #   - Les ACTIVITÉS : réconciliation ensembliste, bornée au périmètre de
+  #     l'utilisateur (`ExperienceAvailability.for_user`) — un porteur n'annule et
+  #     ne crée que sur SES créneaux, jamais sur ceux d'un autre.
+  #   - Le TOTAL et les DATES sont recalculés par `Stay#recompute_aggregates!`
+  #     (source unique déjà éprouvée : bookables + activités actives).
+  class AdminUpdater < ServiceBase
+    class Invalid < StandardError; end
+
+    attr_reader :stay, :availability_warning
+
+    def initialize(stay:, draft:, status: nil, skip_availability: false, user: nil)
+      @stay = stay
+      @draft = draft
+      @requested_status = status
+      @skip_availability = skip_availability
+      @user = user
+      @report_errors = true
+    end
+
+    def run
+      run!
+      true
+    rescue Invalid => e
+      set_error_message(e.message)
+      false
+    rescue => e
+      Sentry.capture_exception(e)
+      set_error_message("Une erreur est survenue lors de la mise à jour du séjour.")
+      false
+    end
+
+    def run!
+      validate!
+      ActiveRecord::Base.transaction do
+        @stay.update!(customer: upsert_customer!, status: stay_status)
+        reconcile_lodging!
+        reconcile_experiences!
+        @stay.recompute_aggregates!
+      end
+      true
+    end
+
+    private
+
+    def validate!
+      raise_invalid("Veuillez choisir des dates valides.") if @draft.nights < 1
+      # Phase 1 : un séjour admin porte au moins un hébergement (espaces / camping
+      # arrivent aux phases 2-3). Retirer le DERNIER hébergement est donc hors
+      # périmètre ici — on change ou on garde l'hébergement.
+      raise_invalid("Veuillez sélectionner un hébergement.") if @draft.lodging.blank?
+      unless Customer.exploitable_email?(@draft.email)
+        raise_invalid("Veuillez préciser une adresse email valide pour le client.")
+      end
+      check_availability!
+    end
+
+    def check_availability!
+      return if @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
+
+      if @skip_availability
+        @availability_warning =
+          "Ces dates ne sont plus disponibles pour #{@draft.lodging.name} — " \
+          "séjour enregistré en forçant la disponibilité (surbooking / saisie a posteriori)."
+      else
+        raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+      end
+    end
+
+    def upsert_customer!
+      email = Customer.normalize_email(@draft.email)
+      customer = Customer.where(email: email).first_or_initialize
+      customer.email = email
+      customer.first_name = @draft.first_name if customer.first_name.blank?
+      customer.last_name  = @draft.last_name  if customer.last_name.blank?
+      customer.phone      = @draft.phone      if customer.phone.blank?
+      customer.save!
+      customer
+    end
+
+    def reconcile_lodging!
+      price   = @draft.quote.total_excluding_experiences_cents
+      booking = existing_lodging_booking
+
+      if booking
+        # NB : ni `status` ni `email` ici — voir l'en-tête de classe (anti-email).
+        booking.update!(
+          lodging_id:        @draft.lodging_id,
+          from_date:         @draft.arrival_date,
+          to_date:           @draft.departure_date,
+          adults:            [@draft.adults, 1].max,
+          children:          @draft.children.to_i,
+          group_name:        @draft.group_name,
+          firstname:         @draft.first_name,
+          lastname:          @draft.last_name,
+          phone:             @draft.phone,
+          price_cents:       price,
+          shown_price_cents: price
+        )
+      else
+        booking = Booking.new(
+          firstname:         @draft.first_name,
+          lastname:          @draft.last_name,
+          email:             Customer.normalize_email(@draft.email),
+          phone:             @draft.phone,
+          group_name:        @draft.group_name,
+          from_date:         @draft.arrival_date,
+          to_date:           @draft.departure_date,
+          adults:            [@draft.adults, 1].max,
+          children:          @draft.children.to_i,
+          status:            stay_status,
+          payment_status:    "pending",
+          platform:          "web",
+          lodging_id:        @draft.lodging_id,
+          price_cents:       price,
+          shown_price_cents: price
+        )
+        booking.generate_token
+        booking.save!
+        @stay.stay_items.create!(bookable: booking)
+      end
+    end
+
+    def existing_lodging_booking
+      @stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    end
+
+    def reconcile_experiences!
+      desired  = desired_experience_map
+      allowed  = allowed_availability_ids
+
+      @stay.experience_bookings.active.each do |eb|
+        # On ne réconcilie (annule) QUE dans le périmètre de l'utilisateur.
+        next unless allowed.include?(eb.experience_availability_id)
+        next if desired.key?(eb.experience_availability_id)
+        eb.update!(status: "cancelled")
+      end
+
+      desired.each do |availability_id, participants|
+        eb = @stay.experience_bookings.active.find_by(experience_availability_id: availability_id)
+        if eb
+          eb.update!(participants: participants)
+        else
+          @stay.experience_bookings.create!(
+            experience_availability_id: availability_id,
+            participants: participants,
+            status: "pending"
+          )
+        end
+      end
+    end
+
+    def desired_experience_map
+      allowed = allowed_availability_ids
+      Array(@draft.experiences).each_with_object({}) do |entry, memo|
+        aid          = entry[:availability_id].to_i
+        participants = entry[:participants].to_i
+        next if aid < 1 || participants < 1
+        next unless allowed.include?(aid)
+        memo[aid] = participants
+      end
+    end
+
+    def allowed_availability_ids
+      @allowed_availability_ids ||= ExperienceAvailability.for_user(@user).pluck(:id).to_set
+    end
+
+    def stay_status
+      Stay::STATUSES_ADMIN_CREATABLE.include?(@requested_status) ? @requested_status : @stay.status
+    end
+
+    def raise_invalid(message)
+      raise Invalid, message
+    end
+  end
+end

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -1,0 +1,102 @@
+/ Formulaire CRUD Séjour admin (epic #66, Phase 1). Locals : url, method, submit_label.
+/ Champs sous le namespace `stay[...]`. Devis B2C forfaitaire (PricingModel).
+- selected_customer_id = @stay.persisted? ? @stay.customer_id : nil
+- current_status = (@stay.status.presence || "pending")
+- selected_experiences = {}
+- Array(@draft&.experiences).each { |e| selected_experiences[e[:availability_id].to_i] = e[:participants] }
+
+= form_with url: url, method: method, data: { controller: "stay-form" } do
+  .space-y-8
+    / --- Client -------------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Client
+      .flex.gap-4.text-sm
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[customer_mode]" value="existing" checked=true data-action="change->stay-form#toggleCustomer"
+          | Client existant
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[customer_mode]" value="new" data-action="change->stay-form#toggleCustomer"
+          | Nouveau client
+
+      .space-y-1(data-stay-form-target="existingPanel")
+        label.block.text-sm.font-medium.text-gray-700 Sélectionner un client
+        = select_tag "stay[customer_id]", options_for_select(@customers.map { |c| [c.name.presence || c.email, c.id] }, selected_customer_id), include_blank: "— Choisir un client —", class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+
+      .space-y-2.hidden(data-stay-form-target="newPanel")
+        .grid.grid-cols-2.gap-2
+          = text_field_tag "stay[new_customer][first_name]", @draft&.first_name, placeholder: "Prénom", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+          = text_field_tag "stay[new_customer][last_name]", @draft&.last_name, placeholder: "Nom", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+        = email_field_tag "stay[new_customer][email]", @draft&.email, placeholder: "Email", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        = telephone_field_tag "stay[new_customer][phone]", @draft&.phone, placeholder: "Téléphone", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Séjour (dates + groupe) --------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Séjour
+      .grid.grid-cols-2.gap-4
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Arrivée
+          = date_field_tag "stay[arrival_date]", @draft&.arrival_date&.iso8601, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Départ
+          = date_field_tag "stay[departure_date]", @draft&.departure_date&.iso8601, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      .grid.grid-cols-3.gap-4
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Adultes
+          = number_field_tag "stay[adults]", (@draft&.adults.to_i.positive? ? @draft.adults : 1), min: 1, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Enfants
+          = number_field_tag "stay[children]", @draft&.children.to_i, min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Chiens
+          = number_field_tag "stay[dogs_count]", @draft&.dogs_count.to_i, min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Nom du groupe (optionnel)
+        = text_field_tag "stay[group_name]", @draft&.group_name, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Hébergement --------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Hébergement
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Hébergement
+        = select_tag "stay[lodging_id]", options_for_select(@lodgings.map { |l| [l.form_label, l.id] }, @draft&.lodging_id), include_blank: "— Choisir un hébergement —", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Activités ----------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Activités
+      - if @assignable_availabilities.blank?
+        p.text-sm.text-gray-500 Aucun créneau d'activité proposable.
+      - else
+        p.text-sm.text-gray-500 Indiquez le nombre de participants pour chaque créneau souhaité (0 = non réservé).
+        ul.divide-y.divide-gray-100
+          - @assignable_availabilities.each_with_index do |availability, index|
+            li.py-2.flex.items-center.justify-between.gap-4
+              span.text-sm.text-gray-900 = availability.label
+              = hidden_field_tag "stay[experiences][#{index}][availability_id]", availability.id
+              = number_field_tag "stay[experiences][#{index}][participants]", selected_experiences[availability.id].to_i, min: 0, class: "w-20 rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Statut + force dispo -----------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Statut & disponibilité
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Statut du séjour
+        = select_tag "stay[status]", options_for_select([["En attente", "pending"], ["Confirmé", "confirmed"]], current_status), class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      label.flex.items-center.gap-2.text-sm.text-gray-700
+        = check_box_tag "stay[force_availability]", "1", false
+        | Forcer la disponibilité (surbooking / saisie a posteriori)
+
+    / --- Devis --------------------------------------------------------------
+    - if @quote
+      section.bg-gray-50.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-2
+        h2.text-base.font-semibold.text-gray-900 Devis (B2C)
+        ul.text-sm.text-gray-700.space-y-1
+          - @quote.breakdown.each do |line|
+            li.flex.justify-between
+              span = line[:label]
+              span = humanized_money_with_symbol(Money.new(line[:amount_cents]))
+        .flex.justify-between.border-t.border-gray-200.pt-2.font-semibold.text-gray-900
+          span Total
+          span = humanized_money_with_symbol(Money.new(@quote.total_cents))
+
+    .flex.justify-end.gap-3
+      = link_to "Annuler", recent_stays_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      = submit_tag submit_label, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"

--- a/app/views/stays/edit.html.slim
+++ b/app/views/stays/edit.html.slim
@@ -1,0 +1,7 @@
+.px-4.sm:px-6.lg:px-8.py-6
+  .mb-6.flex.items-start.justify-between.gap-4
+    div
+      h1.text-xl.font-semibold.text-gray-900 = "Modifier le séjour ##{@stay.id}"
+      p.mt-1.text-sm.text-gray-600 Modifiez la composition du séjour (hébergement + activités). Aucun paiement n'est déclenché.
+    = button_to "Supprimer le séjour", stay_path(@stay), method: :delete, data: { turbo_confirm: "Supprimer ce séjour ? Cette action est réversible (soft-delete)." }, class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+  = render "form", url: stay_path(@stay), method: :patch, submit_label: "Enregistrer les modifications"

--- a/app/views/stays/new.html.slim
+++ b/app/views/stays/new.html.slim
@@ -1,0 +1,5 @@
+.px-4.sm:px-6.lg:px-8.py-6
+  .mb-6
+    h1.text-xl.font-semibold.text-gray-900 Nouveau séjour
+    p.mt-1.text-sm.text-gray-600 Créez un séjour composable (hébergement + activités). Aucun paiement n'est déclenché à la création.
+  = render "form", url: stays_path, method: :post, submit_label: "Créer le séjour"

--- a/app/views/stays/recent.html.slim
+++ b/app/views/stays/recent.html.slim
@@ -3,6 +3,8 @@
     .sm:flex-auto
       h1.text-xl.font-semibold.text-gray-900 Séjours récents
       p.mt-2.text-sm.text-gray-700 Observez la transition Tally → /reservation par canal d'attribution.
+    .mt-4.sm:mt-0.sm:ml-4
+      = link_to "Nouveau séjour", new_stay_path, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
 
   / Filtre par source (AC-T2-23).
   = form_with url: recent_stays_path, method: :get, class: "mb-4 flex items-center gap-2" do
@@ -18,6 +20,7 @@
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Canal
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Statut
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Créé le
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Actions
       tbody.divide-y.divide-gray-200.bg-white
         - @stays.each do |stay|
           tr.hover:bg-gray-50
@@ -31,6 +34,8 @@
               span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.py-0.5.text-xs.font-medium.text-gray-700 = stay.source
             td.px-4.py-2.text-sm = stay.status_badge
             td.px-4.py-2.text-sm.text-gray-500 = l(stay.created_at.to_date, format: :long)
+            td.px-4.py-2.text-sm.text-right
+              = link_to "Éditer", edit_stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 hover:underline"
         - if @stays.empty?
           tr
-            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="5" Aucun séjour pour ce canal.
+            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="6" Aucun séjour pour ce canal.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,7 +113,12 @@ Rails.application.routes.draw do
   # Le CRUD admin d'une activité SUR un séjour (epic #55, Phase 6) est imbriqué
   # sous cette ressource : la création porte TOUJOURS le séjour dans l'URL, si
   # bien qu'une activité ne peut jamais naître sans son séjour d'attache.
-  resources :stays, only: [:show] do
+  # CRUD Séjour admin (epic #66, Phase 1) — le séjour devient le point d'entrée
+  # de création composable côté admin (hébergement + activités). URLs anglaises.
+  # `show` reste rendu sans layout (fragment de modale) ; new/edit sont des pages
+  # pleines. La route `stays/recents` ci-dessus est déclarée AVANT pour ne pas
+  # être captée par `/stays/:id`.
+  resources :stays, only: [:show, :new, :create, :edit, :update, :destroy] do
     resources :experience_bookings, only: [:create]
   end
   resources :experience_bookings, only: [:index, :update, :destroy] do

--- a/spec/requests/stays_admin_crud_spec.rb
+++ b/spec/requests/stays_admin_crud_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+# CRUD Séjour admin (epic #66, Phase 1) — le séjour devient le point d'entrée de
+# création composable côté admin (hébergement + activités), en réutilisant
+# `Reservations::Builder` en mode admin : aucun Stripe, aucun email forcé,
+# force-dispo avec avertissement, statut au choix, client existant ou à la volée.
+RSpec.describe "Stays — CRUD admin (epic #66)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-stays@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  # Hébergement tarifé au barème B2C (Pricing::Catalog) : La Hulotte = 485 € la
+  # 1re nuit + 260 € par nuit suivante. 2 nuits → 745 € (74 500 cents).
+  let!(:lodging)  { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+  let(:hulotte_two_nights_cents) { 74_500 }
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  # Crée un séjour admin directement via le Builder (helper pour edit/update/destroy).
+  def create_admin_stay(status: "pending")
+    draft = Reservations::Draft.new(
+      lodging_id: lodging.id, arrival_date: arrival, departure_date: departure,
+      adults: 2, first_name: "Alice", last_name: "Martin",
+      email: "alice@example.com", phone: "0470111222"
+    )
+    builder = Reservations::Builder.new(draft: draft, admin: true, status: status, source: "manual")
+    builder.run!
+    builder.stay
+  end
+
+  describe "GET /stays/new" do
+    it "affiche le formulaire de composition" do
+      get new_stay_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Nouveau séjour")
+      expect(response.body).to include("La Hulotte")
+      expect(response.body).to include("Forcer la disponibilité")
+    end
+  end
+
+  describe "POST /stays (create)" do
+    it "crée un séjour avec un nouveau client, une occupation d'hébergement et AUCUN paiement" do
+      expect {
+        post stays_path, params: base_params
+      }.to change(Stay, :count).by(1)
+       .and change(Customer, :count).by(1)
+       .and change(Booking, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      stay = Stay.order(:created_at).last
+      expect(stay.source).to eq("manual")
+      expect(stay.status).to eq("pending")
+      expect(stay.customer.email).to eq("alice@example.com")
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents)
+      # Décision figée : aucun paiement (donc aucun appel Stripe) à la création admin.
+      expect(stay.payments).to be_empty
+    end
+
+    it "réutilise un client existant sélectionné par id (pas de doublon)" do
+      customer = Customer.create!(email: "bob@example.com", first_name: "Bob", customer_type: "individual")
+      expect {
+        post stays_path, params: base_params(customer_mode: "existing", customer_id: customer.id, new_customer: {})
+      }.to change(Stay, :count).by(1).and change(Customer, :count).by(0)
+
+      expect(Stay.order(:created_at).last.customer).to eq(customer)
+    end
+
+    it "laisse l'admin choisir le statut confirmé" do
+      post stays_path, params: base_params(status: "confirmed")
+      expect(Stay.order(:created_at).last.status).to eq("confirmed")
+    end
+
+    it "bloque la création sur des dates indisponibles hors force" do
+      Unavailability.create!(lodging: lodging, date: arrival)
+      expect { post stays_path, params: base_params }.not_to change(Stay, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("plus disponibles")
+    end
+
+    it "force la création sur des dates indisponibles avec un avertissement" do
+      Unavailability.create!(lodging: lodging, date: arrival)
+      expect {
+        post stays_path, params: base_params(force_availability: "1")
+      }.to change(Stay, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to include("forçant la disponibilité")
+    end
+
+    it "attache les activités sélectionnées et les intègre au total" do
+      exp   = Experience.create!(name: "Balade ânes", fixed_price_cents: 4_000, price_cents: 1_500)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "10:00")
+
+      post stays_path, params: base_params(experiences: { "0" => { availability_id: avail.id, participants: 2 } })
+
+      stay = Stay.order(:created_at).last
+      expect(stay.experience_bookings.count).to eq(1)
+      # Activité : 40 € forfait + 15 €/pers × 2 = 70 € (7 000 cents). Total = 745 € + 70 €.
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents + 7_000)
+    end
+  end
+
+  describe "GET /stays/:id/edit" do
+    it "affiche le formulaire prérempli" do
+      stay = create_admin_stay
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Modifier le séjour ##{stay.id}")
+      expect(response.body).to include("La Hulotte")
+    end
+  end
+
+  describe "PATCH /stays/:id (update)" do
+    let!(:cheveche) { Lodging.create!(name: "La Chevêche", summary: "gîte") }
+
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: lodging.id, status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "modifie l'hébergement et recalcule le total" do
+      stay = create_admin_stay
+      patch stay_path(stay), params: update_params(stay, lodging_id: cheveche.id)
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay.reload
+      booking = stay.stay_items.where(bookable_type: "Booking").first.bookable
+      expect(booking.lodging_id).to eq(cheveche.id)
+      # La Chevêche = 275 € + 200 € = 475 € (47 500 cents) sur 2 nuits.
+      expect(stay.total_amount_cents).to eq(47_500)
+    end
+
+    it "bascule le statut en confirmé SANS envoyer d'email au client" do
+      stay = create_admin_stay
+      ActionMailer::Base.deliveries.clear
+      patch stay_path(stay), params: update_params(stay, status: "confirmed")
+
+      expect(stay.reload.status).to eq("confirmed")
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+
+    it "ajoute une activité à un séjour existant" do
+      stay  = create_admin_stay
+      exp   = Experience.create!(name: "Poterie", price_cents: 2_000)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "14:00")
+
+      expect {
+        patch stay_path(stay), params: update_params(stay, experiences: { "0" => { availability_id: avail.id, participants: 3 } })
+      }.to change { stay.experience_bookings.active.count }.from(0).to(1)
+
+      expect(stay.reload.total_amount_cents).to eq(hulotte_two_nights_cents + 6_000) # 20 €/pers × 3
+    end
+
+    it "retire une activité en passant ses participants à 0" do
+      stay  = create_admin_stay
+      exp   = Experience.create!(name: "Poterie", price_cents: 2_000)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "14:00")
+      stay.experience_bookings.create!(experience_availability: avail, participants: 2, status: "pending")
+
+      expect {
+        patch stay_path(stay), params: update_params(stay, experiences: { "0" => { availability_id: avail.id, participants: 0 } })
+      }.to change { stay.experience_bookings.active.count }.from(1).to(0)
+    end
+  end
+
+  describe "DELETE /stays/:id (destroy)" do
+    it "soft-supprime le séjour (jamais de hard destroy)" do
+      stay = create_admin_stay
+      delete stay_path(stay)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(Stay.exists?(stay.id)).to be(false)                     # hors default scope
+      expect(Stay.unscoped.find(stay.id).deleted_at).to be_present   # présent mais marqué supprimé
+    end
+  end
+end


### PR DESCRIPTION
## Epic #66 — Phase 1 : CRUD Séjour admin composable (Stay-first)

Premier maillon de la bascule « le séjour est le point d'entrée unique de création côté admin ». L'admin peut créer/éditer/supprimer un séjour composable **hébergement + activités**, en réutilisant `Reservations::Builder` / `Reservations::Draft` / `PricingModel` — **sans jamais toucher à Stripe**.

### Livré
- `StaysController` : `new` / `create` / `edit` / `update` / `destroy` (URLs **anglaises** ; `stays/recents` conservé AVANT `/stays/:id`).
- **Mode admin sur le Builder** (4 kwargs inertes pour le funnel public, `admin: false` par défaut → comportement historique intact) :
  - `admin: true` → **aucun `Payment`** (le solde se règle après via `/sejour/:token`), pas d'email client.
  - `status:` → statut à la création borné à `pending`/`confirmed` (`Stay::STATUSES_ADMIN_CREATABLE`).
  - `skip_availability:` → **force-dispo avec avertissement** (`flash[:alert]`), le veto Grand-Duc reste la source de vérité.
  - `source:` → `manual` côté admin.
- `Stays::AdminUpdater` : édition de compo (upsert client par email, réconciliation activités bornée à `ExperienceAvailability.for_user`), **aucun email client à l'édition** même sur passage `confirmed` (testé).
- Client : **sélection d'un existant OU création à la volée** (Stimulus `stay_form`).
- Devis **B2C forfaitaire** (`PricingModel`, même barème que le funnel public), rendu au submit.
- `destroy` = soft-delete (soft_deletion + PaperTrail).

### Tests
`bundle exec rspec` → **522 examples, 0 failures, 18 pending** (pending = specs de modèles générés préexistants). Nouveau `spec/requests/stays_admin_crud_spec.rb` = 13 exemples verts.

### Hors périmètre (phases suivantes)
Espaces → Phase 2 · camping/repas → Phase 3 · calendrier groupé par séjour → Phases 4-5. Phase 1 exige un hébergement (activités/espaces/camping seuls refusés ici). Devis « live » au submit (pas temps-réel). Vérif navigateur = passe agent-browser groupée en fin d'epic (comme #55).

Refs #66
