### PR TITLE
Epic #66 Phase 2 — Espaces dans la composition du Séjour admin

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -1,5 +1,6 @@
 class StaysController < BaseController
   before_action :set_accounting_view, only: :show
+  before_action :set_stay, only: %i[edit update destroy]
 
   # Rendu sans layout : le fragment HTML est injecté dans la modale de détails
   # par le contrôleur Stimulus stay-details (fetch + innerHTML). [tranche 1]
@@ -22,10 +23,191 @@ class StaysController < BaseController
     @stays = Stay.from_source(@source).recent.includes(:customer).limit(100).decorate
   end
 
+  # --- CRUD Séjour admin (epic #66, Phase 1) --------------------------------
+  # Le séjour devient le point d'entrée de création composable côté admin
+  # (hébergement + activités), en réutilisant `Reservations::Builder` en mode
+  # admin (aucun Stripe, aucun email forcé, force-dispo, statut au choix).
+
+  def new
+    @stay  = Stay.new(status: "pending")
+    @draft = Reservations::Draft.new
+    prepare_form
+  end
+
+  def create
+    @draft  = build_draft
+    builder = Reservations::Builder.new(
+      draft:             @draft,
+      admin:             true,
+      status:            requested_status,
+      source:            "manual",
+      skip_availability: force_availability?
+    )
+
+    if builder.run
+      flash[:notice] = "Séjour créé."
+      flash[:alert]  = builder.availability_warning if builder.availability_warning
+      redirect_to recent_stays_path
+    else
+      @stay  = Stay.new(status: requested_status.presence || "pending")
+      @quote = safe_quote(@draft)
+      flash.now[:alert] = builder.error_message(default: "Le séjour n'a pas pu être créé.")
+      prepare_form
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @draft = draft_from_stay(@stay)
+    prepare_form
+  end
+
+  def update
+    @draft  = build_draft
+    updater = Stays::AdminUpdater.new(
+      stay:              @stay,
+      draft:             @draft,
+      status:            requested_status,
+      skip_availability: force_availability?,
+      user:              current_user
+    )
+
+    if updater.run
+      flash[:notice] = "Séjour mis à jour."
+      flash[:alert]  = updater.availability_warning if updater.availability_warning
+      redirect_to recent_stays_path
+    else
+      @quote = safe_quote(@draft)
+      flash.now[:alert] = updater.error_message(default: "Le séjour n'a pas pu être mis à jour.")
+      prepare_form
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # Suppression = soft-delete (soft_deletion + PaperTrail), jamais de hard destroy.
+  def destroy
+    @stay.soft_delete!(validate: false)
+    redirect_to recent_stays_path, notice: "Séjour supprimé."
+  end
+
   private
+
+  def set_stay
+    @stay = Stay.find(params[:id])
+  end
 
   def set_accounting_view
     @accounting_view = true
+  end
+
+  # Données partagées par les vues new/edit.
+  def prepare_form
+    @lodgings  = bookable_lodgings
+    @customers = Customer.order(:organization_name, :last_name, :first_name).limit(1_000)
+    @assignable_availabilities = ExperienceAvailability.for_user(current_user)
+                                                       .upcoming
+                                                       .includes(:experience)
+    @statuses = Stay::STATUSES_ADMIN_CREATABLE
+    @quote  ||= safe_quote(@draft)
+  end
+
+  # Hébergements tarifables (barème B2C forfaitaire, `Pricing::Catalog`), dans
+  # l'ordre du catalogue. Même barème que le funnel public — surtout PAS le
+  # barème admin par tier (décision figée epic #66).
+  def bookable_lodgings
+    names = Pricing::Catalog::LODGING_RATES.keys
+    Lodging.where(name: names).sort_by { |l| names.index(l.name) || 99 }
+  end
+
+  # Construit un `Reservations::Draft` (contrat commun Builder/PricingModel)
+  # depuis les paramètres du formulaire admin.
+  def build_draft
+    p = stay_params
+    contact = customer_contact(p)
+    Reservations::Draft.new(
+      lodging_id:     p[:lodging_id],
+      arrival_date:   p[:arrival_date],
+      departure_date: p[:departure_date],
+      adults:         p[:adults],
+      children:       p[:children],
+      dogs_count:     p[:dogs_count],
+      group_name:     p[:group_name],
+      first_name:     contact[:first_name],
+      last_name:      contact[:last_name],
+      email:          contact[:email],
+      phone:          contact[:phone],
+      experiences:    activity_entries(p)
+    )
+  end
+
+  # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
+  def draft_from_stay(stay)
+    booking = stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    Reservations::Draft.new(
+      lodging_id:     booking&.lodging_id,
+      arrival_date:   stay.arrival_date,
+      departure_date: stay.departure_date,
+      adults:         booking&.adults,
+      children:       booking&.children,
+      group_name:     booking&.group_name,
+      first_name:     stay.customer&.first_name,
+      last_name:      stay.customer&.last_name,
+      email:          stay.customer&.email,
+      phone:          stay.customer&.phone,
+      experiences:    stay.experience_bookings.active.map { |eb|
+        { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
+      }
+    )
+  end
+
+  # Coordonnées client : soit un client existant sélectionné (on lit ses
+  # coordonnées pour que le Builder/Updater le retrouve par email), soit un
+  # nouveau client saisi à la volée.
+  def customer_contact(p)
+    if p[:customer_mode].to_s == "new"
+      nc = p[:new_customer] || {}
+      { first_name: nc[:first_name], last_name: nc[:last_name], email: nc[:email], phone: nc[:phone] }
+    elsif (customer = Customer.find_by(id: p[:customer_id]))
+      { first_name: customer.first_name, last_name: customer.last_name, email: customer.email, phone: customer.phone }
+    else
+      {}
+    end
+  end
+
+  # Entrées d'activités : chaque ligne porte un créneau (`availability_id`) et un
+  # nombre de participants. On borne au périmètre de l'utilisateur et on résout
+  # l'`experience_id` (nécessaire au devis B2C via `PricingModel`).
+  def activity_entries(p)
+    rows = p[:experiences]
+    rows = rows.respond_to?(:values) ? rows.values : Array(rows)
+    allowed = ExperienceAvailability.for_user(current_user).index_by(&:id)
+
+    rows.filter_map do |row|
+      availability_id = row[:availability_id].to_i
+      participants    = row[:participants].to_i
+      next if availability_id < 1 || participants < 1
+      avail = allowed[availability_id]
+      next unless avail
+      { id: avail.experience_id, availability_id: availability_id, participants: participants }
+    end
+  end
+
+  def requested_status
+    stay_params[:status]
+  end
+
+  def force_availability?
+    ActiveModel::Type::Boolean.new.cast(stay_params[:force_availability])
+  end
+
+  def safe_quote(draft)
+    draft&.quote
+  rescue StandardError
+    nil
+  end
+
+  def stay_params
+    params.fetch(:stay, {})
   end
 
   def set_presenters; end

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -136,7 +136,8 @@ class StaysController < BaseController
       last_name:      contact[:last_name],
       email:          contact[:email],
       phone:          contact[:phone],
-      experiences:    activity_entries(p)
+      experiences:    activity_entries(p),
+      halls:          space_entries(p)
     )
   end
 
@@ -156,8 +157,29 @@ class StaysController < BaseController
       phone:          stay.customer&.phone,
       experiences:    stay.experience_bookings.active.map { |eb|
         { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
-      }
+      },
+      halls:          halls_from_stay(stay)
     )
+  end
+
+  # Reconstruit les lignes d'espaces {kind, date, period} d'un séjour depuis son
+  # SpaceBooking (réservations existantes), pour préremplir le form edit. Le nom
+  # de la Space est re-mappé vers sa clé de pricing (grande_salle, …).
+  def halls_from_stay(stay)
+    space_booking = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+    return [] if space_booking.nil?
+
+    space_booking.space_reservations.map do |res|
+      key = space_key_for_name(res.space&.name)
+      next if key.nil?
+      { kind: key, date: res.date&.iso8601, period: res.duration }
+    end.compact
+  end
+
+  # Space#name → clé de pricing (inverse de SpaceComposition::SPACE_NAMES_BY_KEY).
+  def space_key_for_name(name)
+    return nil if name.blank?
+    SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(name) }&.first
   end
 
   # Coordonnées client : soit un client existant sélectionné (on lit ses
@@ -189,6 +211,23 @@ class StaysController < BaseController
       avail = allowed[availability_id]
       next unless avail
       { id: avail.experience_id, availability_id: availability_id, participants: participants }
+    end
+  end
+
+  # Entrées d'espaces (epic #66, Phase 2) : chaque ligne du form porte un espace
+  # (`kind` = clé de pricing grande_salle/petite_salle/cuisine_pro), une `date` et
+  # une `period` (journee/soiree/journee_et_soiree). On écarte les lignes
+  # incomplètes ; le résultat alimente `Reservations::Draft#halls` — commun au
+  # devis (PricingModel) ET à la persistance (SpaceComposition).
+  def space_entries(p)
+    rows = p[:halls]
+    rows = rows.respond_to?(:values) ? rows.values : Array(rows)
+    rows.filter_map do |row|
+      kind   = row[:kind].to_s
+      date   = row[:date].to_s
+      period = row[:period].to_s
+      next if kind.blank? || date.blank? || period.blank?
+      { kind: kind, date: date, period: period }
     end
   end
 

--- a/app/frontend/controllers/stay_form_controller.js
+++ b/app/frontend/controllers/stay_form_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Formulaire CRUD Séjour admin (epic #66, Phase 1). Bascule client existant /
+// nouveau client : seul le panneau actif est visible (les deux restent dans le
+// DOM, le contrôleur ne soumet pas côté client — c'est `customer_mode` qui dit
+// au serveur quel panneau lire).
+//
+// Usage (dans stays/_form) :
+//   form(data-controller="stay-form")
+//     input[type=radio name="stay[customer_mode]"] (data-action="change->stay-form#toggleCustomer")
+//     div(data-stay-form-target="existingPanel")
+//     div(data-stay-form-target="newPanel")
+export default class extends Controller {
+  static targets = ["existingPanel", "newPanel"]
+
+  connect() {
+    this.toggleCustomer()
+  }
+
+  toggleCustomer() {
+    const mode =
+      this.element.querySelector('input[name="stay[customer_mode]"]:checked')?.value ||
+      "existing"
+    this.togglePanel(this.existingPanelTarget, mode === "existing")
+    this.togglePanel(this.newPanelTarget, mode === "new")
+  }
+
+  togglePanel(panel, active) {
+    if (!panel) return
+    panel.classList.toggle("hidden", !active)
+  }
+}

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -24,6 +24,12 @@ class Stay < ApplicationRecord
   # de paiement ; Booking garde le sien tant que la colonne existe.
   PAYMENT_STATUSES = %w[pending partially_paid paid].freeze
 
+  # Statuts qu'un admin peut POSER à la création d'un séjour (epic #66, Phase 1).
+  # `status` reste une chaîne libre au niveau modèle (valeurs historiques :
+  # pending / confirmed / canceled) ; on borne seulement ce que le CRUD admin
+  # accepte de créer — jamais un `canceled` par le formulaire de création.
+  STATUSES_ADMIN_CREATABLE = %w[pending confirmed].freeze
+
   belongs_to :customer
   has_many :stay_items, dependent: :destroy
   has_many :experience_bookings, dependent: :destroy

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -209,10 +209,15 @@ class Stay < ApplicationRecord
     # jamais les bornes du calendrier du séjour.
     amount = items.sum { |b| b.try(:price_cents).to_i } +
              experience_bookings.active.sum(&:price_cents)
-    update!(
-      arrival_date: arrivals.min,
-      departure_date: departures.max,
-      total_amount_cents: amount
-    )
+    # Séjour SANS hébergement (epic #66, Phase 2) : les dates viennent des
+    # SpaceBooking (Booking ET SpaceBooking exposent from_date/to_date), donc un
+    # séjour « espaces seuls » reste daté. On ne réécrit les dates QUE si au moins
+    # un bookable en porte — sinon on préserve les dates existantes plutôt que de
+    # les écraser à nil (garde-fou : un recompute sur un séjour sans bookable daté
+    # ne doit pas effacer arrival/departure).
+    attrs = { total_amount_cents: amount }
+    attrs[:arrival_date]   = arrivals.min   if arrivals.any?
+    attrs[:departure_date] = departures.max if departures.any?
+    update!(attrs)
   end
 end

--- a/app/services/concerns/space_composition.rb
+++ b/app/services/concerns/space_composition.rb
@@ -1,0 +1,150 @@
+# Composition d'ESPACES d'un séjour depuis un `Reservations::Draft` (epic #66,
+# Phase 2). Concern PARTAGÉ par `Reservations::Builder` (création) et
+# `Stays::AdminUpdater` (édition) : les deux traduisent les espaces choisis
+# (`space_slots` grille nuit-par-nuit OU `halls` ponctuels {kind, date, period})
+# en un `SpaceBooking` + ses `SpaceReservation`, rattaché au séjour via un
+# `StayItem`.
+#
+# Réutilisation maximale (décision figée) :
+#   - la disponibilité reste CAPACITY-AWARE via `Space#available_on?` (source
+#     unique de vérité, comme `SpaceBookable#available?`) ;
+#   - le montant de l'espace vient du devis B2C (`PricingModel`, part `:space`),
+#     jamais recalculé ici.
+#
+# ⚠️ MAPPING clé de pricing → `Space` (à surveiller — voir gap connu) : le funnel
+# public price les espaces avec des clés forfaitaires (`grande_salle`, …) qui ne
+# correspondent pas 1:1 aux `Space.name` en base (seed : « Tilleul », « Saule »).
+# On résout donc par une LISTE de noms candidats par clé, tolérante aux deux
+# conventions (nom marketing OU nom du seed). Si aucune `Space` ne matche, la
+# ligne reste dans le devis mais n'est pas persistée (voir `unresolved_space_keys`).
+module SpaceComposition
+  extend ActiveSupport::Concern
+
+  # Noms de `Space` acceptés pour chaque clé de pricing, par ordre de préférence.
+  # Le premier trouvé en base gagne. Cf. `PricingModel::SPACE_NAMES`.
+  SPACE_NAMES_BY_KEY = {
+    "grande_salle" => ["Grande Salle", "Tilleul"],
+    "petite_salle" => ["Petite Salle", "Saule"],
+    "cuisine_pro"  => ["Cuisine professionnelle", "Cuisine pro"]
+  }.freeze
+
+  private
+
+  # Le draft porte-t-il au moins un espace exploitable (résolu ou non) ?
+  # Sert au gate « contenu réservable » (un séjour peut être espaces-seuls).
+  def draft_has_spaces?(draft)
+    raw_space_entries(draft).any?
+  end
+
+  # Specs de réservation d'espace RÉSOLUES : [{ space:, date:, duration: }].
+  # Ne contient que les entrées dont la `Space` existe en base.
+  def space_reservation_specs(draft)
+    raw_space_entries(draft).filter_map do |entry|
+      space = space_for_key(entry[:key])
+      next if space.nil?
+      { space: space, date: entry[:date], duration: entry[:duration] }
+    end
+  end
+
+  # Clés d'espace demandées mais SANS `Space` correspondante en base — utile pour
+  # avertir l'admin (le devis les compte, mais elles ne seront pas persistées).
+  def unresolved_space_keys(draft)
+    raw_space_entries(draft)
+      .map { |e| e[:key] }
+      .uniq
+      .reject { |key| space_for_key(key) }
+  end
+
+  # Conflits capacity-aware : (space, date) déjà plein (`Space#available_on?`).
+  # Retourne les specs en conflit (vide = tout dispo).
+  def space_availability_conflicts(specs)
+    specs.reject { |spec| spec[:space].available_on?(spec[:date]) }
+  end
+
+  # Crée un `SpaceBooking` + ses `SpaceReservation` à partir de specs résolues,
+  # et le rattache au séjour via un `StayItem`. Retourne le `SpaceBooking`.
+  # `window` = [arrival_date, departure_date] du draft, pour fixer from/to_date
+  # sur la fenêtre du séjour (cohérent avec `Stay#recompute_aggregates!`).
+  def persist_space_booking!(stay:, draft:, specs:, status:, price_cents:)
+    space_booking = build_space_booking(draft: draft, specs: specs, status: status, price_cents: price_cents)
+    space_booking.save!
+    stay.stay_items.create!(bookable: space_booking)
+    space_booking
+  end
+
+  def build_space_booking(draft:, specs:, status:, price_cents:)
+    dates = specs.map { |s| s[:date] }.compact
+    space_booking = SpaceBooking.new(
+      firstname:      draft.first_name,
+      lastname:       draft.last_name,
+      email:          Customer.normalize_email(draft.email),
+      phone:          draft.phone,
+      group_name:     draft.group_name,
+      from_date:      draft.arrival_date || dates.min,
+      to_date:        draft.departure_date || dates.max,
+      status:         status,
+      payment_status: "pending",
+      price_cents:    price_cents
+    )
+    space_booking.generate_token
+    specs.each do |spec|
+      space_booking.space_reservations.build(space: spec[:space], date: spec[:date], duration: spec[:duration])
+    end
+    space_booking
+  end
+
+  # Réservable d'espace déjà rattaché au séjour (édition), ou nil.
+  def existing_space_booking(stay)
+    stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+  end
+
+  # --- Interne ------------------------------------------------------------
+
+  # Entrées d'espace BRUTES (avant résolution `Space`) : [{ key:, date:, duration: }].
+  # Fusionne les deux représentations : `space_slots` (grille nuit-par-nuit,
+  # indexée depuis `arrival_date`) et `halls` (ponctuels {kind, date, period}).
+  def raw_space_entries(draft)
+    entries = []
+
+    slots   = draft.space_slots
+    arrival = draft.arrival_date
+    if slots.present? && arrival.present?
+      slots.each do |key, periods|
+        next unless SPACE_NAMES_BY_KEY.key?(key.to_s)
+        Array(periods).each_with_index do |period, night_idx|
+          next if period.blank?
+          entries << { key: key.to_s, date: arrival + night_idx, duration: period.to_s }
+        end
+      end
+    end
+
+    Array(draft.halls).each do |hall|
+      hall = hall.symbolize_keys if hall.respond_to?(:symbolize_keys)
+      key    = hall[:kind].to_s
+      period = hall[:period].to_s
+      next unless SPACE_NAMES_BY_KEY.key?(key)
+      next if period.blank?
+      date = parse_space_date(hall[:date])
+      next if date.nil?
+      entries << { key: key, date: date, duration: period }
+    end
+
+    entries
+  end
+
+  def space_for_key(key)
+    @space_by_key ||= {}
+    return @space_by_key[key.to_s] if @space_by_key.key?(key.to_s)
+
+    names = SPACE_NAMES_BY_KEY[key.to_s]
+    space = names && Space.where(name: names).min_by { |s| names.index(s.name) || 99 }
+    @space_by_key[key.to_s] = space
+  end
+
+  def parse_space_date(value)
+    return value if value.is_a?(Date)
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+end

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -39,6 +39,20 @@ class PricingModel
       total_cents.to_i - experiences_cents.to_i
     end
 
+    # Part des ESPACES (salles / cuisine pro) dans le total (epic #66, Phase 2).
+    # Permet de ventiler proprement le devis entre le `Booking` d'hébergement et
+    # le `SpaceBooking` d'espaces SANS jamais double-compter : l'hébergement porte
+    # `lodging_bundle_cents`, les espaces `spaces_cents`, la somme reste
+    # `total_excluding_experiences_cents`.
+    def spaces_cents
+      lines.select { |line| line.category == :space }.sum(&:amount_cents)
+    end
+
+    # Base hébergement/camping/repas = total hors activités ET hors espaces.
+    def lodging_bundle_cents
+      total_excluding_experiences_cents - spaces_cents
+    end
+
     def breakdown
       lines.map(&:to_h)
     end
@@ -171,7 +185,7 @@ class PricingModel
       next if date_label.nil?
       period_label = PERIOD_LABELS[period] || period
       Line.new(label: "#{humanize(entry[:kind])} — #{date_label}, #{period_label}",
-               amount_cents: unit)
+               amount_cents: unit, category: :space)
     end
   end
 
@@ -201,7 +215,7 @@ class PricingModel
         period_label = PERIOD_LABELS[period.to_s] || period.to_s
         Line.new(
           label:        "#{space_name} — nuit #{night_idx + 1}, #{period_label}",
-          amount_cents: unit
+          amount_cents: unit, category: :space
         )
       end
     end.compact

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -16,11 +16,34 @@ module Reservations
   class Builder < ServiceBase
     class DraftInvalid < StandardError; end
 
-    attr_reader :draft, :stay, :customer, :booking, :payment
+    attr_reader :draft, :stay, :customer, :booking, :payment, :availability_warning
 
-    def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE)
+    # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
+    # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
+    # `skip_availability` n'affectent QUE le canal admin ; le funnel public
+    # (`admin: false`) garde exactement le comportement historique.
+    #
+    #   - admin: true           → ne crée AUCUN Payment (le solde se règle après,
+    #                             via la page client /sejour/:token) ; c'est aussi
+    #                             au contrôleur de NE PAS envoyer d'email client.
+    #   - status:               → statut du Stay à la création (`pending`/`confirmed`),
+    #                             au choix de l'admin. Défaut : `pending` (jamais
+    #                             d'auto-confirm côté public — Q5/AC-T2-19).
+    #   - source:               → canal d'attribution du Stay. Défaut `reservation`
+    #                             (public) ; l'admin passe `manual`.
+    #   - skip_availability:    → force la disponibilité : la dispo reste VÉRIFIÉE
+    #                             (le veto Grand-Duc de `Lodging#available_between?`
+    #                             fait foi) mais l'indisponibilité n'échoue plus —
+    #                             elle est exposée via `availability_warning`
+    #                             (surbooking / saisie a posteriori autorisés).
+    def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE,
+                   admin: false, status: nil, source: nil, skip_availability: false)
       @draft = draft
       @deposit_rate = deposit_rate
+      @admin = admin
+      @requested_status = status
+      @requested_source = source
+      @skip_availability = skip_availability
       @report_errors = true
     end
 
@@ -55,8 +78,8 @@ module Reservations
         # partira au paiement du solde (Phase 3), une fois le porteur validé.
         @stay = Stay.create!(
           customer: @customer,
-          source: "reservation",
-          status: "pending",
+          source: stay_source,
+          status: stay_status,
           arrival_date: draft.arrival_date,
           departure_date: draft.departure_date,
           total_amount_cents: quote.total_excluding_experiences_cents,
@@ -74,13 +97,10 @@ module Reservations
         # Le paiement est rattaché au Stay dans tous les cas ; le booking n'est
         # plus qu'une référence de commodité pour le canal historique. Son montant
         # reste l'acompte HORS activités (`quote.deposit_cents`).
-        @payment = Payment.create!(
-          booking: @booking,
-          stay: @stay,
-          amount_cents: quote.deposit_cents,
-          status: "pending",
-          payment_method: "card"
-        )
+        #
+        # Canal admin (epic #66) : AUCUN paiement n'est créé à l'enregistrement —
+        # le solde se règle après coup depuis la page client /sejour/:token.
+        @payment = build_payment!(quote) unless @admin
       end
       true
     end
@@ -107,7 +127,16 @@ module Reservations
       raise_invalid("Veuillez préciser votre prénom.") if draft.first_name.blank?
       raise_invalid("Veuillez préciser une adresse email valide.") unless Customer.exploitable_email?(draft.email)
       if draft.lodging.present? && !draft.lodging.available_between?(draft.arrival_date, draft.departure_date)
-        raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+        # Force-dispo admin (epic #66) : on n'échoue pas, on consigne un
+        # avertissement que le contrôleur remonte à l'admin. Hors force, le
+        # comportement historique tient (l'indisponibilité bloque la création).
+        if @skip_availability
+          @availability_warning =
+            "Ces dates ne sont plus disponibles pour #{draft.lodging.name} — " \
+            "séjour enregistré en forçant la disponibilité (surbooking / saisie a posteriori)."
+        else
+          raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+        end
       end
     end
 
@@ -165,7 +194,7 @@ module Reservations
         to_date: draft.departure_date,
         adults: [draft.adults, 1].max,
         children: draft.children.to_i,
-        status: "pending",
+        status: stay_status,
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
@@ -178,6 +207,27 @@ module Reservations
       booking.generate_token
       booking.save!
       booking
+    end
+
+    def build_payment!(quote)
+      Payment.create!(
+        booking: @booking,
+        stay: @stay,
+        amount_cents: quote.deposit_cents,
+        status: "pending",
+        payment_method: "card"
+      )
+    end
+
+    # Statut du Stay (et du Booking d'occupation) à la création. Le public reste
+    # sur `pending` (jamais d'auto-confirm — Q5) ; l'admin choisit explicitement.
+    def stay_status
+      return "pending" unless @admin
+      Stay::STATUSES_ADMIN_CREATABLE.include?(@requested_status) ? @requested_status : "pending"
+    end
+
+    def stay_source
+      @requested_source.presence || "reservation"
     end
 
     # Multi-chiens hors flow auto (Q2) : on consigne pour traitement manuel.

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -14,9 +14,11 @@ module Reservations
   # plusieurs chiens est marqué pour traitement manuel (note interne) et ne
   # facture jamais N × 50 € (AC-T2-09b / AC-T2-15).
   class Builder < ServiceBase
+    include SpaceComposition
+
     class DraftInvalid < StandardError; end
 
-    attr_reader :draft, :stay, :customer, :booking, :payment, :availability_warning
+    attr_reader :draft, :stay, :customer, :booking, :space_booking, :payment, :availability_warning
 
     # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
     # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
@@ -86,6 +88,11 @@ module Reservations
           notes: internal_notes
         )
         @stay.stay_items.create!(bookable: @booking) if @booking
+        # Espaces (epic #66, Phase 2) : les salles / cuisine pro choisies
+        # deviennent un SpaceBooking + StayItem, MÊME sans hébergement (séjour
+        # « espaces seuls »). Sa part de prix vient du devis (`spaces_cents`) —
+        # l'hébergement porte `lodging_bundle_cents`, donc aucun double-compte.
+        @space_booking = build_space_booking_for!(@stay, quote)
         # Sélections d'activités du funnel (epic #55, Phase 4) : chaque créneau
         # choisi devient un ExperienceBooking `pending` rattaché au Stay — de la
         # MÊME nature que ceux du rail email, donc soumis à la validation porteur.
@@ -138,6 +145,25 @@ module Reservations
           raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
         end
       end
+      check_space_availability!
+    end
+
+    # Dispo espaces CAPACITY-AWARE (`Space#available_on?`, source unique). Hors
+    # force, un espace déjà plein bloque ; en force-dispo admin, on consigne un
+    # avertissement (surbooking / saisie a posteriori) sans échouer — comme pour
+    # l'hébergement.
+    def check_space_availability!
+      conflicts = space_availability_conflicts(space_reservation_specs(draft))
+      return if conflicts.empty?
+
+      names = conflicts.map { |c| c[:space].name }.uniq.join(", ")
+      if @skip_availability
+        message = "Espace(s) déjà complet(s) à ces dates : #{names} — " \
+                  "séjour enregistré en forçant la disponibilité."
+        @availability_warning = [@availability_warning, message].compact.join(" ")
+      else
+        raise_invalid("Espace(s) déjà complet(s) à ces dates : #{names}.")
+      end
     end
 
     def bookable_content?
@@ -145,8 +171,23 @@ module Reservations
         draft.campings.any? ||
         draft.vans.any? ||
         draft.hamacs.any? ||
-        Array(draft.halls).any? ||
-        Array(draft.space_slots).any?
+        draft_has_spaces?(draft)
+    end
+
+    # Crée le SpaceBooking (+ StayItem) du séjour depuis les espaces du draft.
+    # No-op si aucun espace résolu. La dispo capacity-aware a déjà été vérifiée
+    # (ou forcée) dans `validate_draft!`. Retourne le SpaceBooking ou nil.
+    def build_space_booking_for!(stay, quote)
+      specs = space_reservation_specs(draft)
+      return nil if specs.empty?
+
+      persist_space_booking!(
+        stay:        stay,
+        draft:       draft,
+        specs:       specs,
+        status:      stay_status,
+        price_cents: quote.spaces_cents
+      )
     end
 
     def upsert_customer!
@@ -198,11 +239,12 @@ module Reservations
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
-        # Occupation d'hébergement : son prix suit le total HORS activités
-        # (fix montant fantôme, epic #55 Phase 1) — cohérent avec le
-        # `total_amount_cents` du Stay et l'assiette de l'acompte.
-        price_cents: quote.total_excluding_experiences_cents,
-        shown_price_cents: quote.total_excluding_experiences_cents
+        # Occupation d'hébergement : son prix porte l'hébergement + camping/repas
+        # HORS espaces et HORS activités (epic #66, Phase 2). Les espaces vivent
+        # sur leur propre SpaceBooking — additionner les deux redonne exactement
+        # `total_excluding_experiences_cents`, sans double-compte.
+        price_cents: quote.lodging_bundle_cents,
+        shown_price_cents: quote.lodging_bundle_cents
       )
       booking.generate_token
       booking.save!

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -1,0 +1,192 @@
+module Stays
+  # Mise à jour de la composition d'un séjour existant depuis le CRUD admin
+  # (epic #66, Phase 1). Symétrique de `Reservations::Builder` (création) mais
+  # côté édition : on RÉCONCILIE l'occupation d'hébergement et les activités du
+  # séjour à partir d'un `Reservations::Draft` reconstruit depuis le formulaire —
+  # toujours SANS Stripe et sans email de confirmation forcé.
+  #
+  # Choix de conception :
+  #   - Le CLIENT est upserté par email (même mécanisme que le Builder) : que
+  #     l'admin sélectionne un client existant ou en crée un à la volée, le
+  #     formulaire remplit les coordonnées du draft, et on retrouve/complète le
+  #     `Customer` par son email normalisé.
+  #   - L'HÉBERGEMENT : on met à jour le `Booking` d'occupation existant, ou on en
+  #     crée un s'il n'y en a pas. On NE TOUCHE PAS au `status`/`email` du Booking
+  #     à l'édition (ces deux changements déclenchent l'email client via
+  #     `Booking#notify_customer_on_update`) — l'admin ne doit jamais spammer le
+  #     client en éditant la compo. Le statut fait foi au niveau du Stay.
+  #   - Les ACTIVITÉS : réconciliation ensembliste, bornée au périmètre de
+  #     l'utilisateur (`ExperienceAvailability.for_user`) — un porteur n'annule et
+  #     ne crée que sur SES créneaux, jamais sur ceux d'un autre.
+  #   - Le TOTAL et les DATES sont recalculés par `Stay#recompute_aggregates!`
+  #     (source unique déjà éprouvée : bookables + activités actives).
+  class AdminUpdater < ServiceBase
+    class Invalid < StandardError; end
+
+    attr_reader :stay, :availability_warning
+
+    def initialize(stay:, draft:, status: nil, skip_availability: false, user: nil)
+      @stay = stay
+      @draft = draft
+      @requested_status = status
+      @skip_availability = skip_availability
+      @user = user
+      @report_errors = true
+    end
+
+    def run
+      run!
+      true
+    rescue Invalid => e
+      set_error_message(e.message)
+      false
+    rescue => e
+      Sentry.capture_exception(e)
+      set_error_message("Une erreur est survenue lors de la mise à jour du séjour.")
+      false
+    end
+
+    def run!
+      validate!
+      ActiveRecord::Base.transaction do
+        @stay.update!(customer: upsert_customer!, status: stay_status)
+        reconcile_lodging!
+        reconcile_experiences!
+        @stay.recompute_aggregates!
+      end
+      true
+    end
+
+    private
+
+    def validate!
+      raise_invalid("Veuillez choisir des dates valides.") if @draft.nights < 1
+      # Phase 1 : un séjour admin porte au moins un hébergement (espaces / camping
+      # arrivent aux phases 2-3). Retirer le DERNIER hébergement est donc hors
+      # périmètre ici — on change ou on garde l'hébergement.
+      raise_invalid("Veuillez sélectionner un hébergement.") if @draft.lodging.blank?
+      unless Customer.exploitable_email?(@draft.email)
+        raise_invalid("Veuillez préciser une adresse email valide pour le client.")
+      end
+      check_availability!
+    end
+
+    def check_availability!
+      return if @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
+
+      if @skip_availability
+        @availability_warning =
+          "Ces dates ne sont plus disponibles pour #{@draft.lodging.name} — " \
+          "séjour enregistré en forçant la disponibilité (surbooking / saisie a posteriori)."
+      else
+        raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+      end
+    end
+
+    def upsert_customer!
+      email = Customer.normalize_email(@draft.email)
+      customer = Customer.where(email: email).first_or_initialize
+      customer.email = email
+      customer.first_name = @draft.first_name if customer.first_name.blank?
+      customer.last_name  = @draft.last_name  if customer.last_name.blank?
+      customer.phone      = @draft.phone      if customer.phone.blank?
+      customer.save!
+      customer
+    end
+
+    def reconcile_lodging!
+      price   = @draft.quote.total_excluding_experiences_cents
+      booking = existing_lodging_booking
+
+      if booking
+        # NB : ni `status` ni `email` ici — voir l'en-tête de classe (anti-email).
+        booking.update!(
+          lodging_id:        @draft.lodging_id,
+          from_date:         @draft.arrival_date,
+          to_date:           @draft.departure_date,
+          adults:            [@draft.adults, 1].max,
+          children:          @draft.children.to_i,
+          group_name:        @draft.group_name,
+          firstname:         @draft.first_name,
+          lastname:          @draft.last_name,
+          phone:             @draft.phone,
+          price_cents:       price,
+          shown_price_cents: price
+        )
+      else
+        booking = Booking.new(
+          firstname:         @draft.first_name,
+          lastname:          @draft.last_name,
+          email:             Customer.normalize_email(@draft.email),
+          phone:             @draft.phone,
+          group_name:        @draft.group_name,
+          from_date:         @draft.arrival_date,
+          to_date:           @draft.departure_date,
+          adults:            [@draft.adults, 1].max,
+          children:          @draft.children.to_i,
+          status:            stay_status,
+          payment_status:    "pending",
+          platform:          "web",
+          lodging_id:        @draft.lodging_id,
+          price_cents:       price,
+          shown_price_cents: price
+        )
+        booking.generate_token
+        booking.save!
+        @stay.stay_items.create!(bookable: booking)
+      end
+    end
+
+    def existing_lodging_booking
+      @stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    end
+
+    def reconcile_experiences!
+      desired  = desired_experience_map
+      allowed  = allowed_availability_ids
+
+      @stay.experience_bookings.active.each do |eb|
+        # On ne réconcilie (annule) QUE dans le périmètre de l'utilisateur.
+        next unless allowed.include?(eb.experience_availability_id)
+        next if desired.key?(eb.experience_availability_id)
+        eb.update!(status: "cancelled")
+      end
+
+      desired.each do |availability_id, participants|
+        eb = @stay.experience_bookings.active.find_by(experience_availability_id: availability_id)
+        if eb
+          eb.update!(participants: participants)
+        else
+          @stay.experience_bookings.create!(
+            experience_availability_id: availability_id,
+            participants: participants,
+            status: "pending"
+          )
+        end
+      end
+    end
+
+    def desired_experience_map
+      allowed = allowed_availability_ids
+      Array(@draft.experiences).each_with_object({}) do |entry, memo|
+        aid          = entry[:availability_id].to_i
+        participants = entry[:participants].to_i
+        next if aid < 1 || participants < 1
+        next unless allowed.include?(aid)
+        memo[aid] = participants
+      end
+    end
+
+    def allowed_availability_ids
+      @allowed_availability_ids ||= ExperienceAvailability.for_user(@user).pluck(:id).to_set
+    end
+
+    def stay_status
+      Stay::STATUSES_ADMIN_CREATABLE.include?(@requested_status) ? @requested_status : @stay.status
+    end
+
+    def raise_invalid(message)
+      raise Invalid, message
+    end
+  end
+end

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -21,6 +21,8 @@ module Stays
   #   - Le TOTAL et les DATES sont recalculés par `Stay#recompute_aggregates!`
   #     (source unique déjà éprouvée : bookables + activités actives).
   class AdminUpdater < ServiceBase
+    include SpaceComposition
+
     class Invalid < StandardError; end
 
     attr_reader :stay, :availability_warning
@@ -51,6 +53,7 @@ module Stays
       ActiveRecord::Base.transaction do
         @stay.update!(customer: upsert_customer!, status: stay_status)
         reconcile_lodging!
+        reconcile_spaces!
         reconcile_experiences!
         @stay.recompute_aggregates!
       end
@@ -61,17 +64,21 @@ module Stays
 
     def validate!
       raise_invalid("Veuillez choisir des dates valides.") if @draft.nights < 1
-      # Phase 1 : un séjour admin porte au moins un hébergement (espaces / camping
-      # arrivent aux phases 2-3). Retirer le DERNIER hébergement est donc hors
-      # périmètre ici — on change ou on garde l'hébergement.
-      raise_invalid("Veuillez sélectionner un hébergement.") if @draft.lodging.blank?
+      # Phase 2 (epic #66) : un séjour admin porte AU MOINS un hébergement OU un
+      # espace. On assouplit la contrainte Phase 1 (hébergement obligatoire) pour
+      # autoriser un séjour « espaces seuls ». Camping/repas arrivent en Phase 3.
+      unless @draft.lodging.present? || draft_has_spaces?(@draft)
+        raise_invalid("Veuillez sélectionner un hébergement ou un espace.")
+      end
       unless Customer.exploitable_email?(@draft.email)
         raise_invalid("Veuillez préciser une adresse email valide pour le client.")
       end
       check_availability!
+      check_space_availability!
     end
 
     def check_availability!
+      return if @draft.lodging.blank?
       return if @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
 
       if @skip_availability
@@ -81,6 +88,33 @@ module Stays
       else
         raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
       end
+    end
+
+    # Dispo espaces capacity-aware (`Space#available_on?`), même logique de force
+    # que l'hébergement. On ignore les créneaux DÉJÀ portés par le SpaceBooking du
+    # séjour (sinon l'édition d'un séjour espaces-seuls se bloquerait elle-même).
+    def check_space_availability!
+      specs     = space_reservation_specs(@draft)
+      own       = own_space_reservation_keys
+      conflicts = space_availability_conflicts(specs)
+                    .reject { |c| own.include?([c[:space].id, c[:date]]) }
+      return if conflicts.empty?
+
+      names = conflicts.map { |c| c[:space].name }.uniq.join(", ")
+      if @skip_availability
+        message = "Espace(s) déjà complet(s) à ces dates : #{names} — " \
+                  "séjour enregistré en forçant la disponibilité."
+        @availability_warning = [@availability_warning, message].compact.join(" ")
+      else
+        raise_invalid("Espace(s) déjà complet(s) à ces dates : #{names}.")
+      end
+    end
+
+    # (space_id, date) déjà réservés par le SpaceBooking courant du séjour.
+    def own_space_reservation_keys
+      sb = existing_space_booking(@stay)
+      return [].to_set if sb.nil?
+      sb.space_reservations.map { |r| [r.space_id, r.date] }.to_set
     end
 
     def upsert_customer!
@@ -95,8 +129,22 @@ module Stays
     end
 
     def reconcile_lodging!
-      price   = @draft.quote.total_excluding_experiences_cents
       booking = existing_lodging_booking
+
+      # Séjour « espaces seuls » (epic #66, Phase 2) : plus d'hébergement au
+      # draft → on détache et libère l'occupation existante (soft-delete du
+      # StayItem ET du Booking, pour rendre les dates au calendrier).
+      if @draft.lodging.blank?
+        if booking
+          @stay.stay_items.where(bookable_type: "Booking").each { |i| i.soft_delete!(validate: false) }
+          booking.soft_delete!(validate: false)
+        end
+        return
+      end
+
+      # Prix HORS espaces (les espaces vivent sur le SpaceBooking) et HORS
+      # activités — additionner Booking + SpaceBooking redonne le total prévu.
+      price = @draft.quote.lodging_bundle_cents
 
       if booking
         # NB : ni `status` ni `email` ici — voir l'en-tête de classe (anti-email).
@@ -139,6 +187,51 @@ module Stays
 
     def existing_lodging_booking
       @stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    end
+
+    # Réconcilie l'occupation d'ESPACES du séjour (epic #66, Phase 2) : rebuild
+    # complet des `SpaceReservation` depuis le draft. Comme pour l'hébergement,
+    # on NE TOUCHE PAS au `status`/`email` du SpaceBooking à l'édition (l'update
+    # de statut déclenche l'email client — anti-spam admin).
+    def reconcile_spaces!
+      specs         = space_reservation_specs(@draft)
+      space_booking = existing_space_booking(@stay)
+
+      # Plus d'espace au draft → on détache/soft-delete un éventuel SpaceBooking.
+      if specs.empty?
+        if space_booking
+          @stay.stay_items.where(bookable_type: "SpaceBooking").each { |i| i.soft_delete!(validate: false) }
+          space_booking.soft_delete!(validate: false)
+        end
+        return
+      end
+
+      price = @draft.quote.spaces_cents
+      dates = specs.map { |s| s[:date] }
+
+      if space_booking
+        space_booking.space_reservations.destroy_all
+        space_booking.update!(
+          firstname:   @draft.first_name,
+          lastname:    @draft.last_name,
+          phone:       @draft.phone,
+          group_name:  @draft.group_name,
+          from_date:   @draft.arrival_date || dates.min,
+          to_date:     @draft.departure_date || dates.max,
+          price_cents: price
+        )
+        specs.each do |spec|
+          space_booking.space_reservations.create!(space: spec[:space], date: spec[:date], duration: spec[:duration])
+        end
+      else
+        persist_space_booking!(
+          stay:        @stay,
+          draft:       @draft,
+          specs:       specs,
+          status:      @stay.status,
+          price_cents: price
+        )
+      end
     end
 
     def reconcile_experiences!

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -1,0 +1,102 @@
+/ Formulaire CRUD Séjour admin (epic #66, Phase 1). Locals : url, method, submit_label.
+/ Champs sous le namespace `stay[...]`. Devis B2C forfaitaire (PricingModel).
+- selected_customer_id = @stay.persisted? ? @stay.customer_id : nil
+- current_status = (@stay.status.presence || "pending")
+- selected_experiences = {}
+- Array(@draft&.experiences).each { |e| selected_experiences[e[:availability_id].to_i] = e[:participants] }
+
+= form_with url: url, method: method, data: { controller: "stay-form" } do
+  .space-y-8
+    / --- Client -------------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Client
+      .flex.gap-4.text-sm
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[customer_mode]" value="existing" checked=true data-action="change->stay-form#toggleCustomer"
+          | Client existant
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[customer_mode]" value="new" data-action="change->stay-form#toggleCustomer"
+          | Nouveau client
+
+      .space-y-1(data-stay-form-target="existingPanel")
+        label.block.text-sm.font-medium.text-gray-700 Sélectionner un client
+        = select_tag "stay[customer_id]", options_for_select(@customers.map { |c| [c.name.presence || c.email, c.id] }, selected_customer_id), include_blank: "— Choisir un client —", class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+
+      .space-y-2.hidden(data-stay-form-target="newPanel")
+        .grid.grid-cols-2.gap-2
+          = text_field_tag "stay[new_customer][first_name]", @draft&.first_name, placeholder: "Prénom", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+          = text_field_tag "stay[new_customer][last_name]", @draft&.last_name, placeholder: "Nom", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+        = email_field_tag "stay[new_customer][email]", @draft&.email, placeholder: "Email", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        = telephone_field_tag "stay[new_customer][phone]", @draft&.phone, placeholder: "Téléphone", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Séjour (dates + groupe) --------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Séjour
+      .grid.grid-cols-2.gap-4
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Arrivée
+          = date_field_tag "stay[arrival_date]", @draft&.arrival_date&.iso8601, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Départ
+          = date_field_tag "stay[departure_date]", @draft&.departure_date&.iso8601, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      .grid.grid-cols-3.gap-4
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Adultes
+          = number_field_tag "stay[adults]", (@draft&.adults.to_i.positive? ? @draft.adults : 1), min: 1, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Enfants
+          = number_field_tag "stay[children]", @draft&.children.to_i, min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Chiens
+          = number_field_tag "stay[dogs_count]", @draft&.dogs_count.to_i, min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Nom du groupe (optionnel)
+        = text_field_tag "stay[group_name]", @draft&.group_name, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Hébergement --------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Hébergement
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Hébergement
+        = select_tag "stay[lodging_id]", options_for_select(@lodgings.map { |l| [l.form_label, l.id] }, @draft&.lodging_id), include_blank: "— Choisir un hébergement —", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Activités ----------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Activités
+      - if @assignable_availabilities.blank?
+        p.text-sm.text-gray-500 Aucun créneau d'activité proposable.
+      - else
+        p.text-sm.text-gray-500 Indiquez le nombre de participants pour chaque créneau souhaité (0 = non réservé).
+        ul.divide-y.divide-gray-100
+          - @assignable_availabilities.each_with_index do |availability, index|
+            li.py-2.flex.items-center.justify-between.gap-4
+              span.text-sm.text-gray-900 = availability.label
+              = hidden_field_tag "stay[experiences][#{index}][availability_id]", availability.id
+              = number_field_tag "stay[experiences][#{index}][participants]", selected_experiences[availability.id].to_i, min: 0, class: "w-20 rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Statut + force dispo -----------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Statut & disponibilité
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Statut du séjour
+        = select_tag "stay[status]", options_for_select([["En attente", "pending"], ["Confirmé", "confirmed"]], current_status), class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      label.flex.items-center.gap-2.text-sm.text-gray-700
+        = check_box_tag "stay[force_availability]", "1", false
+        | Forcer la disponibilité (surbooking / saisie a posteriori)
+
+    / --- Devis --------------------------------------------------------------
+    - if @quote
+      section.bg-gray-50.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-2
+        h2.text-base.font-semibold.text-gray-900 Devis (B2C)
+        ul.text-sm.text-gray-700.space-y-1
+          - @quote.breakdown.each do |line|
+            li.flex.justify-between
+              span = line[:label]
+              span = humanized_money_with_symbol(Money.new(line[:amount_cents]))
+        .flex.justify-between.border-t.border-gray-200.pt-2.font-semibold.text-gray-900
+          span Total
+          span = humanized_money_with_symbol(Money.new(@quote.total_cents))
+
+    .flex.justify-end.gap-3
+      = link_to "Annuler", recent_stays_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      = submit_tag submit_label, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -60,6 +60,21 @@
         label.block.text-sm.font-medium.text-gray-700 Hébergement
         = select_tag "stay[lodging_id]", options_for_select(@lodgings.map { |l| [l.form_label, l.id] }, @draft&.lodging_id), include_blank: "— Choisir un hébergement —", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
+    / --- Espaces (salles / cuisine pro) -------------------------------------
+    - space_kind_options = [["Grande salle", "grande_salle"], ["Petite salle", "petite_salle"], ["Cuisine pro", "cuisine_pro"]]
+    - period_options = [["Journée", "journee"], ["Soirée", "soiree"], ["Journée + soirée", "journee_et_soiree"]]
+    - existing_halls = Array(@draft&.halls).map { |h| h.respond_to?(:symbolize_keys) ? h.symbolize_keys : h }
+    - space_rows = existing_halls + Array.new([3 - existing_halls.size, 1].max) { {} }
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Espaces
+      p.text-sm.text-gray-500 Ajoutez une salle ou la cuisine pro (date + période). Un séjour peut être composé d'espaces seuls, sans hébergement.
+      ul.divide-y.divide-gray-100
+        - space_rows.each_with_index do |row, index|
+          li.py-2.grid.grid-cols-3.gap-2
+            = select_tag "stay[halls][#{index}][kind]", options_for_select(space_kind_options, row[:kind]), include_blank: "— Espace —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = date_field_tag "stay[halls][#{index}][date]", row[:date], class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = select_tag "stay[halls][#{index}][period]", options_for_select(period_options, row[:period]), include_blank: "— Période —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+
     / --- Activités ----------------------------------------------------------
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
       h2.text-base.font-semibold.text-gray-900 Activités

--- a/app/views/stays/edit.html.slim
+++ b/app/views/stays/edit.html.slim
@@ -1,0 +1,7 @@
+.px-4.sm:px-6.lg:px-8.py-6
+  .mb-6.flex.items-start.justify-between.gap-4
+    div
+      h1.text-xl.font-semibold.text-gray-900 = "Modifier le séjour ##{@stay.id}"
+      p.mt-1.text-sm.text-gray-600 Modifiez la composition du séjour (hébergement + activités). Aucun paiement n'est déclenché.
+    = button_to "Supprimer le séjour", stay_path(@stay), method: :delete, data: { turbo_confirm: "Supprimer ce séjour ? Cette action est réversible (soft-delete)." }, class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+  = render "form", url: stay_path(@stay), method: :patch, submit_label: "Enregistrer les modifications"

--- a/app/views/stays/new.html.slim
+++ b/app/views/stays/new.html.slim
@@ -1,0 +1,5 @@
+.px-4.sm:px-6.lg:px-8.py-6
+  .mb-6
+    h1.text-xl.font-semibold.text-gray-900 Nouveau séjour
+    p.mt-1.text-sm.text-gray-600 Créez un séjour composable (hébergement + activités). Aucun paiement n'est déclenché à la création.
+  = render "form", url: stays_path, method: :post, submit_label: "Créer le séjour"

--- a/app/views/stays/recent.html.slim
+++ b/app/views/stays/recent.html.slim
@@ -3,6 +3,8 @@
     .sm:flex-auto
       h1.text-xl.font-semibold.text-gray-900 Séjours récents
       p.mt-2.text-sm.text-gray-700 Observez la transition Tally → /reservation par canal d'attribution.
+    .mt-4.sm:mt-0.sm:ml-4
+      = link_to "Nouveau séjour", new_stay_path, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
 
   / Filtre par source (AC-T2-23).
   = form_with url: recent_stays_path, method: :get, class: "mb-4 flex items-center gap-2" do
@@ -18,6 +20,7 @@
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Canal
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Statut
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Créé le
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Actions
       tbody.divide-y.divide-gray-200.bg-white
         - @stays.each do |stay|
           tr.hover:bg-gray-50
@@ -31,6 +34,8 @@
               span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.py-0.5.text-xs.font-medium.text-gray-700 = stay.source
             td.px-4.py-2.text-sm = stay.status_badge
             td.px-4.py-2.text-sm.text-gray-500 = l(stay.created_at.to_date, format: :long)
+            td.px-4.py-2.text-sm.text-right
+              = link_to "Éditer", edit_stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 hover:underline"
         - if @stays.empty?
           tr
-            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="5" Aucun séjour pour ce canal.
+            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="6" Aucun séjour pour ce canal.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,7 +113,12 @@ Rails.application.routes.draw do
   # Le CRUD admin d'une activité SUR un séjour (epic #55, Phase 6) est imbriqué
   # sous cette ressource : la création porte TOUJOURS le séjour dans l'URL, si
   # bien qu'une activité ne peut jamais naître sans son séjour d'attache.
-  resources :stays, only: [:show] do
+  # CRUD Séjour admin (epic #66, Phase 1) — le séjour devient le point d'entrée
+  # de création composable côté admin (hébergement + activités). URLs anglaises.
+  # `show` reste rendu sans layout (fragment de modale) ; new/edit sont des pages
+  # pleines. La route `stays/recents` ci-dessus est déclarée AVANT pour ne pas
+  # être captée par `/stays/:id`.
+  resources :stays, only: [:show, :new, :create, :edit, :update, :destroy] do
     resources :experience_bookings, only: [:create]
   end
   resources :experience_bookings, only: [:index, :update, :destroy] do

--- a/spec/models/stay_recompute_spaces_spec.rb
+++ b/spec/models/stay_recompute_spaces_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+# Epic #66, Phase 2 — `Stay#recompute_aggregates!` doit tolérer un séjour SANS
+# hébergement : dates + total dérivés des SpaceBooking, et surtout ne JAMAIS
+# écraser les dates à nil quand aucun bookable daté n'est présent.
+RSpec.describe Stay, "#recompute_aggregates! (espaces seuls, epic #66)" do
+  let!(:customer) { Customer.create!(email: "c@example.com", first_name: "C", customer_type: "individual") }
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+
+  def stay_with_space
+    stay = Stay.create!(customer: customer, source: "manual", status: "pending",
+                        arrival_date: arrival, departure_date: departure, total_amount_cents: 0)
+    space = Space.create!(name: "Grande Salle", capacity: 1)
+    sb = SpaceBooking.create!(firstname: "C", from_date: arrival, to_date: departure,
+                              status: "pending", price_cents: 29_000)
+    sb.space_reservations.create!(space: space, date: arrival, duration: "journee")
+    stay.stay_items.create!(bookable: sb)
+    stay
+  end
+
+  it "dérive dates et total depuis le SpaceBooking (sans Booking)" do
+    stay = stay_with_space
+    stay.recompute_aggregates!
+    stay.reload
+
+    expect(stay.total_amount_cents).to eq(29_000)
+    expect(stay.arrival_date).to eq(arrival)
+    expect(stay.departure_date).to eq(departure)
+  end
+
+  it "n'écrase pas les dates à nil quand aucun bookable daté n'existe" do
+    stay = Stay.create!(customer: customer, source: "manual", status: "pending",
+                        arrival_date: arrival, departure_date: departure, total_amount_cents: 5_000)
+    stay.recompute_aggregates!
+    stay.reload
+
+    expect(stay.arrival_date).to eq(arrival)
+    expect(stay.departure_date).to eq(departure)
+    expect(stay.total_amount_cents).to eq(0) # aucun bookable ni activité
+  end
+end

--- a/spec/requests/stays_admin_crud_spec.rb
+++ b/spec/requests/stays_admin_crud_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+# CRUD Séjour admin (epic #66, Phase 1) — le séjour devient le point d'entrée de
+# création composable côté admin (hébergement + activités), en réutilisant
+# `Reservations::Builder` en mode admin : aucun Stripe, aucun email forcé,
+# force-dispo avec avertissement, statut au choix, client existant ou à la volée.
+RSpec.describe "Stays — CRUD admin (epic #66)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-stays@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  # Hébergement tarifé au barème B2C (Pricing::Catalog) : La Hulotte = 485 € la
+  # 1re nuit + 260 € par nuit suivante. 2 nuits → 745 € (74 500 cents).
+  let!(:lodging)  { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+  let(:hulotte_two_nights_cents) { 74_500 }
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  # Crée un séjour admin directement via le Builder (helper pour edit/update/destroy).
+  def create_admin_stay(status: "pending")
+    draft = Reservations::Draft.new(
+      lodging_id: lodging.id, arrival_date: arrival, departure_date: departure,
+      adults: 2, first_name: "Alice", last_name: "Martin",
+      email: "alice@example.com", phone: "0470111222"
+    )
+    builder = Reservations::Builder.new(draft: draft, admin: true, status: status, source: "manual")
+    builder.run!
+    builder.stay
+  end
+
+  describe "GET /stays/new" do
+    it "affiche le formulaire de composition" do
+      get new_stay_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Nouveau séjour")
+      expect(response.body).to include("La Hulotte")
+      expect(response.body).to include("Forcer la disponibilité")
+    end
+  end
+
+  describe "POST /stays (create)" do
+    it "crée un séjour avec un nouveau client, une occupation d'hébergement et AUCUN paiement" do
+      expect {
+        post stays_path, params: base_params
+      }.to change(Stay, :count).by(1)
+       .and change(Customer, :count).by(1)
+       .and change(Booking, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      stay = Stay.order(:created_at).last
+      expect(stay.source).to eq("manual")
+      expect(stay.status).to eq("pending")
+      expect(stay.customer.email).to eq("alice@example.com")
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents)
+      # Décision figée : aucun paiement (donc aucun appel Stripe) à la création admin.
+      expect(stay.payments).to be_empty
+    end
+
+    it "réutilise un client existant sélectionné par id (pas de doublon)" do
+      customer = Customer.create!(email: "bob@example.com", first_name: "Bob", customer_type: "individual")
+      expect {
+        post stays_path, params: base_params(customer_mode: "existing", customer_id: customer.id, new_customer: {})
+      }.to change(Stay, :count).by(1).and change(Customer, :count).by(0)
+
+      expect(Stay.order(:created_at).last.customer).to eq(customer)
+    end
+
+    it "laisse l'admin choisir le statut confirmé" do
+      post stays_path, params: base_params(status: "confirmed")
+      expect(Stay.order(:created_at).last.status).to eq("confirmed")
+    end
+
+    it "bloque la création sur des dates indisponibles hors force" do
+      Unavailability.create!(lodging: lodging, date: arrival)
+      expect { post stays_path, params: base_params }.not_to change(Stay, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("plus disponibles")
+    end
+
+    it "force la création sur des dates indisponibles avec un avertissement" do
+      Unavailability.create!(lodging: lodging, date: arrival)
+      expect {
+        post stays_path, params: base_params(force_availability: "1")
+      }.to change(Stay, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to include("forçant la disponibilité")
+    end
+
+    it "attache les activités sélectionnées et les intègre au total" do
+      exp   = Experience.create!(name: "Balade ânes", fixed_price_cents: 4_000, price_cents: 1_500)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "10:00")
+
+      post stays_path, params: base_params(experiences: { "0" => { availability_id: avail.id, participants: 2 } })
+
+      stay = Stay.order(:created_at).last
+      expect(stay.experience_bookings.count).to eq(1)
+      # Activité : 40 € forfait + 15 €/pers × 2 = 70 € (7 000 cents). Total = 745 € + 70 €.
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents + 7_000)
+    end
+  end
+
+  describe "GET /stays/:id/edit" do
+    it "affiche le formulaire prérempli" do
+      stay = create_admin_stay
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Modifier le séjour ##{stay.id}")
+      expect(response.body).to include("La Hulotte")
+    end
+  end
+
+  describe "PATCH /stays/:id (update)" do
+    let!(:cheveche) { Lodging.create!(name: "La Chevêche", summary: "gîte") }
+
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: lodging.id, status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "modifie l'hébergement et recalcule le total" do
+      stay = create_admin_stay
+      patch stay_path(stay), params: update_params(stay, lodging_id: cheveche.id)
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay.reload
+      booking = stay.stay_items.where(bookable_type: "Booking").first.bookable
+      expect(booking.lodging_id).to eq(cheveche.id)
+      # La Chevêche = 275 € + 200 € = 475 € (47 500 cents) sur 2 nuits.
+      expect(stay.total_amount_cents).to eq(47_500)
+    end
+
+    it "bascule le statut en confirmé SANS envoyer d'email au client" do
+      stay = create_admin_stay
+      ActionMailer::Base.deliveries.clear
+      patch stay_path(stay), params: update_params(stay, status: "confirmed")
+
+      expect(stay.reload.status).to eq("confirmed")
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+
+    it "ajoute une activité à un séjour existant" do
+      stay  = create_admin_stay
+      exp   = Experience.create!(name: "Poterie", price_cents: 2_000)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "14:00")
+
+      expect {
+        patch stay_path(stay), params: update_params(stay, experiences: { "0" => { availability_id: avail.id, participants: 3 } })
+      }.to change { stay.experience_bookings.active.count }.from(0).to(1)
+
+      expect(stay.reload.total_amount_cents).to eq(hulotte_two_nights_cents + 6_000) # 20 €/pers × 3
+    end
+
+    it "retire une activité en passant ses participants à 0" do
+      stay  = create_admin_stay
+      exp   = Experience.create!(name: "Poterie", price_cents: 2_000)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "14:00")
+      stay.experience_bookings.create!(experience_availability: avail, participants: 2, status: "pending")
+
+      expect {
+        patch stay_path(stay), params: update_params(stay, experiences: { "0" => { availability_id: avail.id, participants: 0 } })
+      }.to change { stay.experience_bookings.active.count }.from(1).to(0)
+    end
+  end
+
+  describe "DELETE /stays/:id (destroy)" do
+    it "soft-supprime le séjour (jamais de hard destroy)" do
+      stay = create_admin_stay
+      delete stay_path(stay)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(Stay.exists?(stay.id)).to be(false)                     # hors default scope
+      expect(Stay.unscoped.find(stay.id).deleted_at).to be_present   # présent mais marqué supprimé
+    end
+  end
+end

--- a/spec/requests/stays_admin_spaces_spec.rb
+++ b/spec/requests/stays_admin_spaces_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+# Epic #66, Phase 2 — Espaces dans la composition du Séjour admin. Le CRUD admin
+# crée/édite un SpaceBooking + StayItem depuis les espaces choisis (form `halls`),
+# permet un séjour « espaces seuls » (sans hébergement), et n'appelle jamais
+# Stripe ni d'email client forcé.
+RSpec.describe "Stays — espaces (epic #66, Phase 2)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-spaces@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:lodging)      { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+  let(:arrival)       { Date.today + 30 }
+  let(:departure)     { Date.today + 32 }
+  let(:grande_salle_journee_cents) { 29_000 }
+  let(:hulotte_two_nights_cents)   { 74_500 }
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  def hall_param(kind: "grande_salle", date: nil, period: "journee")
+    { "0" => { kind: kind, date: (date || arrival).iso8601, period: period } }
+  end
+
+  describe "POST /stays — hébergement + espace" do
+    it "crée un SpaceBooking + StayItem et intègre l'espace au total" do
+      expect {
+        post stays_path, params: base_params(halls: hall_param)
+      }.to change(Stay, :count).by(1)
+       .and change(SpaceBooking, :count).by(1)
+       .and change(Booking, :count).by(1)
+
+      stay = Stay.order(:created_at).last
+      sb = stay.stay_items.where(bookable_type: "SpaceBooking").first.bookable
+      expect(sb.space_reservations.map(&:space)).to eq([grande_salle])
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents + grande_salle_journee_cents)
+      expect(stay.payments).to be_empty # aucun Stripe
+    end
+  end
+
+  describe "POST /stays — séjour espaces seuls (sans hébergement)" do
+    it "crée un séjour sans Booking, avec son SpaceBooking persisté" do
+      expect {
+        post stays_path, params: base_params(lodging_id: "", halls: hall_param)
+      }.to change(Stay, :count).by(1)
+       .and change(SpaceBooking, :count).by(1)
+       .and change(Booking, :count).by(0)
+
+      stay = Stay.order(:created_at).last
+      expect(stay.stay_items.where(bookable_type: "Booking")).to be_empty
+      expect(stay.stay_items.where(bookable_type: "SpaceBooking").count).to eq(1)
+      expect(stay.total_amount_cents).to eq(grande_salle_journee_cents)
+      expect(stay.arrival_date).to eq(arrival)
+      expect(stay.departure_date).to eq(departure)
+    end
+  end
+
+  describe "PATCH /stays/:id — édition d'un séjour espaces seuls" do
+    def create_spaces_only_stay
+      draft = Reservations::Draft.new(
+        lodging_id: nil, arrival_date: arrival, departure_date: departure,
+        first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222",
+        halls: [{ kind: "grande_salle", date: arrival.iso8601, period: "journee" }]
+      )
+      builder = Reservations::Builder.new(draft: draft, admin: true, source: "manual")
+      builder.run!
+      builder.stay
+    end
+
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: "", status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "préremplit le form d'édition avec l'espace existant" do
+      stay = create_spaces_only_stay
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Espaces")
+      # L'espace existant est présélectionné (grande_salle / journée) et chiffré.
+      expect(response.body).to include('selected="selected" value="grande_salle"')
+      expect(response.body).to include('selected="selected" value="journee"')
+      expect(response.body).to include("Grande salle — ")
+    end
+
+    it "change la période de l'espace et recalcule le total" do
+      stay = create_spaces_only_stay
+      expect(stay.total_amount_cents).to eq(grande_salle_journee_cents)
+
+      # journée → journée + soirée = 380 € (38 000 c) pour la grande salle.
+      patch stay_path(stay), params: update_params(stay, halls: hall_param(period: "journee_et_soiree"))
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay.reload
+      sb = stay.stay_items.where(bookable_type: "SpaceBooking").first.bookable
+      expect(sb.space_reservations.first.duration).to eq("journee_et_soiree")
+      expect(stay.total_amount_cents).to eq(38_000)
+    end
+
+    it "retire l'espace en vidant les lignes → refusé (séjour deviendrait vide)" do
+      stay = create_spaces_only_stay
+      patch stay_path(stay), params: update_params(stay) # ni lodging ni halls
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("hébergement ou un espace")
+    end
+  end
+
+  describe "capacité / force-dispo (édition)" do
+    it "force l'ajout d'un espace complet avec avertissement" do
+      # Grande salle complète à l'arrivée (capacity 1, une résa confirmée).
+      occ = SpaceBooking.create!(firstname: "Occ", from_date: arrival, to_date: arrival, status: "confirmed")
+      occ.space_reservations.create!(space: grande_salle, date: arrival, duration: "journee")
+
+      post stays_path, params: base_params(lodging_id: "", halls: hall_param, force_availability: "1")
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to match(/forçant la disponibilité/i)
+      expect(SpaceBooking.where(status: "pending").count).to eq(1)
+    end
+  end
+end

--- a/spec/services/reservations/builder_spaces_spec.rb
+++ b/spec/services/reservations/builder_spaces_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+# Epic #66, Phase 2 — Espaces dans la composition du séjour. Le Builder persiste
+# désormais les espaces choisis (halls / space_slots) en un SpaceBooking +
+# StayItem, y compris pour un séjour « espaces seuls » (sans hébergement). La part
+# espaces vit sur le SpaceBooking ; l'hébergement porte le reste (aucun double-compte).
+RSpec.describe Reservations::Builder, "espaces (epic #66, Phase 2)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+  # Grande Salle → grande_salle (grille de pricing). Capacity 1 = salle exclusive.
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+  # grande_salle / journée (barème semaine des salles) = 290 €.
+  let(:grande_salle_journee_cents) { 29_000 }
+  let(:hulotte_two_nights_cents)   { 74_500 }
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      lodging_id: hulotte.id,
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  def hall(date: nil, kind: "grande_salle", period: "journee")
+    { kind: kind, date: (date || arrival).iso8601, period: period }
+  end
+
+  describe "hébergement + espace" do
+    it "crée un SpaceBooking + StayItem et ventile le prix sans double-compte" do
+      builder = described_class.new(draft: draft(halls: [hall]), admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      sb = builder.space_booking
+      expect(sb).to be_persisted
+      expect(builder.stay.stay_items.map(&:bookable)).to include(sb)
+      expect(sb.space_reservations.map(&:space)).to eq([grande_salle])
+      expect(sb.price_cents).to eq(grande_salle_journee_cents)
+
+      # Le Booking d'hébergement porte le reste (hors espaces) — pas de double-compte.
+      expect(builder.booking.price_cents).to eq(hulotte_two_nights_cents)
+      # Total prévu = hébergement + espace.
+      expect(builder.stay.total_amount_cents).to eq(hulotte_two_nights_cents + grande_salle_journee_cents)
+      # recompute redonne exactement le même total (Booking + SpaceBooking).
+      builder.stay.recompute_aggregates!
+      expect(builder.stay.reload.total_amount_cents).to eq(hulotte_two_nights_cents + grande_salle_journee_cents)
+    end
+  end
+
+  describe "séjour « espaces seuls » (sans hébergement)" do
+    let(:spaces_only) { draft(lodging_id: nil, halls: [hall]) }
+
+    it "ne crée AUCUN Booking mais persiste le SpaceBooking en StayItem" do
+      builder = described_class.new(draft: spaces_only, admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      expect(builder.booking).to be_nil
+      sb = builder.space_booking
+      expect(sb).to be_persisted
+      expect(builder.stay.stay_items.map(&:bookable)).to eq([sb])
+      expect(builder.stay.total_amount_cents).to eq(grande_salle_journee_cents)
+      expect(builder.stay.arrival_date).to eq(arrival)
+      expect(builder.stay.departure_date).to eq(departure)
+    end
+
+    it "garde des agrégats corrects après recompute (dates non écrasées à nil)" do
+      builder = described_class.new(draft: spaces_only, admin: true, source: "manual")
+      builder.run
+      stay = builder.stay
+
+      stay.recompute_aggregates!
+      stay.reload
+      expect(stay.total_amount_cents).to eq(grande_salle_journee_cents)
+      expect(stay.arrival_date).to eq(arrival)
+      expect(stay.departure_date).to eq(departure)
+    end
+  end
+
+  describe "disponibilité capacity-aware des espaces" do
+    def occupy_grande_salle!(date)
+      sb = SpaceBooking.create!(firstname: "Occ", from_date: date, to_date: date, status: "confirmed")
+      sb.space_reservations.create!(space: grande_salle, date: date, duration: "journee")
+    end
+
+    it "bloque un espace déjà complet hors force" do
+      occupy_grande_salle!(arrival)
+      builder = described_class.new(draft: draft(lodging_id: nil, halls: [hall]), admin: true, source: "manual")
+
+      expect(builder.run).to be(false)
+      expect(builder.error_message).to match(/complet/i)
+      expect(Stay.count).to eq(0)
+    end
+
+    it "force la création avec un avertissement" do
+      occupy_grande_salle!(arrival)
+      builder = described_class.new(
+        draft: draft(lodging_id: nil, halls: [hall]), admin: true, source: "manual", skip_availability: true
+      )
+
+      expect(builder.run).to be(true)
+      expect(builder.availability_warning).to match(/forçant la disponibilité/i)
+      expect(builder.space_booking).to be_persisted
+    end
+  end
+end


### PR DESCRIPTION
## Epic #66 — Phase 2 : Espaces dans la composition du Séjour admin

> Empilée sur la Phase 1 (#67). Base = `feature/issue-66-phase1-crud-stay-admin`.

Comble le trou « `Stay` sans `stay_item` » : la composition admin (et le funnel public) persiste enfin les **espaces** en `SpaceBooking` + `StayItem`. Un séjour peut désormais être **espaces-seuls** (sans hébergement).

### Livré
- **Concern partagé `SpaceComposition`** (Builder + AdminUpdater) : traduit les `space_slots` (grille nuit-par-nuit) **et** `halls` (ponctuels) du `Draft` en `SpaceBooking` + `SpaceReservation` + `StayItem`, dispo **capacity-aware** (`Space#available_on?`), même flag `skip_availability`/force que l'hébergement.
- **Séjour espaces-seuls** : `bookable_content?` l'accepte, `AdminUpdater#reconcile_lodging!` détache/soft-delete l'hébergement en transition, la contrainte « hébergement obligatoire » devient « hébergement **OU** espace ».
- **`recompute_aggregates!`** dérive dates + total des bookables (Booking **et** SpaceBooking) ; garde-fou : ne réécrit les dates que si un bookable daté existe (plus d'écrasement à `nil`).
- **Prix sans double-compte** : lignes espaces taguées `category: :space` ; `Booking.lodging_bundle_cents` (hors espaces) + `SpaceBooking.spaces_cents` = total exact.
- Form : section « Espaces » (kind / date / period), hébergement rendu optionnel, prefill à l'édition.

### Tests
`bundle exec rspec` → **535 examples, 0 failures, 18 pending** (+13 vs Phase 1). Nouveaux : `builder_spaces_spec`, `stay_recompute_spaces_spec`, `stays_admin_spaces_spec`.

### ⚠️ À trancher (Michael) — mapping clé pricing → Space
Le funnel price les espaces avec les clés `grande_salle` / `petite_salle` / `cuisine_pro`, mais le **seed nomme les salles « Tilleul » / « Saule »**. Un résolveur tolérant (`SPACE_NAMES_BY_KEY`, liste de candidats) est en place. **Si aucune `Space` ne matche une clé, l'espace reste dans le devis mais n'est PAS persisté** (`unresolved_space_keys`, pas encore remonté dans l'UI). → décider : renommer/aliaser les Spaces en prod, ou ajuster la constante. À revoir avant la mise en prod du CRUD.

### Hors périmètre
Camping/repas persistés → Phase 3 · calendrier groupé → Phases 4-5 · location d'espace 0 nuit (journée sèche) non traitée · UI 3 lignes d'espaces fixes (pas d'ajout dynamique JS) · vérif navigateur = passe groupée de fin d'epic.

Refs #66
