### PR TITLE
Epic #66 Phase 4 — Calendrier groupé et coloré par séjour

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,19 +16,38 @@ class PagesController < BaseController
           .between_times(@first, @last)
       )
       # group space reservations by day
+      # Le calendrier bascule sur les SÉJOURS (epic #66, Phase 4) : on précharge
+      # `space_booking.stay` (via `stay_item`, has_one through) pour colorer et
+      # regrouper les occupations par `stay_id` sans requête N+1.
       @space_reservations = SpaceReservation.all
         .includes(:space_booking)
-        .preload(:space, space_booking: [:event, :space_reservations])
+        .preload(:space, space_booking: [:event, :space_reservations, :stay])
         .where.not(space_booking: { status: ["declined", "canceled"] })
         .between_times(@first, @last, field: :date)
       @grouped_space_reservations = @space_reservations.to_a.group_by { |sr| sr.date }
-      # group reservations by day
+      # group reservations by day (préchargement du séjour porteur, cf. supra)
       @reservations = Reservation.all
         .includes(:booking)
-        .preload(:room, booking: [:lodging, :reservations])
+        .preload(:room, booking: [:lodging, :reservations, :stay])
         .where.not(booking: { status: ["declined", "canceled"] })
         .between_times(@first, @last, field: :date)
       @grouped_reservations = @reservations.to_a.group_by { |r| r.date }
+      # Camping / van (epic #66, Phase 3–4) — capacité globale, aucune réservation
+      # jour par jour : on étale la fenêtre [from, to) en nuits, groupées par jour,
+      # pour un bloc agrégé (« Camping » / « Van ») par nuit occupée, coloré par
+      # séjour. Préchargement du séjour (anti-N+1).
+      @grouped_camping_bookings = nights_grouped_by_day(
+        CampingBooking
+          .includes(:stay)
+          .where.not(status: ["declined", "canceled"])
+          .where("from_date < ? AND to_date > ?", @last.to_date, @first.to_date)
+      )
+      @grouped_van_bookings = nights_grouped_by_day(
+        VanBooking
+          .includes(:stay)
+          .where.not(status: ["declined", "canceled"])
+          .where("from_date < ? AND to_date > ?", @last.to_date, @first.to_date)
+      )
       @activities = PublicActivity::Activity.where("created_at > ?", 14.days.ago).order(created_at: :desc)
     end
   end
@@ -110,6 +129,24 @@ class PagesController < BaseController
   end
 
   private
+
+  # Étale une collection de réservables « capacité globale » (camping / van), qui
+  # ne portent QUE des dates [from_date, to_date), en un hash { jour => [records] }
+  # borné à la fenêtre visible du calendrier. Une nuit `d` est couverte si
+  # `from_date <= d < to_date` (même convention que `GlobalCapacityBookable`).
+  def nights_grouped_by_day(records)
+    window_start = @first.to_date
+    window_end   = @last.to_date
+    grouped = {}
+    records.each do |record|
+      next unless record.from_date && record.to_date
+      (record.from_date...record.to_date).each do |night|
+        next unless night >= window_start && night <= window_end
+        (grouped[night] ||= []) << record
+      end
+    end
+    grouped
+  end
 
   def set_dates
     # get the date from params if there is one - for display AND to limit our query

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -137,8 +137,58 @@ class StaysController < BaseController
       email:          contact[:email],
       phone:          contact[:phone],
       experiences:    activity_entries(p),
-      halls:          space_entries(p)
+      halls:          space_entries(p),
+      campings:       camping_entries(p),
+      vans:           van_entries(p),
+      meals:          meal_entries(p)
     )
+  end
+
+  # Nombre de nuits déduit des dates du formulaire (pour tarifer camping/van).
+  def nights_from_params(p)
+    arrival   = parse_form_date(p[:arrival_date])
+    departure = parse_form_date(p[:departure_date])
+    return 0 if arrival.nil? || departure.nil?
+    (departure - arrival).to_i.clamp(0, 10_000)
+  end
+
+  def parse_form_date(value)
+    return nil if value.blank?
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  # Camping (epic #66, Phase 3) : le form porte un nombre de personnes ; le
+  # camping occupe toute la fenêtre du séjour (nights déduit des dates).
+  def camping_entries(p)
+    people = p.dig(:camping, :people).to_i
+    return [] if people < 1
+    nights = nights_from_params(p)
+    return [] if nights < 1
+    [{ kind: "tente", people: people, nights: nights }]
+  end
+
+  # Van / camping-car : le form porte un nombre de véhicules. Une entrée par
+  # véhicule (contrat PricingModel : une ligne `:van` par entrée).
+  def van_entries(p)
+    vehicles = p.dig(:van, :vehicles).to_i
+    return [] if vehicles < 1
+    nights = nights_from_params(p)
+    return [] if nights < 1
+    Array.new(vehicles) { { nights: nights } }
+  end
+
+  # Repas datés {kind, date, people} — on écarte les lignes incomplètes.
+  def meal_entries(p)
+    rows = p[:meals]
+    rows = rows.respond_to?(:values) ? rows.values : Array(rows)
+    rows.filter_map do |row|
+      kind   = row[:kind].to_s
+      people = row[:people].to_i
+      next if kind.blank? || people < 1
+      { kind: kind, date: row[:date].to_s.presence, people: people }
+    end
   end
 
   # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
@@ -158,8 +208,35 @@ class StaysController < BaseController
       experiences:    stay.experience_bookings.active.map { |eb|
         { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
       },
-      halls:          halls_from_stay(stay)
+      halls:          halls_from_stay(stay),
+      campings:       campings_from_stay(stay),
+      vans:           vans_from_stay(stay),
+      meals:          meals_from_stay(stay)
     )
+  end
+
+  # Reconstruit l'entrée camping {kind, people, nights} depuis le CampingBooking
+  # persisté, pour préremplir le form edit (nights déduit de la fenêtre).
+  def campings_from_stay(stay)
+    camping = stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
+    return [] if camping.nil?
+    nights = camping.from_date && camping.to_date ? (camping.to_date - camping.from_date).to_i : stay.experience_bookings.size
+    [{ kind: camping.kind, people: camping.people, nights: [nights, 1].max }]
+  end
+
+  # Reconstruit les entrées van (une par véhicule) depuis le VanBooking persisté.
+  def vans_from_stay(stay)
+    van = stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
+    return [] if van.nil?
+    nights = van.from_date && van.to_date ? (van.to_date - van.from_date).to_i : 1
+    Array.new([van.vehicles, 1].max) { { nights: [nights, 1].max } }
+  end
+
+  # Reconstruit les repas {kind, date, people} depuis les MealOrder du séjour.
+  def meals_from_stay(stay)
+    stay.meal_orders.map do |order|
+      { kind: order.kind, date: order.date&.iso8601, people: order.people }
+    end
   end
 
   # Reconstruit les lignes d'espaces {kind, date, period} d'un séjour depuis son

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -1,5 +1,6 @@
 class StaysController < BaseController
   before_action :set_accounting_view, only: :show
+  before_action :set_stay, only: %i[edit update destroy]
 
   # Rendu sans layout : le fragment HTML est injecté dans la modale de détails
   # par le contrôleur Stimulus stay-details (fetch + innerHTML). [tranche 1]
@@ -22,10 +23,191 @@ class StaysController < BaseController
     @stays = Stay.from_source(@source).recent.includes(:customer).limit(100).decorate
   end
 
+  # --- CRUD Séjour admin (epic #66, Phase 1) --------------------------------
+  # Le séjour devient le point d'entrée de création composable côté admin
+  # (hébergement + activités), en réutilisant `Reservations::Builder` en mode
+  # admin (aucun Stripe, aucun email forcé, force-dispo, statut au choix).
+
+  def new
+    @stay  = Stay.new(status: "pending")
+    @draft = Reservations::Draft.new
+    prepare_form
+  end
+
+  def create
+    @draft  = build_draft
+    builder = Reservations::Builder.new(
+      draft:             @draft,
+      admin:             true,
+      status:            requested_status,
+      source:            "manual",
+      skip_availability: force_availability?
+    )
+
+    if builder.run
+      flash[:notice] = "Séjour créé."
+      flash[:alert]  = builder.availability_warning if builder.availability_warning
+      redirect_to recent_stays_path
+    else
+      @stay  = Stay.new(status: requested_status.presence || "pending")
+      @quote = safe_quote(@draft)
+      flash.now[:alert] = builder.error_message(default: "Le séjour n'a pas pu être créé.")
+      prepare_form
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @draft = draft_from_stay(@stay)
+    prepare_form
+  end
+
+  def update
+    @draft  = build_draft
+    updater = Stays::AdminUpdater.new(
+      stay:              @stay,
+      draft:             @draft,
+      status:            requested_status,
+      skip_availability: force_availability?,
+      user:              current_user
+    )
+
+    if updater.run
+      flash[:notice] = "Séjour mis à jour."
+      flash[:alert]  = updater.availability_warning if updater.availability_warning
+      redirect_to recent_stays_path
+    else
+      @quote = safe_quote(@draft)
+      flash.now[:alert] = updater.error_message(default: "Le séjour n'a pas pu être mis à jour.")
+      prepare_form
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # Suppression = soft-delete (soft_deletion + PaperTrail), jamais de hard destroy.
+  def destroy
+    @stay.soft_delete!(validate: false)
+    redirect_to recent_stays_path, notice: "Séjour supprimé."
+  end
+
   private
+
+  def set_stay
+    @stay = Stay.find(params[:id])
+  end
 
   def set_accounting_view
     @accounting_view = true
+  end
+
+  # Données partagées par les vues new/edit.
+  def prepare_form
+    @lodgings  = bookable_lodgings
+    @customers = Customer.order(:organization_name, :last_name, :first_name).limit(1_000)
+    @assignable_availabilities = ExperienceAvailability.for_user(current_user)
+                                                       .upcoming
+                                                       .includes(:experience)
+    @statuses = Stay::STATUSES_ADMIN_CREATABLE
+    @quote  ||= safe_quote(@draft)
+  end
+
+  # Hébergements tarifables (barème B2C forfaitaire, `Pricing::Catalog`), dans
+  # l'ordre du catalogue. Même barème que le funnel public — surtout PAS le
+  # barème admin par tier (décision figée epic #66).
+  def bookable_lodgings
+    names = Pricing::Catalog::LODGING_RATES.keys
+    Lodging.where(name: names).sort_by { |l| names.index(l.name) || 99 }
+  end
+
+  # Construit un `Reservations::Draft` (contrat commun Builder/PricingModel)
+  # depuis les paramètres du formulaire admin.
+  def build_draft
+    p = stay_params
+    contact = customer_contact(p)
+    Reservations::Draft.new(
+      lodging_id:     p[:lodging_id],
+      arrival_date:   p[:arrival_date],
+      departure_date: p[:departure_date],
+      adults:         p[:adults],
+      children:       p[:children],
+      dogs_count:     p[:dogs_count],
+      group_name:     p[:group_name],
+      first_name:     contact[:first_name],
+      last_name:      contact[:last_name],
+      email:          contact[:email],
+      phone:          contact[:phone],
+      experiences:    activity_entries(p)
+    )
+  end
+
+  # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
+  def draft_from_stay(stay)
+    booking = stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    Reservations::Draft.new(
+      lodging_id:     booking&.lodging_id,
+      arrival_date:   stay.arrival_date,
+      departure_date: stay.departure_date,
+      adults:         booking&.adults,
+      children:       booking&.children,
+      group_name:     booking&.group_name,
+      first_name:     stay.customer&.first_name,
+      last_name:      stay.customer&.last_name,
+      email:          stay.customer&.email,
+      phone:          stay.customer&.phone,
+      experiences:    stay.experience_bookings.active.map { |eb|
+        { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
+      }
+    )
+  end
+
+  # Coordonnées client : soit un client existant sélectionné (on lit ses
+  # coordonnées pour que le Builder/Updater le retrouve par email), soit un
+  # nouveau client saisi à la volée.
+  def customer_contact(p)
+    if p[:customer_mode].to_s == "new"
+      nc = p[:new_customer] || {}
+      { first_name: nc[:first_name], last_name: nc[:last_name], email: nc[:email], phone: nc[:phone] }
+    elsif (customer = Customer.find_by(id: p[:customer_id]))
+      { first_name: customer.first_name, last_name: customer.last_name, email: customer.email, phone: customer.phone }
+    else
+      {}
+    end
+  end
+
+  # Entrées d'activités : chaque ligne porte un créneau (`availability_id`) et un
+  # nombre de participants. On borne au périmètre de l'utilisateur et on résout
+  # l'`experience_id` (nécessaire au devis B2C via `PricingModel`).
+  def activity_entries(p)
+    rows = p[:experiences]
+    rows = rows.respond_to?(:values) ? rows.values : Array(rows)
+    allowed = ExperienceAvailability.for_user(current_user).index_by(&:id)
+
+    rows.filter_map do |row|
+      availability_id = row[:availability_id].to_i
+      participants    = row[:participants].to_i
+      next if availability_id < 1 || participants < 1
+      avail = allowed[availability_id]
+      next unless avail
+      { id: avail.experience_id, availability_id: availability_id, participants: participants }
+    end
+  end
+
+  def requested_status
+    stay_params[:status]
+  end
+
+  def force_availability?
+    ActiveModel::Type::Boolean.new.cast(stay_params[:force_availability])
+  end
+
+  def safe_quote(draft)
+    draft&.quote
+  rescue StandardError
+    nil
+  end
+
+  def stay_params
+    params.fetch(:stay, {})
   end
 
   def set_presenters; end

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -136,7 +136,8 @@ class StaysController < BaseController
       last_name:      contact[:last_name],
       email:          contact[:email],
       phone:          contact[:phone],
-      experiences:    activity_entries(p)
+      experiences:    activity_entries(p),
+      halls:          space_entries(p)
     )
   end
 
@@ -156,8 +157,29 @@ class StaysController < BaseController
       phone:          stay.customer&.phone,
       experiences:    stay.experience_bookings.active.map { |eb|
         { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
-      }
+      },
+      halls:          halls_from_stay(stay)
     )
+  end
+
+  # Reconstruit les lignes d'espaces {kind, date, period} d'un séjour depuis son
+  # SpaceBooking (réservations existantes), pour préremplir le form edit. Le nom
+  # de la Space est re-mappé vers sa clé de pricing (grande_salle, …).
+  def halls_from_stay(stay)
+    space_booking = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+    return [] if space_booking.nil?
+
+    space_booking.space_reservations.map do |res|
+      key = space_key_for_name(res.space&.name)
+      next if key.nil?
+      { kind: key, date: res.date&.iso8601, period: res.duration }
+    end.compact
+  end
+
+  # Space#name → clé de pricing (inverse de SpaceComposition::SPACE_NAMES_BY_KEY).
+  def space_key_for_name(name)
+    return nil if name.blank?
+    SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(name) }&.first
   end
 
   # Coordonnées client : soit un client existant sélectionné (on lit ses
@@ -189,6 +211,23 @@ class StaysController < BaseController
       avail = allowed[availability_id]
       next unless avail
       { id: avail.experience_id, availability_id: availability_id, participants: participants }
+    end
+  end
+
+  # Entrées d'espaces (epic #66, Phase 2) : chaque ligne du form porte un espace
+  # (`kind` = clé de pricing grande_salle/petite_salle/cuisine_pro), une `date` et
+  # une `period` (journee/soiree/journee_et_soiree). On écarte les lignes
+  # incomplètes ; le résultat alimente `Reservations::Draft#halls` — commun au
+  # devis (PricingModel) ET à la persistance (SpaceComposition).
+  def space_entries(p)
+    rows = p[:halls]
+    rows = rows.respond_to?(:values) ? rows.values : Array(rows)
+    rows.filter_map do |row|
+      kind   = row[:kind].to_s
+      date   = row[:date].to_s
+      period = row[:period].to_s
+      next if kind.blank? || date.blank? || period.blank?
+      { kind: kind, date: date, period: period }
     end
   end
 

--- a/app/decorators/booking_decorator.rb
+++ b/app/decorators/booking_decorator.rb
@@ -30,6 +30,20 @@ class BookingDecorator < ApplicationDecorator
     classes.join(" ")
   end
 
+  # Classe structurelle du bloc calendrier (epic #66, Phase 4). Quand un séjour
+  # groupe l'occupation, la COULEUR vient d'un style inline par `stay_id`
+  # (`CalendarHelper#stay_block_style`) ; on ne garde donc ici que la structure
+  # (ombre + bordure) et l'atténuation des séjours non confirmés. Sans séjour
+  # (bookings legacy sans `StayItem`), on retombe sur `calendar_class` — couleur
+  # par type d'occupation, comportement historique strictement inchangé.
+  def calendar_block_class
+    return calendar_class if object.stay.nil?
+
+    classes = ["shadow", "border-l-4"]
+    classes << "opacity-50" unless object.confirmed?
+    classes.join(" ")
+  end
+
   def dates_counter(current_date)
     if object.to_date == object.from_date + 1.day
     else

--- a/app/decorators/space_booking_decorator.rb
+++ b/app/decorators/space_booking_decorator.rb
@@ -20,6 +20,18 @@ class SpaceBookingDecorator < ApplicationDecorator
     classes.join(" ")
   end
 
+  # Classe structurelle du bloc calendrier (epic #66, Phase 4). Voir la note
+  # jumelle dans `BookingDecorator#calendar_block_class` : couleur par séjour en
+  # style inline quand un `Stay` groupe l'occupation, sinon `calendar_class`
+  # (orange espace) historique.
+  def calendar_block_class
+    return calendar_class if object.stay.nil?
+
+    classes = ["shadow", "border-l-4"]
+    classes << "opacity-50" unless object.confirmed?
+    classes.join(" ")
+  end
+
   def dates_counter(current_date)
     if object.to_date != object.from_date
       total_days = (object.to_date - object.from_date).to_i + 1

--- a/app/frontend/controllers/stay_form_controller.js
+++ b/app/frontend/controllers/stay_form_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Formulaire CRUD Séjour admin (epic #66, Phase 1). Bascule client existant /
+// nouveau client : seul le panneau actif est visible (les deux restent dans le
+// DOM, le contrôleur ne soumet pas côté client — c'est `customer_mode` qui dit
+// au serveur quel panneau lire).
+//
+// Usage (dans stays/_form) :
+//   form(data-controller="stay-form")
+//     input[type=radio name="stay[customer_mode]"] (data-action="change->stay-form#toggleCustomer")
+//     div(data-stay-form-target="existingPanel")
+//     div(data-stay-form-target="newPanel")
+export default class extends Controller {
+  static targets = ["existingPanel", "newPanel"]
+
+  connect() {
+    this.toggleCustomer()
+  }
+
+  toggleCustomer() {
+    const mode =
+      this.element.querySelector('input[name="stay[customer_mode]"]:checked')?.value ||
+      "existing"
+    this.togglePanel(this.existingPanelTarget, mode === "existing")
+    this.togglePanel(this.newPanelTarget, mode === "new")
+  }
+
+  togglePanel(panel, active) {
+    if (!panel) return
+    panel.classList.toggle("hidden", !active)
+  }
+}

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -1,4 +1,27 @@
 module CalendarHelper
+  # --- Couleur déterministe par séjour (epic #66, Phase 4) -----------------
+  # Le calendrier regroupe et colore les occupations PAR SÉJOUR (`stay_id`).
+  # La teinte dérive de l'id du séjour via l'angle d'or (137,508°) qui répartit
+  # les teintes le plus loin possible les unes des autres — deux séjours voisins
+  # obtiennent donc des couleurs bien distinctes.
+  #
+  # Le rendu passe par du STYLE INLINE et NON par des classes Tailwind : une
+  # classe dynamique (`bg-[hsl(...)]` / `bg-#{...}`) est invisible au scan JIT de
+  # Tailwind et ne serait jamais générée. Le style inline est garanti au runtime.
+  GOLDEN_ANGLE = 137.508
+
+  # Teinte HSL (0–359) stable pour un séjour donné.
+  def stay_hue(stay_id)
+    ((stay_id.to_i * GOLDEN_ANGLE) % 360).round
+  end
+
+  # Style d'accent d'un bloc calendrier groupé par séjour : bordure gauche
+  # colorée + fond très clair de la même teinte. Combiné avec `border-l-4`.
+  def stay_block_style(stay_id)
+    hue = stay_hue(stay_id)
+    "border-left-color: hsl(#{hue}, 65%, 45%); background-color: hsl(#{hue}, 70%, 96%);"
+  end
+
   def button_to_next_month(current_date, data = {}, options = {})
     link_to(params.permit(:date, :no_title, :view).merge(date: current_date.next_month), class: "btn-page-header-with-icon", data: data) do
       if options[:no_label].nil?

--- a/app/models/camping_booking.rb
+++ b/app/models/camping_booking.rb
@@ -1,0 +1,67 @@
+# == Schema Information
+#
+# Table name: camping_bookings
+#
+#  id          :bigint           not null, primary key
+#  firstname   :string
+#  lastname    :string
+#  email       :string
+#  phone       :string
+#  group_name  :string
+#  from_date   :date
+#  to_date     :date
+#  people      :integer          default(1), not null
+#  kind        :string           default("tente"), not null
+#  status      :string
+#  price_cents :integer
+#  token       :string
+#  notes       :text
+#  deleted_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Réservation de CAMPING (tente) — epic #66, Phase 3. Occupe le calendrier via un
+# `StayItem` polymorphe (expose from_date/to_date comme Booking/SpaceBooking), et
+# consomme `people` personnes contre la CAPACITÉ GLOBALE du terrain (pas
+# d'emplacements nommés — décision figée). Tarif €/pers/nuit (`Pricing::Catalog`).
+class CampingBooking < ApplicationRecord
+  include GlobalCapacityBookable
+
+  # Capacité totale du terrain de camping, en PERSONNES. Valeur par défaut
+  # provisoire — À AJUSTER par Michael selon la capacité réelle du domaine.
+  TOTAL_CAPACITY = 30
+
+  # Inverse de la relation StayItem (mêmes conventions que Booking/SpaceBooking).
+  has_one :stay_item, as: :bookable
+  has_one :stay, through: :stay_item
+
+  has_paper_trail
+  has_soft_deletion default_scope: true
+
+  monetize :price_cents, allow_nil: true
+
+  validates :people, numericality: { only_integer: true, greater_than: 0 }
+
+  before_create :generate_token
+
+  scope :current_and_future, -> { where("to_date >= ?", Date.today).order(from_date: :asc) }
+  scope :past, -> { where("to_date < ?", Date.today).order(from_date: :desc) }
+
+  def self.capacity_units_column = :people
+
+  # Unités consommées par cette réservation (contrat GlobalCapacityBookable).
+  def capacity_units = people.to_i
+
+  def confirmed? = status == "confirmed"
+  def pending?   = status == "pending"
+
+  def name = "#{firstname} #{lastname}".strip
+
+  def generate_token
+    return if token.present?
+    loop do
+      self.token = SecureRandom.hex(8)
+      break unless CampingBooking.unscoped.exists?(token: token)
+    end
+  end
+end

--- a/app/models/concerns/global_capacity_bookable.rb
+++ b/app/models/concerns/global_capacity_bookable.rb
@@ -1,0 +1,54 @@
+# Disponibilité à CAPACITÉ GLOBALE pour les réservables « plein air » du terrain
+# (camping, van/camping-car) — epic #66, Phase 3.
+#
+# Contrairement aux `Space` (capacité par ressource nommée), ces réservables
+# partagent une SEULE capacité globale du domaine (pas d'emplacements nommés,
+# décision figée Michael 2026-07-18). Le modèle hôte fournit :
+#   - une constante `TOTAL_CAPACITY` (capacité totale, en unités du modèle) ;
+#   - `#capacity_units` : le nombre d'unités que CETTE réservation consomme
+#     (personnes pour le camping, véhicules pour le van).
+#
+# Une réservation occupe chaque NUIT de la fenêtre [from_date, to_date). Une nuit
+# `d` est couverte si `from_date <= d < to_date`. La dispo est vérifiée nuit par
+# nuit : pour chaque nuit demandée, (unités déjà confirmées) + (unités demandées)
+# ne doit pas dépasser `TOTAL_CAPACITY`. Seules les réservations `confirmed`
+# comptent contre la capacité (comme `Space#booked_on?`).
+module GlobalCapacityBookable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :confirmed, -> { where(status: "confirmed") }
+    # Réservations couvrant la nuit `date` (from <= date < to).
+    scope :covering, ->(date) { where("from_date <= ? AND to_date > ?", date, date) }
+  end
+
+  class_methods do
+    # Unités déjà CONFIRMÉES pour la nuit `date`, en excluant éventuellement une
+    # réservation donnée (utile à l'édition d'un réservable existant).
+    def units_reserved_on(date, excluding_id: nil)
+      scope = confirmed.covering(date)
+      scope = scope.where.not(id: excluding_id) if excluding_id
+      scope.sum(capacity_units_column)
+    end
+
+    # Unités restantes pour la nuit `date`.
+    def remaining_on(date, excluding_id: nil)
+      [self::TOTAL_CAPACITY - units_reserved_on(date, excluding_id: excluding_id), 0].max
+    end
+
+    # Première nuit en conflit de capacité pour une demande, ou nil si tout passe.
+    # `from`/`to` = fenêtre [arrivée, départ) ; `units` = unités demandées.
+    def capacity_conflict_date(units:, from:, to:, excluding_id: nil)
+      return nil if units.to_i < 1 || from.blank? || to.blank?
+
+      (from...to).find do |date|
+        units_reserved_on(date, excluding_id: excluding_id) + units.to_i > self::TOTAL_CAPACITY
+      end
+    end
+
+    # Colonne portant les unités consommées — surchargée par chaque modèle.
+    def capacity_units_column
+      raise NotImplementedError, "#{name} must define .capacity_units_column"
+    end
+  end
+end

--- a/app/models/meal_order.rb
+++ b/app/models/meal_order.rb
@@ -1,0 +1,41 @@
+# == Schema Information
+#
+# Table name: meal_orders
+#
+#  id          :bigint           not null, primary key
+#  stay_id     :bigint           not null
+#  kind        :string
+#  date        :date
+#  people      :integer          default(1), not null
+#  price_cents :integer
+#  deleted_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Commande de REPAS — epic #66, Phase 3. Rattachée DIRECTEMENT au séjour
+# (`has_many` sur Stay, comme `ExperienceBooking`), PAS via `StayItem` : un repas
+# n'occupe pas le calendrier. Modèle daté `{kind, date, people}` ; `date` est
+# nullable pour tolérer les repas du funnel public (forme `{kind, people}` sans
+# date). Tarif €/pers (`Pricing::Catalog::MEAL_PER_PERSON_CENTS`).
+class MealOrder < ApplicationRecord
+  belongs_to :stay
+
+  has_paper_trail
+  has_soft_deletion default_scope: true
+
+  monetize :price_cents, allow_nil: true
+
+  validates :kind, presence: true
+  validates :people, numericality: { only_integer: true, greater_than: 0 }
+
+  # Libellé lisible du type de repas (fallback sur la clé humanisée).
+  MEAL_LABELS = {
+    "repas_vege_midi"  => "Repas végé (midi)",
+    "buffet"           => "Buffet pain-fromages",
+    "formule_complete" => "Formule complète"
+  }.freeze
+
+  def label
+    MEAL_LABELS[kind.to_s] || kind.to_s.tr("_", " ").capitalize
+  end
+end

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -24,6 +24,12 @@ class Stay < ApplicationRecord
   # de paiement ; Booking garde le sien tant que la colonne existe.
   PAYMENT_STATUSES = %w[pending partially_paid paid].freeze
 
+  # Statuts qu'un admin peut POSER à la création d'un séjour (epic #66, Phase 1).
+  # `status` reste une chaîne libre au niveau modèle (valeurs historiques :
+  # pending / confirmed / canceled) ; on borne seulement ce que le CRUD admin
+  # accepte de créer — jamais un `canceled` par le formulaire de création.
+  STATUSES_ADMIN_CREATABLE = %w[pending confirmed].freeze
+
   belongs_to :customer
   has_many :stay_items, dependent: :destroy
   has_many :experience_bookings, dependent: :destroy

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -209,10 +209,15 @@ class Stay < ApplicationRecord
     # jamais les bornes du calendrier du séjour.
     amount = items.sum { |b| b.try(:price_cents).to_i } +
              experience_bookings.active.sum(&:price_cents)
-    update!(
-      arrival_date: arrivals.min,
-      departure_date: departures.max,
-      total_amount_cents: amount
-    )
+    # Séjour SANS hébergement (epic #66, Phase 2) : les dates viennent des
+    # SpaceBooking (Booking ET SpaceBooking exposent from_date/to_date), donc un
+    # séjour « espaces seuls » reste daté. On ne réécrit les dates QUE si au moins
+    # un bookable en porte — sinon on préserve les dates existantes plutôt que de
+    # les écraser à nil (garde-fou : un recompute sur un séjour sans bookable daté
+    # ne doit pas effacer arrival/departure).
+    attrs = { total_amount_cents: amount }
+    attrs[:arrival_date]   = arrivals.min   if arrivals.any?
+    attrs[:departure_date] = departures.max if departures.any?
+    update!(attrs)
   end
 end

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -33,6 +33,9 @@ class Stay < ApplicationRecord
   belongs_to :customer
   has_many :stay_items, dependent: :destroy
   has_many :experience_bookings, dependent: :destroy
+  # Repas (epic #66, Phase 3) : rattachés en direct (pas d'occupation calendrier),
+  # sur le modèle d'`experience_bookings`.
+  has_many :meal_orders, dependent: :destroy
 
   has_paper_trail
   has_soft_deletion default_scope: true
@@ -207,8 +210,12 @@ class Stay < ApplicationRecord
     # bookables (hébergement/espaces) + activités ACTIVES (hors annulées). Les
     # DATES restent dérivées des SEULS bookables — une activité ne déborde
     # jamais les bornes du calendrier du séjour.
+    # Le total agrège : bookables (hébergement/espaces/camping/van via StayItem)
+    # + activités ACTIVES + repas (epic #66, Phase 3 — has_many direct, non
+    # calendrier). Les repas soft-deleted sont exclus par le default_scope.
     amount = items.sum { |b| b.try(:price_cents).to_i } +
-             experience_bookings.active.sum(&:price_cents)
+             experience_bookings.active.sum(&:price_cents) +
+             meal_orders.sum(:price_cents).to_i
     # Séjour SANS hébergement (epic #66, Phase 2) : les dates viennent des
     # SpaceBooking (Booking ET SpaceBooking exposent from_date/to_date), donc un
     # séjour « espaces seuls » reste daté. On ne réécrit les dates QUE si au moins

--- a/app/models/stay_item.rb
+++ b/app/models/stay_item.rb
@@ -12,13 +12,14 @@
 #
 class StayItem < ApplicationRecord
   belongs_to :stay
-  # Polymorphic, extensible: Booking + SpaceBooking today; ActivityBooking,
-  # EventBooking, MealOrder, … later without a schema change.
+  # Polymorphic, extensible: Booking + SpaceBooking + CampingBooking + VanBooking
+  # today (epic #66, Phase 3). Les repas (MealOrder) n'occupent PAS le calendrier
+  # → rattachés en direct sur Stay, pas via StayItem.
   belongs_to :bookable, polymorphic: true
 
   has_paper_trail
   has_soft_deletion default_scope: true
 
-  validates :bookable_type, inclusion: { in: %w[Booking SpaceBooking] }
+  validates :bookable_type, inclusion: { in: %w[Booking SpaceBooking CampingBooking VanBooking] }
   validates :bookable_id, uniqueness: { scope: [:stay_id, :bookable_type] }
 end

--- a/app/models/van_booking.rb
+++ b/app/models/van_booking.rb
@@ -1,0 +1,64 @@
+# == Schema Information
+#
+# Table name: van_bookings
+#
+#  id          :bigint           not null, primary key
+#  firstname   :string
+#  lastname    :string
+#  email       :string
+#  phone       :string
+#  group_name  :string
+#  from_date   :date
+#  to_date     :date
+#  vehicles    :integer          default(1), not null
+#  status      :string
+#  price_cents :integer
+#  token       :string
+#  notes       :text
+#  deleted_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Réservation de VAN / camping-car — epic #66, Phase 3. Même logique que le
+# camping : occupe le calendrier via un `StayItem` polymorphe et consomme
+# `vehicles` véhicules contre une CAPACITÉ GLOBALE (nombre de places véhicules du
+# domaine). Tarif forfait/nuit/véhicule (`Pricing::Catalog::VAN_PER_NIGHT_CENTS`).
+class VanBooking < ApplicationRecord
+  include GlobalCapacityBookable
+
+  # Capacité totale en VÉHICULES. Valeur par défaut provisoire — À AJUSTER par
+  # Michael selon le nombre réel de places véhicules du domaine.
+  TOTAL_CAPACITY = 5
+
+  has_one :stay_item, as: :bookable
+  has_one :stay, through: :stay_item
+
+  has_paper_trail
+  has_soft_deletion default_scope: true
+
+  monetize :price_cents, allow_nil: true
+
+  validates :vehicles, numericality: { only_integer: true, greater_than: 0 }
+
+  before_create :generate_token
+
+  scope :current_and_future, -> { where("to_date >= ?", Date.today).order(from_date: :asc) }
+  scope :past, -> { where("to_date < ?", Date.today).order(from_date: :desc) }
+
+  def self.capacity_units_column = :vehicles
+
+  def capacity_units = vehicles.to_i
+
+  def confirmed? = status == "confirmed"
+  def pending?   = status == "pending"
+
+  def name = "#{firstname} #{lastname}".strip
+
+  def generate_token
+    return if token.present?
+    loop do
+      self.token = SecureRandom.hex(8)
+      break unless VanBooking.unscoped.exists?(token: token)
+    end
+  end
+end

--- a/app/services/concerns/camping_composition.rb
+++ b/app/services/concerns/camping_composition.rb
@@ -1,0 +1,126 @@
+# Composition CAMPING & VAN d'un séjour depuis un `Reservations::Draft`
+# (epic #66, Phase 3). Concern PARTAGÉ par `Reservations::Builder` (création) et
+# `Stays::AdminUpdater` (édition), sur le modèle de `SpaceComposition`.
+#
+# Décisions figées (Michael, 2026-07-18) :
+#   - Camping = capacité GLOBALE du terrain (pas d'emplacements nommés). Un
+#     `CampingBooking` occupe N personnes sur la fenêtre du séjour, vérifié
+#     contre `CampingBooking::TOTAL_CAPACITY` (forçable par l'admin).
+#   - Van / camping-car = même logique, en VÉHICULES, contre
+#     `VanBooking::TOTAL_CAPACITY`.
+#   - Les deux OCCUPENT le calendrier → rattachés via `StayItem` polymorphe, avec
+#     from_date/to_date = fenêtre du séjour (comme Booking/SpaceBooking).
+#   - Le montant vient du devis B2C (`PricingModel`, parts `:camping` / `:van`),
+#     jamais recalculé ici — aucun double-compte avec `lodging_only_cents`.
+module CampingComposition
+  extend ActiveSupport::Concern
+
+  private
+
+  # --- Lecture du draft ----------------------------------------------------
+
+  # Nombre total de personnes en camping demandé (agrège les entrées du draft).
+  def draft_camping_people(draft)
+    Array(draft.campings).sum { |e| symbol(e)[:people].to_i.clamp(0, 100_000) }
+  end
+
+  def draft_has_camping?(draft)
+    draft_camping_people(draft).positive?
+  end
+
+  # Nombre de véhicules demandés — une entrée `vans` = un véhicule (contrat
+  # PricingModel : `van_lines` produit une ligne par entrée).
+  def draft_van_vehicles(draft)
+    Array(draft.vans).count { |e| (symbol(e)[:nights] || draft.nights).to_i.positive? }
+  end
+
+  def draft_has_van?(draft)
+    draft_van_vehicles(draft).positive?
+  end
+
+  # --- Disponibilité capacité globale (forçable) ---------------------------
+
+  # Renvoie un message d'avertissement si la demande dépasse la capacité globale,
+  # sinon nil. Hors force, l'appelant transforme le message en erreur bloquante.
+  # `excluding_camping_id` / `excluding_van_id` : réservations propres au séjour à
+  # ignorer (édition — sinon l'édition d'un séjour camping-seul se bloque elle-même).
+  def camping_capacity_message(draft, excluding_id: nil)
+    people = draft_camping_people(draft)
+    return nil if people.zero?
+    date = CampingBooking.capacity_conflict_date(
+      units: people, from: draft.arrival_date, to: draft.departure_date, excluding_id: excluding_id
+    )
+    return nil if date.nil?
+    "Camping complet le #{date.strftime('%-d/%m')} (capacité #{CampingBooking::TOTAL_CAPACITY} pers)."
+  end
+
+  def van_capacity_message(draft, excluding_id: nil)
+    vehicles = draft_van_vehicles(draft)
+    return nil if vehicles.zero?
+    date = VanBooking.capacity_conflict_date(
+      units: vehicles, from: draft.arrival_date, to: draft.departure_date, excluding_id: excluding_id
+    )
+    return nil if date.nil?
+    "Emplacements van complets le #{date.strftime('%-d/%m')} (capacité #{VanBooking::TOTAL_CAPACITY} véhicules)."
+  end
+
+  # --- Persistance ---------------------------------------------------------
+
+  def persist_camping_booking!(stay:, draft:, status:, price_cents:)
+    camping = build_camping_booking(draft: draft, status: status, price_cents: price_cents)
+    camping.save!
+    stay.stay_items.create!(bookable: camping)
+    camping
+  end
+
+  def build_camping_booking(draft:, status:, price_cents:)
+    CampingBooking.new(
+      firstname:   draft.first_name,
+      lastname:    draft.last_name,
+      email:       Customer.normalize_email(draft.email),
+      phone:       draft.phone,
+      group_name:  draft.group_name,
+      from_date:   draft.arrival_date,
+      to_date:     draft.departure_date,
+      people:      [draft_camping_people(draft), 1].max,
+      kind:        "tente",
+      status:      status,
+      price_cents: price_cents
+    )
+  end
+
+  def persist_van_booking!(stay:, draft:, status:, price_cents:)
+    van = build_van_booking(draft: draft, status: status, price_cents: price_cents)
+    van.save!
+    stay.stay_items.create!(bookable: van)
+    van
+  end
+
+  def build_van_booking(draft:, status:, price_cents:)
+    VanBooking.new(
+      firstname:   draft.first_name,
+      lastname:    draft.last_name,
+      email:       Customer.normalize_email(draft.email),
+      phone:       draft.phone,
+      group_name:  draft.group_name,
+      from_date:   draft.arrival_date,
+      to_date:     draft.departure_date,
+      vehicles:    [draft_van_vehicles(draft), 1].max,
+      status:      status,
+      price_cents: price_cents
+    )
+  end
+
+  # Réservables déjà rattachés au séjour (édition), ou nil.
+  def existing_camping_booking(stay)
+    stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
+  end
+
+  def existing_van_booking(stay)
+    stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
+  end
+
+  def symbol(entry)
+    entry.respond_to?(:symbolize_keys) ? entry.symbolize_keys : entry
+  end
+end

--- a/app/services/concerns/meal_composition.rb
+++ b/app/services/concerns/meal_composition.rb
@@ -1,0 +1,68 @@
+# Composition REPAS d'un séjour depuis un `Reservations::Draft` (epic #66,
+# Phase 3). Concern PARTAGÉ par `Reservations::Builder` (création) et
+# `Stays::AdminUpdater` (édition).
+#
+# Décision figée : un repas est une commande datée `{kind, date, people}`
+# rattachée DIRECTEMENT au séjour (`has_many :meal_orders`), SANS occupation
+# calendrier — donc pas de `StayItem`, sur le modèle d'`ExperienceBooking`. Le
+# montant vient du barème B2C (`Pricing::Catalog::MEAL_PER_PERSON_CENTS`) — la
+# même source que la ligne `:meal` du devis, donc aucun double-compte.
+#
+# `date` est nullable : le funnel public envoie des repas sans date
+# (`{kind, people}`) ; on la tolère (le canal admin, lui, fournit une date).
+module MealComposition
+  extend ActiveSupport::Concern
+
+  private
+
+  # Entrées de repas exploitables du draft : [{ kind:, date:, people: }].
+  def draft_meal_entries(draft)
+    Array(draft.meals).filter_map do |raw|
+      entry  = raw.respond_to?(:symbolize_keys) ? raw.symbolize_keys : raw
+      kind   = entry[:kind].to_s
+      people = entry[:people].to_i
+      next if kind.blank? || people < 1
+      next unless Pricing::Catalog::MEAL_PER_PERSON_CENTS.key?(kind)
+      { kind: kind, date: parse_meal_date(entry[:date]), people: people }
+    end
+  end
+
+  def draft_has_meals?(draft)
+    draft_meal_entries(draft).any?
+  end
+
+  # Prix TVAC d'une entrée repas (source unique = Catalog, comme `meal_lines`).
+  def meal_entry_price_cents(entry)
+    Pricing::Catalog::MEAL_PER_PERSON_CENTS[entry[:kind].to_s].to_i * entry[:people].to_i
+  end
+
+  # Crée les MealOrder du séjour depuis les entrées du draft. Retourne la somme
+  # des montants créés.
+  def create_meal_orders!(stay, draft)
+    draft_meal_entries(draft).sum(0) do |entry|
+      order = stay.meal_orders.create!(
+        kind:        entry[:kind],
+        date:        entry[:date],
+        people:      entry[:people],
+        price_cents: meal_entry_price_cents(entry)
+      )
+      order.price_cents
+    end
+  end
+
+  # Réconcilie les repas à l'édition : rebuild complet (petit volume). Les
+  # anciennes commandes sont soft-deleted (PaperTrail + default_scope), les
+  # nouvelles recréées depuis le draft.
+  def reconcile_meals!(stay, draft)
+    stay.meal_orders.each { |order| order.soft_delete!(validate: false) }
+    create_meal_orders!(stay, draft)
+  end
+
+  def parse_meal_date(value)
+    return nil if value.blank?
+    return value if value.is_a?(Date)
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+end

--- a/app/services/concerns/space_composition.rb
+++ b/app/services/concerns/space_composition.rb
@@ -1,0 +1,150 @@
+# Composition d'ESPACES d'un séjour depuis un `Reservations::Draft` (epic #66,
+# Phase 2). Concern PARTAGÉ par `Reservations::Builder` (création) et
+# `Stays::AdminUpdater` (édition) : les deux traduisent les espaces choisis
+# (`space_slots` grille nuit-par-nuit OU `halls` ponctuels {kind, date, period})
+# en un `SpaceBooking` + ses `SpaceReservation`, rattaché au séjour via un
+# `StayItem`.
+#
+# Réutilisation maximale (décision figée) :
+#   - la disponibilité reste CAPACITY-AWARE via `Space#available_on?` (source
+#     unique de vérité, comme `SpaceBookable#available?`) ;
+#   - le montant de l'espace vient du devis B2C (`PricingModel`, part `:space`),
+#     jamais recalculé ici.
+#
+# ⚠️ MAPPING clé de pricing → `Space` (à surveiller — voir gap connu) : le funnel
+# public price les espaces avec des clés forfaitaires (`grande_salle`, …) qui ne
+# correspondent pas 1:1 aux `Space.name` en base (seed : « Tilleul », « Saule »).
+# On résout donc par une LISTE de noms candidats par clé, tolérante aux deux
+# conventions (nom marketing OU nom du seed). Si aucune `Space` ne matche, la
+# ligne reste dans le devis mais n'est pas persistée (voir `unresolved_space_keys`).
+module SpaceComposition
+  extend ActiveSupport::Concern
+
+  # Noms de `Space` acceptés pour chaque clé de pricing, par ordre de préférence.
+  # Le premier trouvé en base gagne. Cf. `PricingModel::SPACE_NAMES`.
+  SPACE_NAMES_BY_KEY = {
+    "grande_salle" => ["Grande Salle", "Tilleul"],
+    "petite_salle" => ["Petite Salle", "Saule"],
+    "cuisine_pro"  => ["Cuisine professionnelle", "Cuisine pro"]
+  }.freeze
+
+  private
+
+  # Le draft porte-t-il au moins un espace exploitable (résolu ou non) ?
+  # Sert au gate « contenu réservable » (un séjour peut être espaces-seuls).
+  def draft_has_spaces?(draft)
+    raw_space_entries(draft).any?
+  end
+
+  # Specs de réservation d'espace RÉSOLUES : [{ space:, date:, duration: }].
+  # Ne contient que les entrées dont la `Space` existe en base.
+  def space_reservation_specs(draft)
+    raw_space_entries(draft).filter_map do |entry|
+      space = space_for_key(entry[:key])
+      next if space.nil?
+      { space: space, date: entry[:date], duration: entry[:duration] }
+    end
+  end
+
+  # Clés d'espace demandées mais SANS `Space` correspondante en base — utile pour
+  # avertir l'admin (le devis les compte, mais elles ne seront pas persistées).
+  def unresolved_space_keys(draft)
+    raw_space_entries(draft)
+      .map { |e| e[:key] }
+      .uniq
+      .reject { |key| space_for_key(key) }
+  end
+
+  # Conflits capacity-aware : (space, date) déjà plein (`Space#available_on?`).
+  # Retourne les specs en conflit (vide = tout dispo).
+  def space_availability_conflicts(specs)
+    specs.reject { |spec| spec[:space].available_on?(spec[:date]) }
+  end
+
+  # Crée un `SpaceBooking` + ses `SpaceReservation` à partir de specs résolues,
+  # et le rattache au séjour via un `StayItem`. Retourne le `SpaceBooking`.
+  # `window` = [arrival_date, departure_date] du draft, pour fixer from/to_date
+  # sur la fenêtre du séjour (cohérent avec `Stay#recompute_aggregates!`).
+  def persist_space_booking!(stay:, draft:, specs:, status:, price_cents:)
+    space_booking = build_space_booking(draft: draft, specs: specs, status: status, price_cents: price_cents)
+    space_booking.save!
+    stay.stay_items.create!(bookable: space_booking)
+    space_booking
+  end
+
+  def build_space_booking(draft:, specs:, status:, price_cents:)
+    dates = specs.map { |s| s[:date] }.compact
+    space_booking = SpaceBooking.new(
+      firstname:      draft.first_name,
+      lastname:       draft.last_name,
+      email:          Customer.normalize_email(draft.email),
+      phone:          draft.phone,
+      group_name:     draft.group_name,
+      from_date:      draft.arrival_date || dates.min,
+      to_date:        draft.departure_date || dates.max,
+      status:         status,
+      payment_status: "pending",
+      price_cents:    price_cents
+    )
+    space_booking.generate_token
+    specs.each do |spec|
+      space_booking.space_reservations.build(space: spec[:space], date: spec[:date], duration: spec[:duration])
+    end
+    space_booking
+  end
+
+  # Réservable d'espace déjà rattaché au séjour (édition), ou nil.
+  def existing_space_booking(stay)
+    stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+  end
+
+  # --- Interne ------------------------------------------------------------
+
+  # Entrées d'espace BRUTES (avant résolution `Space`) : [{ key:, date:, duration: }].
+  # Fusionne les deux représentations : `space_slots` (grille nuit-par-nuit,
+  # indexée depuis `arrival_date`) et `halls` (ponctuels {kind, date, period}).
+  def raw_space_entries(draft)
+    entries = []
+
+    slots   = draft.space_slots
+    arrival = draft.arrival_date
+    if slots.present? && arrival.present?
+      slots.each do |key, periods|
+        next unless SPACE_NAMES_BY_KEY.key?(key.to_s)
+        Array(periods).each_with_index do |period, night_idx|
+          next if period.blank?
+          entries << { key: key.to_s, date: arrival + night_idx, duration: period.to_s }
+        end
+      end
+    end
+
+    Array(draft.halls).each do |hall|
+      hall = hall.symbolize_keys if hall.respond_to?(:symbolize_keys)
+      key    = hall[:kind].to_s
+      period = hall[:period].to_s
+      next unless SPACE_NAMES_BY_KEY.key?(key)
+      next if period.blank?
+      date = parse_space_date(hall[:date])
+      next if date.nil?
+      entries << { key: key, date: date, duration: period }
+    end
+
+    entries
+  end
+
+  def space_for_key(key)
+    @space_by_key ||= {}
+    return @space_by_key[key.to_s] if @space_by_key.key?(key.to_s)
+
+    names = SPACE_NAMES_BY_KEY[key.to_s]
+    space = names && Space.where(name: names).min_by { |s| names.index(s.name) || 99 }
+    @space_by_key[key.to_s] = space
+  end
+
+  def parse_space_date(value)
+    return value if value.is_a?(Date)
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+end

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -39,6 +39,20 @@ class PricingModel
       total_cents.to_i - experiences_cents.to_i
     end
 
+    # Part des ESPACES (salles / cuisine pro) dans le total (epic #66, Phase 2).
+    # Permet de ventiler proprement le devis entre le `Booking` d'hébergement et
+    # le `SpaceBooking` d'espaces SANS jamais double-compter : l'hébergement porte
+    # `lodging_bundle_cents`, les espaces `spaces_cents`, la somme reste
+    # `total_excluding_experiences_cents`.
+    def spaces_cents
+      lines.select { |line| line.category == :space }.sum(&:amount_cents)
+    end
+
+    # Base hébergement/camping/repas = total hors activités ET hors espaces.
+    def lodging_bundle_cents
+      total_excluding_experiences_cents - spaces_cents
+    end
+
     def breakdown
       lines.map(&:to_h)
     end
@@ -171,7 +185,7 @@ class PricingModel
       next if date_label.nil?
       period_label = PERIOD_LABELS[period] || period
       Line.new(label: "#{humanize(entry[:kind])} — #{date_label}, #{period_label}",
-               amount_cents: unit)
+               amount_cents: unit, category: :space)
     end
   end
 
@@ -201,7 +215,7 @@ class PricingModel
         period_label = PERIOD_LABELS[period.to_s] || period.to_s
         Line.new(
           label:        "#{space_name} — nuit #{night_idx + 1}, #{period_label}",
-          amount_cents: unit
+          amount_cents: unit, category: :space
         )
       end
     end.compact

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -45,12 +45,33 @@ class PricingModel
     # `lodging_bundle_cents`, les espaces `spaces_cents`, la somme reste
     # `total_excluding_experiences_cents`.
     def spaces_cents
-      lines.select { |line| line.category == :space }.sum(&:amount_cents)
+      category_cents(:space)
     end
 
+    # Parts camping / van / repas (epic #66, Phase 3). Chacune est extraite du
+    # devis pour être portée par son propre modèle persisté (`CampingBooking`,
+    # `VanBooking`, `MealOrder`) côté canal admin — sans jamais double-compter.
+    def camping_cents = category_cents(:camping)
+    def van_cents     = category_cents(:van)
+    def meals_cents   = category_cents(:meal)
+
     # Base hébergement/camping/repas = total hors activités ET hors espaces.
+    # INCHANGÉ pour préserver EXACTEMENT le canal public (funnel) : côté public,
+    # camping/van/repas restent devis-only et noyés dans le prix du `Booking`.
     def lodging_bundle_cents
       total_excluding_experiences_cents - spaces_cents
+    end
+
+    # Hébergement PUR (epic #66, Phase 3) = bundle MOINS camping/van/repas. C'est
+    # la part que porte le `Booking` d'hébergement dans le canal ADMIN, où
+    # camping/van/repas vivent sur leurs propres modèles. Invariant admin :
+    #   lodging_only + spaces + camping + van + meals == total_excluding_experiences.
+    def lodging_only_cents
+      lodging_bundle_cents - camping_cents - van_cents - meals_cents
+    end
+
+    def category_cents(category)
+      lines.select { |line| line.category == category }.sum(&:amount_cents)
     end
 
     def breakdown
@@ -139,7 +160,7 @@ class PricingModel
       nights = entry[:nights].to_i
       next if people < 1 || nights < 1
       Line.new(label: "Camping #{entry[:kind]} — #{people} pers × #{nights} nuit(s)",
-               amount_cents: unit * people * nights)
+               amount_cents: unit * people * nights, category: :camping)
     end
   end
 
@@ -153,7 +174,7 @@ class PricingModel
       nights = entry[:nights].to_i
       next if nights < 1
       Line.new(label: "Van / camping-car — #{nights} nuit(s)",
-               amount_cents: Pricing::Catalog::VAN_PER_NIGHT_CENTS * nights)
+               amount_cents: Pricing::Catalog::VAN_PER_NIGHT_CENTS * nights, category: :van)
     end
   end
 
@@ -229,7 +250,7 @@ class PricingModel
       people = entry[:people].to_i
       next if people < 1
       Line.new(label: "#{humanize(entry[:kind])} — #{people} pers",
-               amount_cents: unit * people)
+               amount_cents: unit * people, category: :meal)
     end
   end
 

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -16,11 +16,34 @@ module Reservations
   class Builder < ServiceBase
     class DraftInvalid < StandardError; end
 
-    attr_reader :draft, :stay, :customer, :booking, :payment
+    attr_reader :draft, :stay, :customer, :booking, :payment, :availability_warning
 
-    def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE)
+    # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
+    # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
+    # `skip_availability` n'affectent QUE le canal admin ; le funnel public
+    # (`admin: false`) garde exactement le comportement historique.
+    #
+    #   - admin: true           → ne crée AUCUN Payment (le solde se règle après,
+    #                             via la page client /sejour/:token) ; c'est aussi
+    #                             au contrôleur de NE PAS envoyer d'email client.
+    #   - status:               → statut du Stay à la création (`pending`/`confirmed`),
+    #                             au choix de l'admin. Défaut : `pending` (jamais
+    #                             d'auto-confirm côté public — Q5/AC-T2-19).
+    #   - source:               → canal d'attribution du Stay. Défaut `reservation`
+    #                             (public) ; l'admin passe `manual`.
+    #   - skip_availability:    → force la disponibilité : la dispo reste VÉRIFIÉE
+    #                             (le veto Grand-Duc de `Lodging#available_between?`
+    #                             fait foi) mais l'indisponibilité n'échoue plus —
+    #                             elle est exposée via `availability_warning`
+    #                             (surbooking / saisie a posteriori autorisés).
+    def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE,
+                   admin: false, status: nil, source: nil, skip_availability: false)
       @draft = draft
       @deposit_rate = deposit_rate
+      @admin = admin
+      @requested_status = status
+      @requested_source = source
+      @skip_availability = skip_availability
       @report_errors = true
     end
 
@@ -55,8 +78,8 @@ module Reservations
         # partira au paiement du solde (Phase 3), une fois le porteur validé.
         @stay = Stay.create!(
           customer: @customer,
-          source: "reservation",
-          status: "pending",
+          source: stay_source,
+          status: stay_status,
           arrival_date: draft.arrival_date,
           departure_date: draft.departure_date,
           total_amount_cents: quote.total_excluding_experiences_cents,
@@ -74,13 +97,10 @@ module Reservations
         # Le paiement est rattaché au Stay dans tous les cas ; le booking n'est
         # plus qu'une référence de commodité pour le canal historique. Son montant
         # reste l'acompte HORS activités (`quote.deposit_cents`).
-        @payment = Payment.create!(
-          booking: @booking,
-          stay: @stay,
-          amount_cents: quote.deposit_cents,
-          status: "pending",
-          payment_method: "card"
-        )
+        #
+        # Canal admin (epic #66) : AUCUN paiement n'est créé à l'enregistrement —
+        # le solde se règle après coup depuis la page client /sejour/:token.
+        @payment = build_payment!(quote) unless @admin
       end
       true
     end
@@ -107,7 +127,16 @@ module Reservations
       raise_invalid("Veuillez préciser votre prénom.") if draft.first_name.blank?
       raise_invalid("Veuillez préciser une adresse email valide.") unless Customer.exploitable_email?(draft.email)
       if draft.lodging.present? && !draft.lodging.available_between?(draft.arrival_date, draft.departure_date)
-        raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+        # Force-dispo admin (epic #66) : on n'échoue pas, on consigne un
+        # avertissement que le contrôleur remonte à l'admin. Hors force, le
+        # comportement historique tient (l'indisponibilité bloque la création).
+        if @skip_availability
+          @availability_warning =
+            "Ces dates ne sont plus disponibles pour #{draft.lodging.name} — " \
+            "séjour enregistré en forçant la disponibilité (surbooking / saisie a posteriori)."
+        else
+          raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+        end
       end
     end
 
@@ -165,7 +194,7 @@ module Reservations
         to_date: draft.departure_date,
         adults: [draft.adults, 1].max,
         children: draft.children.to_i,
-        status: "pending",
+        status: stay_status,
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
@@ -178,6 +207,27 @@ module Reservations
       booking.generate_token
       booking.save!
       booking
+    end
+
+    def build_payment!(quote)
+      Payment.create!(
+        booking: @booking,
+        stay: @stay,
+        amount_cents: quote.deposit_cents,
+        status: "pending",
+        payment_method: "card"
+      )
+    end
+
+    # Statut du Stay (et du Booking d'occupation) à la création. Le public reste
+    # sur `pending` (jamais d'auto-confirm — Q5) ; l'admin choisit explicitement.
+    def stay_status
+      return "pending" unless @admin
+      Stay::STATUSES_ADMIN_CREATABLE.include?(@requested_status) ? @requested_status : "pending"
+    end
+
+    def stay_source
+      @requested_source.presence || "reservation"
     end
 
     # Multi-chiens hors flow auto (Q2) : on consigne pour traitement manuel.

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -15,10 +15,13 @@ module Reservations
   # facture jamais N × 50 € (AC-T2-09b / AC-T2-15).
   class Builder < ServiceBase
     include SpaceComposition
+    include CampingComposition
+    include MealComposition
 
     class DraftInvalid < StandardError; end
 
-    attr_reader :draft, :stay, :customer, :booking, :space_booking, :payment, :availability_warning
+    attr_reader :draft, :stay, :customer, :booking, :space_booking,
+                :camping_booking, :van_booking, :payment, :availability_warning
 
     # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
     # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
@@ -93,6 +96,16 @@ module Reservations
         # « espaces seuls »). Sa part de prix vient du devis (`spaces_cents`) —
         # l'hébergement porte `lodging_bundle_cents`, donc aucun double-compte.
         @space_booking = build_space_booking_for!(@stay, quote)
+        # Camping / van / repas (epic #66, Phase 3) — PERSISTÉS UNIQUEMENT côté
+        # admin. Le funnel public reste devis-only pour ces éléments (leur montant
+        # est noyé dans `lodging_bundle_cents` du Booking, comportement historique
+        # inchangé). Côté admin, chacun devient son propre modèle et le Booking
+        # d'hébergement porte `lodging_only_cents` (extraction sans double-compte).
+        if @admin
+          @camping_booking = build_camping_booking_for!(@stay, quote)
+          @van_booking     = build_van_booking_for!(@stay, quote)
+          create_meal_orders!(@stay, draft)
+        end
         # Sélections d'activités du funnel (epic #55, Phase 4) : chaque créneau
         # choisi devient un ExperienceBooking `pending` rattaché au Stay — de la
         # MÊME nature que ceux du rail email, donc soumis à la validation porteur.
@@ -146,6 +159,23 @@ module Reservations
         end
       end
       check_space_availability!
+      check_outdoor_capacity!
+    end
+
+    # Camping / van : capacité GLOBALE du domaine (epic #66, Phase 3). Vérifiée
+    # UNIQUEMENT côté admin — le funnel public ne persiste pas ces réservables et
+    # garde son comportement historique. Même logique de force que l'hébergement.
+    def check_outdoor_capacity!
+      return unless @admin
+      messages = [camping_capacity_message(draft), van_capacity_message(draft)].compact
+      return if messages.empty?
+
+      if @skip_availability
+        forced = messages.map { |m| "#{m} — séjour enregistré en forçant la disponibilité." }
+        @availability_warning = [@availability_warning, *forced].compact.join(" ")
+      else
+        raise_invalid(messages.join(" "))
+      end
     end
 
     # Dispo espaces CAPACITY-AWARE (`Space#available_on?`, source unique). Hors
@@ -187,6 +217,30 @@ module Reservations
         specs:       specs,
         status:      stay_status,
         price_cents: quote.spaces_cents
+      )
+    end
+
+    # Camping (epic #66, Phase 3) : no-op si aucune personne demandée. Sa part de
+    # prix vient du devis (`camping_cents`). Retourne le CampingBooking ou nil.
+    def build_camping_booking_for!(stay, quote)
+      return nil unless draft_has_camping?(draft)
+
+      persist_camping_booking!(
+        stay:        stay,
+        draft:       draft,
+        status:      stay_status,
+        price_cents: quote.camping_cents
+      )
+    end
+
+    def build_van_booking_for!(stay, quote)
+      return nil unless draft_has_van?(draft)
+
+      persist_van_booking!(
+        stay:        stay,
+        draft:       draft,
+        status:      stay_status,
+        price_cents: quote.van_cents
       )
     end
 
@@ -239,16 +293,25 @@ module Reservations
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
-        # Occupation d'hébergement : son prix porte l'hébergement + camping/repas
-        # HORS espaces et HORS activités (epic #66, Phase 2). Les espaces vivent
-        # sur leur propre SpaceBooking — additionner les deux redonne exactement
-        # `total_excluding_experiences_cents`, sans double-compte.
-        price_cents: quote.lodging_bundle_cents,
-        shown_price_cents: quote.lodging_bundle_cents
+        # Prix de l'occupation d'hébergement (epic #66, Phase 3) :
+        #   - Canal ADMIN → `lodging_only_cents` : hébergement PUR (camping / van /
+        #     repas sont extraits sur leurs propres modèles). Invariant admin :
+        #     Booking + SpaceBooking + CampingBooking + VanBooking + MealOrder(s)
+        #     + ExperienceBooking(s) == total du séjour.
+        #   - Canal PUBLIC → `lodging_bundle_cents` : comportement historique
+        #     INCHANGÉ (camping / van / repas noyés dans le Booking, devis-only).
+        price_cents: lodging_price_cents(quote),
+        shown_price_cents: lodging_price_cents(quote)
       )
       booking.generate_token
       booking.save!
       booking
+    end
+
+    # Part de prix portée par le Booking d'hébergement selon le canal (voir
+    # `build_booking!`). Admin : hébergement pur ; public : bundle historique.
+    def lodging_price_cents(quote)
+      @admin ? quote.lodging_only_cents : quote.lodging_bundle_cents
     end
 
     def build_payment!(quote)

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -14,9 +14,11 @@ module Reservations
   # plusieurs chiens est marqué pour traitement manuel (note interne) et ne
   # facture jamais N × 50 € (AC-T2-09b / AC-T2-15).
   class Builder < ServiceBase
+    include SpaceComposition
+
     class DraftInvalid < StandardError; end
 
-    attr_reader :draft, :stay, :customer, :booking, :payment, :availability_warning
+    attr_reader :draft, :stay, :customer, :booking, :space_booking, :payment, :availability_warning
 
     # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
     # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
@@ -86,6 +88,11 @@ module Reservations
           notes: internal_notes
         )
         @stay.stay_items.create!(bookable: @booking) if @booking
+        # Espaces (epic #66, Phase 2) : les salles / cuisine pro choisies
+        # deviennent un SpaceBooking + StayItem, MÊME sans hébergement (séjour
+        # « espaces seuls »). Sa part de prix vient du devis (`spaces_cents`) —
+        # l'hébergement porte `lodging_bundle_cents`, donc aucun double-compte.
+        @space_booking = build_space_booking_for!(@stay, quote)
         # Sélections d'activités du funnel (epic #55, Phase 4) : chaque créneau
         # choisi devient un ExperienceBooking `pending` rattaché au Stay — de la
         # MÊME nature que ceux du rail email, donc soumis à la validation porteur.
@@ -138,6 +145,25 @@ module Reservations
           raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
         end
       end
+      check_space_availability!
+    end
+
+    # Dispo espaces CAPACITY-AWARE (`Space#available_on?`, source unique). Hors
+    # force, un espace déjà plein bloque ; en force-dispo admin, on consigne un
+    # avertissement (surbooking / saisie a posteriori) sans échouer — comme pour
+    # l'hébergement.
+    def check_space_availability!
+      conflicts = space_availability_conflicts(space_reservation_specs(draft))
+      return if conflicts.empty?
+
+      names = conflicts.map { |c| c[:space].name }.uniq.join(", ")
+      if @skip_availability
+        message = "Espace(s) déjà complet(s) à ces dates : #{names} — " \
+                  "séjour enregistré en forçant la disponibilité."
+        @availability_warning = [@availability_warning, message].compact.join(" ")
+      else
+        raise_invalid("Espace(s) déjà complet(s) à ces dates : #{names}.")
+      end
     end
 
     def bookable_content?
@@ -145,8 +171,23 @@ module Reservations
         draft.campings.any? ||
         draft.vans.any? ||
         draft.hamacs.any? ||
-        Array(draft.halls).any? ||
-        Array(draft.space_slots).any?
+        draft_has_spaces?(draft)
+    end
+
+    # Crée le SpaceBooking (+ StayItem) du séjour depuis les espaces du draft.
+    # No-op si aucun espace résolu. La dispo capacity-aware a déjà été vérifiée
+    # (ou forcée) dans `validate_draft!`. Retourne le SpaceBooking ou nil.
+    def build_space_booking_for!(stay, quote)
+      specs = space_reservation_specs(draft)
+      return nil if specs.empty?
+
+      persist_space_booking!(
+        stay:        stay,
+        draft:       draft,
+        specs:       specs,
+        status:      stay_status,
+        price_cents: quote.spaces_cents
+      )
     end
 
     def upsert_customer!
@@ -198,11 +239,12 @@ module Reservations
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
-        # Occupation d'hébergement : son prix suit le total HORS activités
-        # (fix montant fantôme, epic #55 Phase 1) — cohérent avec le
-        # `total_amount_cents` du Stay et l'assiette de l'acompte.
-        price_cents: quote.total_excluding_experiences_cents,
-        shown_price_cents: quote.total_excluding_experiences_cents
+        # Occupation d'hébergement : son prix porte l'hébergement + camping/repas
+        # HORS espaces et HORS activités (epic #66, Phase 2). Les espaces vivent
+        # sur leur propre SpaceBooking — additionner les deux redonne exactement
+        # `total_excluding_experiences_cents`, sans double-compte.
+        price_cents: quote.lodging_bundle_cents,
+        shown_price_cents: quote.lodging_bundle_cents
       )
       booking.generate_token
       booking.save!

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -1,0 +1,192 @@
+module Stays
+  # Mise à jour de la composition d'un séjour existant depuis le CRUD admin
+  # (epic #66, Phase 1). Symétrique de `Reservations::Builder` (création) mais
+  # côté édition : on RÉCONCILIE l'occupation d'hébergement et les activités du
+  # séjour à partir d'un `Reservations::Draft` reconstruit depuis le formulaire —
+  # toujours SANS Stripe et sans email de confirmation forcé.
+  #
+  # Choix de conception :
+  #   - Le CLIENT est upserté par email (même mécanisme que le Builder) : que
+  #     l'admin sélectionne un client existant ou en crée un à la volée, le
+  #     formulaire remplit les coordonnées du draft, et on retrouve/complète le
+  #     `Customer` par son email normalisé.
+  #   - L'HÉBERGEMENT : on met à jour le `Booking` d'occupation existant, ou on en
+  #     crée un s'il n'y en a pas. On NE TOUCHE PAS au `status`/`email` du Booking
+  #     à l'édition (ces deux changements déclenchent l'email client via
+  #     `Booking#notify_customer_on_update`) — l'admin ne doit jamais spammer le
+  #     client en éditant la compo. Le statut fait foi au niveau du Stay.
+  #   - Les ACTIVITÉS : réconciliation ensembliste, bornée au périmètre de
+  #     l'utilisateur (`ExperienceAvailability.for_user`) — un porteur n'annule et
+  #     ne crée que sur SES créneaux, jamais sur ceux d'un autre.
+  #   - Le TOTAL et les DATES sont recalculés par `Stay#recompute_aggregates!`
+  #     (source unique déjà éprouvée : bookables + activités actives).
+  class AdminUpdater < ServiceBase
+    class Invalid < StandardError; end
+
+    attr_reader :stay, :availability_warning
+
+    def initialize(stay:, draft:, status: nil, skip_availability: false, user: nil)
+      @stay = stay
+      @draft = draft
+      @requested_status = status
+      @skip_availability = skip_availability
+      @user = user
+      @report_errors = true
+    end
+
+    def run
+      run!
+      true
+    rescue Invalid => e
+      set_error_message(e.message)
+      false
+    rescue => e
+      Sentry.capture_exception(e)
+      set_error_message("Une erreur est survenue lors de la mise à jour du séjour.")
+      false
+    end
+
+    def run!
+      validate!
+      ActiveRecord::Base.transaction do
+        @stay.update!(customer: upsert_customer!, status: stay_status)
+        reconcile_lodging!
+        reconcile_experiences!
+        @stay.recompute_aggregates!
+      end
+      true
+    end
+
+    private
+
+    def validate!
+      raise_invalid("Veuillez choisir des dates valides.") if @draft.nights < 1
+      # Phase 1 : un séjour admin porte au moins un hébergement (espaces / camping
+      # arrivent aux phases 2-3). Retirer le DERNIER hébergement est donc hors
+      # périmètre ici — on change ou on garde l'hébergement.
+      raise_invalid("Veuillez sélectionner un hébergement.") if @draft.lodging.blank?
+      unless Customer.exploitable_email?(@draft.email)
+        raise_invalid("Veuillez préciser une adresse email valide pour le client.")
+      end
+      check_availability!
+    end
+
+    def check_availability!
+      return if @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
+
+      if @skip_availability
+        @availability_warning =
+          "Ces dates ne sont plus disponibles pour #{@draft.lodging.name} — " \
+          "séjour enregistré en forçant la disponibilité (surbooking / saisie a posteriori)."
+      else
+        raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
+      end
+    end
+
+    def upsert_customer!
+      email = Customer.normalize_email(@draft.email)
+      customer = Customer.where(email: email).first_or_initialize
+      customer.email = email
+      customer.first_name = @draft.first_name if customer.first_name.blank?
+      customer.last_name  = @draft.last_name  if customer.last_name.blank?
+      customer.phone      = @draft.phone      if customer.phone.blank?
+      customer.save!
+      customer
+    end
+
+    def reconcile_lodging!
+      price   = @draft.quote.total_excluding_experiences_cents
+      booking = existing_lodging_booking
+
+      if booking
+        # NB : ni `status` ni `email` ici — voir l'en-tête de classe (anti-email).
+        booking.update!(
+          lodging_id:        @draft.lodging_id,
+          from_date:         @draft.arrival_date,
+          to_date:           @draft.departure_date,
+          adults:            [@draft.adults, 1].max,
+          children:          @draft.children.to_i,
+          group_name:        @draft.group_name,
+          firstname:         @draft.first_name,
+          lastname:          @draft.last_name,
+          phone:             @draft.phone,
+          price_cents:       price,
+          shown_price_cents: price
+        )
+      else
+        booking = Booking.new(
+          firstname:         @draft.first_name,
+          lastname:          @draft.last_name,
+          email:             Customer.normalize_email(@draft.email),
+          phone:             @draft.phone,
+          group_name:        @draft.group_name,
+          from_date:         @draft.arrival_date,
+          to_date:           @draft.departure_date,
+          adults:            [@draft.adults, 1].max,
+          children:          @draft.children.to_i,
+          status:            stay_status,
+          payment_status:    "pending",
+          platform:          "web",
+          lodging_id:        @draft.lodging_id,
+          price_cents:       price,
+          shown_price_cents: price
+        )
+        booking.generate_token
+        booking.save!
+        @stay.stay_items.create!(bookable: booking)
+      end
+    end
+
+    def existing_lodging_booking
+      @stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    end
+
+    def reconcile_experiences!
+      desired  = desired_experience_map
+      allowed  = allowed_availability_ids
+
+      @stay.experience_bookings.active.each do |eb|
+        # On ne réconcilie (annule) QUE dans le périmètre de l'utilisateur.
+        next unless allowed.include?(eb.experience_availability_id)
+        next if desired.key?(eb.experience_availability_id)
+        eb.update!(status: "cancelled")
+      end
+
+      desired.each do |availability_id, participants|
+        eb = @stay.experience_bookings.active.find_by(experience_availability_id: availability_id)
+        if eb
+          eb.update!(participants: participants)
+        else
+          @stay.experience_bookings.create!(
+            experience_availability_id: availability_id,
+            participants: participants,
+            status: "pending"
+          )
+        end
+      end
+    end
+
+    def desired_experience_map
+      allowed = allowed_availability_ids
+      Array(@draft.experiences).each_with_object({}) do |entry, memo|
+        aid          = entry[:availability_id].to_i
+        participants = entry[:participants].to_i
+        next if aid < 1 || participants < 1
+        next unless allowed.include?(aid)
+        memo[aid] = participants
+      end
+    end
+
+    def allowed_availability_ids
+      @allowed_availability_ids ||= ExperienceAvailability.for_user(@user).pluck(:id).to_set
+    end
+
+    def stay_status
+      Stay::STATUSES_ADMIN_CREATABLE.include?(@requested_status) ? @requested_status : @stay.status
+    end
+
+    def raise_invalid(message)
+      raise Invalid, message
+    end
+  end
+end

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -22,6 +22,8 @@ module Stays
   #     (source unique déjà éprouvée : bookables + activités actives).
   class AdminUpdater < ServiceBase
     include SpaceComposition
+    include CampingComposition
+    include MealComposition
 
     class Invalid < StandardError; end
 
@@ -54,6 +56,9 @@ module Stays
         @stay.update!(customer: upsert_customer!, status: stay_status)
         reconcile_lodging!
         reconcile_spaces!
+        reconcile_camping!
+        reconcile_van!
+        reconcile_meals!(@stay, @draft)
         reconcile_experiences!
         @stay.recompute_aggregates!
       end
@@ -64,17 +69,38 @@ module Stays
 
     def validate!
       raise_invalid("Veuillez choisir des dates valides.") if @draft.nights < 1
-      # Phase 2 (epic #66) : un séjour admin porte AU MOINS un hébergement OU un
-      # espace. On assouplit la contrainte Phase 1 (hébergement obligatoire) pour
-      # autoriser un séjour « espaces seuls ». Camping/repas arrivent en Phase 3.
-      unless @draft.lodging.present? || draft_has_spaces?(@draft)
-        raise_invalid("Veuillez sélectionner un hébergement ou un espace.")
+      # Phase 3 (epic #66) : un séjour admin porte AU MOINS un hébergement OU un
+      # espace OU du camping/van. La contrainte de composition s'élargit — un
+      # séjour camping-seul ou van-seul est désormais légitime. (Les repas seuls
+      # ne suffisent pas : ils n'occupent rien et accompagnent une nuitée.)
+      unless @draft.lodging.present? || draft_has_spaces?(@draft) ||
+             draft_has_camping?(@draft) || draft_has_van?(@draft)
+        raise_invalid("Veuillez sélectionner un hébergement, un espace ou un emplacement camping/van.")
       end
       unless Customer.exploitable_email?(@draft.email)
         raise_invalid("Veuillez préciser une adresse email valide pour le client.")
       end
       check_availability!
       check_space_availability!
+      check_outdoor_capacity!
+    end
+
+    # Camping / van : capacité globale (epic #66, Phase 3), en ignorant les
+    # réservables PROPRES au séjour (sinon l'édition d'un séjour camping-seul se
+    # bloquerait elle-même). Même logique de force que l'hébergement/espaces.
+    def check_outdoor_capacity!
+      messages = [
+        camping_capacity_message(@draft, excluding_id: existing_camping_booking(@stay)&.id),
+        van_capacity_message(@draft,     excluding_id: existing_van_booking(@stay)&.id)
+      ].compact
+      return if messages.empty?
+
+      if @skip_availability
+        forced = messages.map { |m| "#{m} — séjour enregistré en forçant la disponibilité." }
+        @availability_warning = [@availability_warning, *forced].compact.join(" ")
+      else
+        raise_invalid(messages.join(" "))
+      end
     end
 
     def check_availability!
@@ -142,9 +168,10 @@ module Stays
         return
       end
 
-      # Prix HORS espaces (les espaces vivent sur le SpaceBooking) et HORS
-      # activités — additionner Booking + SpaceBooking redonne le total prévu.
-      price = @draft.quote.lodging_bundle_cents
+      # Prix de l'hébergement PUR (epic #66, Phase 3) : hors espaces, hors
+      # camping/van/repas (chacun sur son propre modèle) et hors activités.
+      # Additionner tous les réservables + repas redonne exactement le total prévu.
+      price = @draft.quote.lodging_only_cents
 
       if booking
         # NB : ni `status` ni `email` ici — voir l'en-tête de classe (anti-email).
@@ -231,6 +258,65 @@ module Stays
           status:      @stay.status,
           price_cents: price
         )
+      end
+    end
+
+    # Réconcilie le CAMPING du séjour (epic #66, Phase 3) : crée / met à jour /
+    # détache le CampingBooking selon le draft. Comme pour l'hébergement, on ne
+    # touche ni au token ni à l'email à l'édition.
+    def reconcile_camping!
+      camping = existing_camping_booking(@stay)
+
+      unless draft_has_camping?(@draft)
+        if camping
+          @stay.stay_items.where(bookable_type: "CampingBooking").each { |i| i.soft_delete!(validate: false) }
+          camping.soft_delete!(validate: false)
+        end
+        return
+      end
+
+      price = @draft.quote.camping_cents
+      if camping
+        camping.update!(
+          firstname:   @draft.first_name,
+          lastname:    @draft.last_name,
+          phone:       @draft.phone,
+          group_name:  @draft.group_name,
+          from_date:   @draft.arrival_date,
+          to_date:     @draft.departure_date,
+          people:      [draft_camping_people(@draft), 1].max,
+          price_cents: price
+        )
+      else
+        persist_camping_booking!(stay: @stay, draft: @draft, status: @stay.status, price_cents: price)
+      end
+    end
+
+    def reconcile_van!
+      van = existing_van_booking(@stay)
+
+      unless draft_has_van?(@draft)
+        if van
+          @stay.stay_items.where(bookable_type: "VanBooking").each { |i| i.soft_delete!(validate: false) }
+          van.soft_delete!(validate: false)
+        end
+        return
+      end
+
+      price = @draft.quote.van_cents
+      if van
+        van.update!(
+          firstname:   @draft.first_name,
+          lastname:    @draft.last_name,
+          phone:       @draft.phone,
+          group_name:  @draft.group_name,
+          from_date:   @draft.arrival_date,
+          to_date:     @draft.departure_date,
+          vehicles:    [draft_van_vehicles(@draft), 1].max,
+          price_cents: price
+        )
+      else
+        persist_van_booking!(stay: @stay, draft: @draft, status: @stay.status, price_cents: price)
       end
     end
 

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -21,6 +21,8 @@ module Stays
   #   - Le TOTAL et les DATES sont recalculés par `Stay#recompute_aggregates!`
   #     (source unique déjà éprouvée : bookables + activités actives).
   class AdminUpdater < ServiceBase
+    include SpaceComposition
+
     class Invalid < StandardError; end
 
     attr_reader :stay, :availability_warning
@@ -51,6 +53,7 @@ module Stays
       ActiveRecord::Base.transaction do
         @stay.update!(customer: upsert_customer!, status: stay_status)
         reconcile_lodging!
+        reconcile_spaces!
         reconcile_experiences!
         @stay.recompute_aggregates!
       end
@@ -61,17 +64,21 @@ module Stays
 
     def validate!
       raise_invalid("Veuillez choisir des dates valides.") if @draft.nights < 1
-      # Phase 1 : un séjour admin porte au moins un hébergement (espaces / camping
-      # arrivent aux phases 2-3). Retirer le DERNIER hébergement est donc hors
-      # périmètre ici — on change ou on garde l'hébergement.
-      raise_invalid("Veuillez sélectionner un hébergement.") if @draft.lodging.blank?
+      # Phase 2 (epic #66) : un séjour admin porte AU MOINS un hébergement OU un
+      # espace. On assouplit la contrainte Phase 1 (hébergement obligatoire) pour
+      # autoriser un séjour « espaces seuls ». Camping/repas arrivent en Phase 3.
+      unless @draft.lodging.present? || draft_has_spaces?(@draft)
+        raise_invalid("Veuillez sélectionner un hébergement ou un espace.")
+      end
       unless Customer.exploitable_email?(@draft.email)
         raise_invalid("Veuillez préciser une adresse email valide pour le client.")
       end
       check_availability!
+      check_space_availability!
     end
 
     def check_availability!
+      return if @draft.lodging.blank?
       return if @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
 
       if @skip_availability
@@ -81,6 +88,33 @@ module Stays
       else
         raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
       end
+    end
+
+    # Dispo espaces capacity-aware (`Space#available_on?`), même logique de force
+    # que l'hébergement. On ignore les créneaux DÉJÀ portés par le SpaceBooking du
+    # séjour (sinon l'édition d'un séjour espaces-seuls se bloquerait elle-même).
+    def check_space_availability!
+      specs     = space_reservation_specs(@draft)
+      own       = own_space_reservation_keys
+      conflicts = space_availability_conflicts(specs)
+                    .reject { |c| own.include?([c[:space].id, c[:date]]) }
+      return if conflicts.empty?
+
+      names = conflicts.map { |c| c[:space].name }.uniq.join(", ")
+      if @skip_availability
+        message = "Espace(s) déjà complet(s) à ces dates : #{names} — " \
+                  "séjour enregistré en forçant la disponibilité."
+        @availability_warning = [@availability_warning, message].compact.join(" ")
+      else
+        raise_invalid("Espace(s) déjà complet(s) à ces dates : #{names}.")
+      end
+    end
+
+    # (space_id, date) déjà réservés par le SpaceBooking courant du séjour.
+    def own_space_reservation_keys
+      sb = existing_space_booking(@stay)
+      return [].to_set if sb.nil?
+      sb.space_reservations.map { |r| [r.space_id, r.date] }.to_set
     end
 
     def upsert_customer!
@@ -95,8 +129,22 @@ module Stays
     end
 
     def reconcile_lodging!
-      price   = @draft.quote.total_excluding_experiences_cents
       booking = existing_lodging_booking
+
+      # Séjour « espaces seuls » (epic #66, Phase 2) : plus d'hébergement au
+      # draft → on détache et libère l'occupation existante (soft-delete du
+      # StayItem ET du Booking, pour rendre les dates au calendrier).
+      if @draft.lodging.blank?
+        if booking
+          @stay.stay_items.where(bookable_type: "Booking").each { |i| i.soft_delete!(validate: false) }
+          booking.soft_delete!(validate: false)
+        end
+        return
+      end
+
+      # Prix HORS espaces (les espaces vivent sur le SpaceBooking) et HORS
+      # activités — additionner Booking + SpaceBooking redonne le total prévu.
+      price = @draft.quote.lodging_bundle_cents
 
       if booking
         # NB : ni `status` ni `email` ici — voir l'en-tête de classe (anti-email).
@@ -139,6 +187,51 @@ module Stays
 
     def existing_lodging_booking
       @stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    end
+
+    # Réconcilie l'occupation d'ESPACES du séjour (epic #66, Phase 2) : rebuild
+    # complet des `SpaceReservation` depuis le draft. Comme pour l'hébergement,
+    # on NE TOUCHE PAS au `status`/`email` du SpaceBooking à l'édition (l'update
+    # de statut déclenche l'email client — anti-spam admin).
+    def reconcile_spaces!
+      specs         = space_reservation_specs(@draft)
+      space_booking = existing_space_booking(@stay)
+
+      # Plus d'espace au draft → on détache/soft-delete un éventuel SpaceBooking.
+      if specs.empty?
+        if space_booking
+          @stay.stay_items.where(bookable_type: "SpaceBooking").each { |i| i.soft_delete!(validate: false) }
+          space_booking.soft_delete!(validate: false)
+        end
+        return
+      end
+
+      price = @draft.quote.spaces_cents
+      dates = specs.map { |s| s[:date] }
+
+      if space_booking
+        space_booking.space_reservations.destroy_all
+        space_booking.update!(
+          firstname:   @draft.first_name,
+          lastname:    @draft.last_name,
+          phone:       @draft.phone,
+          group_name:  @draft.group_name,
+          from_date:   @draft.arrival_date || dates.min,
+          to_date:     @draft.departure_date || dates.max,
+          price_cents: price
+        )
+        specs.each do |spec|
+          space_booking.space_reservations.create!(space: spec[:space], date: spec[:date], duration: spec[:duration])
+        end
+      else
+        persist_space_booking!(
+          stay:        @stay,
+          draft:       @draft,
+          specs:       specs,
+          status:      @stay.status,
+          price_cents: price
+        )
+      end
     end
 
     def reconcile_experiences!

--- a/app/views/pages/calendar/_bookings.html.slim
+++ b/app/views/pages/calendar/_bookings.html.slim
@@ -21,17 +21,21 @@
                       class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
       .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-event-#{event.id}" data-popover-trigger-value="click")
 
-  / Space reservations
+  / Space reservations — regroupées et colorées PAR SÉJOUR (epic #66, Phase 4) :
+  / couleur stable par `stay_id` (style inline), blocs triés par séjour, un bloc
+  / par ESPACE occupé conservé, `data-stay-id` posé pour la modale Phase 5.
   - if @grouped_space_reservations[date]
-    - @grouped_space_reservations[date].sort_by {|sr| sr.start_time }.group_by { |sr| sr.space_booking.id }.each do |grouped_space_reservations|
+    - @grouped_space_reservations[date].sort_by {|sr| sr.start_time }.group_by { |sr| sr.space_booking.id }.sort_by { |_space_booking_id, space_reservations| [space_reservations.first.space_booking.stay&.id.to_i, space_reservations.first.start_time] }.each do |grouped_space_reservations|
       - space_reservation = grouped_space_reservations.last.first
       - space_booking = SpaceBookingDecorator.new(space_reservation.space_booking)
+      - stay = space_booking.stay
+      - block_style = stay ? stay_block_style(stay.id) : nil
       .popover.absolute.z-10.invisible.inline-block.w-64.text-sm.font-light.text-gray-500.transition-opacity.duration-300.bg-white.border.border-gray-200.rounded-lg.shadow-sm.opacity-0[id="popover-space-reservation-#{space_reservation.id}" data-popover role="tooltip"]
         = render "space_bookings/popover",
                  space_booking: space_booking
         div[data-popper-arrow]
 
-      div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{space_booking.calendar_class}")
+      div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{space_booking.calendar_block_class}" style=block_style data-space-booking-day-entry=space_booking.id data-stay-id=stay&.id)
         .block.min-w-0.w-full
           div.min-w-0
             strong.block.min-w-0.break-words

--- a/app/views/pages/calendar/_day_bookings.html.slim
+++ b/app/views/pages/calendar/_day_bookings.html.slim
@@ -1,16 +1,23 @@
 / Séjours du jour, rendus dans la cellule entre les avatars veilleurs et les
 / notes (demande Michael 2026-07-13 — remplace les barres hebdo de l'issue #10).
+/ Depuis l'epic #66 Phase 4, les occupations sont REGROUPÉES ET COLORÉES PAR
+/ SÉJOUR (`stay_id`) : couleur stable par séjour (style inline, cf.
+/ CalendarHelper#stay_block_style), blocs triés par séjour, et `data-stay-id`
+/ posé pour câbler la modale séjour en Phase 5. On garde UN BLOC PAR RESSOURCE
+/ occupée (chambre/lodging) — source de vérité du veto Grand-Duc, inchangée.
 - if @grouped_reservations && @grouped_reservations[date]
-  - @grouped_reservations[date].sort_by {|r| r.start_time }.group_by { |r| r.booking.id }.each do |grouped_reservations|
+  - @grouped_reservations[date].sort_by {|r| r.start_time }.group_by { |r| r.booking.id }.sort_by { |_booking_id, reservations| [reservations.first.booking.stay&.id.to_i, reservations.first.start_time] }.each do |grouped_reservations|
     - reservation = grouped_reservations.last.first
     - booking = BookingDecorator.new(reservation.booking)
+    - stay = booking.stay
+    - block_style = stay ? stay_block_style(stay.id) : nil
 
     .popover.absolute.z-10.invisible.inline-block.w-64.text-sm.font-light.text-gray-500.transition-opacity.duration-300.bg-white.border.border-gray-200.rounded-lg.shadow-sm.opacity-0[id="popover-reservation-#{reservation.id}" data-popover role="tooltip"]
       = render "bookings/popover",
                booking: booking
       div[data-popper-arrow]
 
-    div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_class}" data-booking-day-entry=booking.id)
+    div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_block_class}" style=block_style data-booking-day-entry=booking.id data-stay-id=stay&.id)
       .block.min-w-0.w-full
         div.min-w-0
           strong.block.min-w-0.break-words
@@ -27,3 +34,30 @@
             - grouped_reservations.last.each do |reservation|
               = room_badge(reservation.room)
       .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-reservation-#{reservation.id}" data-popover-trigger-value="click")
+
+/ Camping (epic #66, Phase 4) — bloc agrégé « Camping » par nuit occupée, coloré
+/ par séjour. Capacité GLOBALE du terrain : pas de ressource nommée (décision
+/ figée) donc pas de badge chambre/espace, ni de veto par ressource. Pas de route
+/ admin dédiée à ce jour → bloc informatif, `data-stay-id` prêt pour la Phase 5.
+- if @grouped_camping_bookings && @grouped_camping_bookings[date]
+  - @grouped_camping_bookings[date].sort_by { |cb| [cb.stay&.id.to_i, cb.from_date.to_s] }.each do |camping|
+    - stay = camping.stay
+    - block_style = stay ? stay_block_style(stay.id) : "border-left-color: #0d9488; background-color: #f0fdfa;"
+    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"opacity-50" unless camping.confirmed?}" style=block_style data-camping-booking-entry=camping.id data-stay-id=stay&.id)
+      .block.min-w-0.w-full
+        strong.block.min-w-0.break-words.text-gray-700
+          = camping.group_name.presence || camping.name.presence || "Camping"
+        .text-xs.text-gray-500
+          | ⛺ Camping · #{camping.people} pers.
+
+/ Van / camping-car (epic #66, Phase 4) — même logique que le camping.
+- if @grouped_van_bookings && @grouped_van_bookings[date]
+  - @grouped_van_bookings[date].sort_by { |vb| [vb.stay&.id.to_i, vb.from_date.to_s] }.each do |van|
+    - stay = van.stay
+    - block_style = stay ? stay_block_style(stay.id) : "border-left-color: #0d9488; background-color: #f0fdfa;"
+    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"opacity-50" unless van.confirmed?}" style=block_style data-van-booking-entry=van.id data-stay-id=stay&.id)
+      .block.min-w-0.w-full
+        strong.block.min-w-0.break-words.text-gray-700
+          = van.group_name.presence || van.name.presence || "Van"
+        .text-xs.text-gray-500
+          | 🚐 Van · #{van.vehicles} véh.

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -1,0 +1,102 @@
+/ Formulaire CRUD Séjour admin (epic #66, Phase 1). Locals : url, method, submit_label.
+/ Champs sous le namespace `stay[...]`. Devis B2C forfaitaire (PricingModel).
+- selected_customer_id = @stay.persisted? ? @stay.customer_id : nil
+- current_status = (@stay.status.presence || "pending")
+- selected_experiences = {}
+- Array(@draft&.experiences).each { |e| selected_experiences[e[:availability_id].to_i] = e[:participants] }
+
+= form_with url: url, method: method, data: { controller: "stay-form" } do
+  .space-y-8
+    / --- Client -------------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Client
+      .flex.gap-4.text-sm
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[customer_mode]" value="existing" checked=true data-action="change->stay-form#toggleCustomer"
+          | Client existant
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[customer_mode]" value="new" data-action="change->stay-form#toggleCustomer"
+          | Nouveau client
+
+      .space-y-1(data-stay-form-target="existingPanel")
+        label.block.text-sm.font-medium.text-gray-700 Sélectionner un client
+        = select_tag "stay[customer_id]", options_for_select(@customers.map { |c| [c.name.presence || c.email, c.id] }, selected_customer_id), include_blank: "— Choisir un client —", class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+
+      .space-y-2.hidden(data-stay-form-target="newPanel")
+        .grid.grid-cols-2.gap-2
+          = text_field_tag "stay[new_customer][first_name]", @draft&.first_name, placeholder: "Prénom", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+          = text_field_tag "stay[new_customer][last_name]", @draft&.last_name, placeholder: "Nom", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+        = email_field_tag "stay[new_customer][email]", @draft&.email, placeholder: "Email", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        = telephone_field_tag "stay[new_customer][phone]", @draft&.phone, placeholder: "Téléphone", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Séjour (dates + groupe) --------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Séjour
+      .grid.grid-cols-2.gap-4
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Arrivée
+          = date_field_tag "stay[arrival_date]", @draft&.arrival_date&.iso8601, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Départ
+          = date_field_tag "stay[departure_date]", @draft&.departure_date&.iso8601, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      .grid.grid-cols-3.gap-4
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Adultes
+          = number_field_tag "stay[adults]", (@draft&.adults.to_i.positive? ? @draft.adults : 1), min: 1, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Enfants
+          = number_field_tag "stay[children]", @draft&.children.to_i, min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Chiens
+          = number_field_tag "stay[dogs_count]", @draft&.dogs_count.to_i, min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Nom du groupe (optionnel)
+        = text_field_tag "stay[group_name]", @draft&.group_name, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Hébergement --------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Hébergement
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Hébergement
+        = select_tag "stay[lodging_id]", options_for_select(@lodgings.map { |l| [l.form_label, l.id] }, @draft&.lodging_id), include_blank: "— Choisir un hébergement —", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Activités ----------------------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Activités
+      - if @assignable_availabilities.blank?
+        p.text-sm.text-gray-500 Aucun créneau d'activité proposable.
+      - else
+        p.text-sm.text-gray-500 Indiquez le nombre de participants pour chaque créneau souhaité (0 = non réservé).
+        ul.divide-y.divide-gray-100
+          - @assignable_availabilities.each_with_index do |availability, index|
+            li.py-2.flex.items-center.justify-between.gap-4
+              span.text-sm.text-gray-900 = availability.label
+              = hidden_field_tag "stay[experiences][#{index}][availability_id]", availability.id
+              = number_field_tag "stay[experiences][#{index}][participants]", selected_experiences[availability.id].to_i, min: 0, class: "w-20 rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Statut + force dispo -----------------------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Statut & disponibilité
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Statut du séjour
+        = select_tag "stay[status]", options_for_select([["En attente", "pending"], ["Confirmé", "confirmed"]], current_status), class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      label.flex.items-center.gap-2.text-sm.text-gray-700
+        = check_box_tag "stay[force_availability]", "1", false
+        | Forcer la disponibilité (surbooking / saisie a posteriori)
+
+    / --- Devis --------------------------------------------------------------
+    - if @quote
+      section.bg-gray-50.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-2
+        h2.text-base.font-semibold.text-gray-900 Devis (B2C)
+        ul.text-sm.text-gray-700.space-y-1
+          - @quote.breakdown.each do |line|
+            li.flex.justify-between
+              span = line[:label]
+              span = humanized_money_with_symbol(Money.new(line[:amount_cents]))
+        .flex.justify-between.border-t.border-gray-200.pt-2.font-semibold.text-gray-900
+          span Total
+          span = humanized_money_with_symbol(Money.new(@quote.total_cents))
+
+    .flex.justify-end.gap-3
+      = link_to "Annuler", recent_stays_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      = submit_tag submit_label, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -60,6 +60,21 @@
         label.block.text-sm.font-medium.text-gray-700 Hébergement
         = select_tag "stay[lodging_id]", options_for_select(@lodgings.map { |l| [l.form_label, l.id] }, @draft&.lodging_id), include_blank: "— Choisir un hébergement —", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
+    / --- Espaces (salles / cuisine pro) -------------------------------------
+    - space_kind_options = [["Grande salle", "grande_salle"], ["Petite salle", "petite_salle"], ["Cuisine pro", "cuisine_pro"]]
+    - period_options = [["Journée", "journee"], ["Soirée", "soiree"], ["Journée + soirée", "journee_et_soiree"]]
+    - existing_halls = Array(@draft&.halls).map { |h| h.respond_to?(:symbolize_keys) ? h.symbolize_keys : h }
+    - space_rows = existing_halls + Array.new([3 - existing_halls.size, 1].max) { {} }
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Espaces
+      p.text-sm.text-gray-500 Ajoutez une salle ou la cuisine pro (date + période). Un séjour peut être composé d'espaces seuls, sans hébergement.
+      ul.divide-y.divide-gray-100
+        - space_rows.each_with_index do |row, index|
+          li.py-2.grid.grid-cols-3.gap-2
+            = select_tag "stay[halls][#{index}][kind]", options_for_select(space_kind_options, row[:kind]), include_blank: "— Espace —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = date_field_tag "stay[halls][#{index}][date]", row[:date], class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = select_tag "stay[halls][#{index}][period]", options_for_select(period_options, row[:period]), include_blank: "— Période —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+
     / --- Activités ----------------------------------------------------------
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
       h2.text-base.font-semibold.text-gray-900 Activités

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -75,6 +75,38 @@
             = date_field_tag "stay[halls][#{index}][date]", row[:date], class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
             = select_tag "stay[halls][#{index}][period]", options_for_select(period_options, row[:period]), include_blank: "— Période —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
 
+    / --- Camping (tente) ----------------------------------------------------
+    - camping_people = Array(@draft&.campings).sum { |c| (c.respond_to?(:symbolize_keys) ? c.symbolize_keys : c)[:people].to_i }
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Camping (tente)
+      p.text-sm.text-gray-500 Nombre de personnes en tente sur la durée du séjour. Capacité globale du terrain (forçable). Un séjour peut être composé de camping seul.
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Personnes
+        = number_field_tag "stay[camping][people]", (camping_people.positive? ? camping_people : nil), min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Van / camping-car --------------------------------------------------
+    - van_vehicles = Array(@draft&.vans).size
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Van / camping-car
+      p.text-sm.text-gray-500 Nombre de véhicules sur la durée du séjour. Capacité globale (forçable).
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Véhicules
+        = number_field_tag "stay[van][vehicles]", (van_vehicles.positive? ? van_vehicles : nil), min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+    / --- Repas --------------------------------------------------------------
+    - meal_kind_options = [["Repas végé (midi)", "repas_vege_midi"], ["Buffet pain-fromages", "buffet"], ["Formule complète", "formule_complete"]]
+    - existing_meals = Array(@draft&.meals).map { |m| m.respond_to?(:symbolize_keys) ? m.symbolize_keys : m }
+    - meal_rows = existing_meals + Array.new([3 - existing_meals.size, 1].max) { {} }
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Repas
+      p.text-sm.text-gray-500 Ajoutez un repas (type + date + nombre de convives). Les repas n'occupent pas le calendrier.
+      ul.divide-y.divide-gray-100
+        - meal_rows.each_with_index do |row, index|
+          li.py-2.grid.grid-cols-3.gap-2
+            = select_tag "stay[meals][#{index}][kind]", options_for_select(meal_kind_options, row[:kind]), include_blank: "— Repas —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = date_field_tag "stay[meals][#{index}][date]", row[:date], class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = number_field_tag "stay[meals][#{index}][people]", row[:people], min: 0, placeholder: "Convives", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+
     / --- Activités ----------------------------------------------------------
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
       h2.text-base.font-semibold.text-gray-900 Activités

--- a/app/views/stays/edit.html.slim
+++ b/app/views/stays/edit.html.slim
@@ -1,0 +1,7 @@
+.px-4.sm:px-6.lg:px-8.py-6
+  .mb-6.flex.items-start.justify-between.gap-4
+    div
+      h1.text-xl.font-semibold.text-gray-900 = "Modifier le séjour ##{@stay.id}"
+      p.mt-1.text-sm.text-gray-600 Modifiez la composition du séjour (hébergement + activités). Aucun paiement n'est déclenché.
+    = button_to "Supprimer le séjour", stay_path(@stay), method: :delete, data: { turbo_confirm: "Supprimer ce séjour ? Cette action est réversible (soft-delete)." }, class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+  = render "form", url: stay_path(@stay), method: :patch, submit_label: "Enregistrer les modifications"

--- a/app/views/stays/new.html.slim
+++ b/app/views/stays/new.html.slim
@@ -1,0 +1,5 @@
+.px-4.sm:px-6.lg:px-8.py-6
+  .mb-6
+    h1.text-xl.font-semibold.text-gray-900 Nouveau séjour
+    p.mt-1.text-sm.text-gray-600 Créez un séjour composable (hébergement + activités). Aucun paiement n'est déclenché à la création.
+  = render "form", url: stays_path, method: :post, submit_label: "Créer le séjour"

--- a/app/views/stays/recent.html.slim
+++ b/app/views/stays/recent.html.slim
@@ -3,6 +3,8 @@
     .sm:flex-auto
       h1.text-xl.font-semibold.text-gray-900 Séjours récents
       p.mt-2.text-sm.text-gray-700 Observez la transition Tally → /reservation par canal d'attribution.
+    .mt-4.sm:mt-0.sm:ml-4
+      = link_to "Nouveau séjour", new_stay_path, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
 
   / Filtre par source (AC-T2-23).
   = form_with url: recent_stays_path, method: :get, class: "mb-4 flex items-center gap-2" do
@@ -18,6 +20,7 @@
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Canal
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Statut
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Créé le
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Actions
       tbody.divide-y.divide-gray-200.bg-white
         - @stays.each do |stay|
           tr.hover:bg-gray-50
@@ -31,6 +34,8 @@
               span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.py-0.5.text-xs.font-medium.text-gray-700 = stay.source
             td.px-4.py-2.text-sm = stay.status_badge
             td.px-4.py-2.text-sm.text-gray-500 = l(stay.created_at.to_date, format: :long)
+            td.px-4.py-2.text-sm.text-right
+              = link_to "Éditer", edit_stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 hover:underline"
         - if @stays.empty?
           tr
-            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="5" Aucun séjour pour ce canal.
+            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="6" Aucun séjour pour ce canal.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,7 +113,12 @@ Rails.application.routes.draw do
   # Le CRUD admin d'une activité SUR un séjour (epic #55, Phase 6) est imbriqué
   # sous cette ressource : la création porte TOUJOURS le séjour dans l'URL, si
   # bien qu'une activité ne peut jamais naître sans son séjour d'attache.
-  resources :stays, only: [:show] do
+  # CRUD Séjour admin (epic #66, Phase 1) — le séjour devient le point d'entrée
+  # de création composable côté admin (hébergement + activités). URLs anglaises.
+  # `show` reste rendu sans layout (fragment de modale) ; new/edit sont des pages
+  # pleines. La route `stays/recents` ci-dessus est déclarée AVANT pour ne pas
+  # être captée par `/stays/:id`.
+  resources :stays, only: [:show, :new, :create, :edit, :update, :destroy] do
     resources :experience_bookings, only: [:create]
   end
   resources :experience_bookings, only: [:index, :update, :destroy] do

--- a/db/migrate/20260718120000_create_camping_van_meal_bookables.rb
+++ b/db/migrate/20260718120000_create_camping_van_meal_bookables.rb
@@ -1,0 +1,61 @@
+class CreateCampingVanMealBookables < ActiveRecord::Migration[7.0]
+  def change
+    # Camping (tente) — occupe le calendrier via StayItem polymorphe. Capacité
+    # GLOBALE du terrain (pas d'emplacements nommés) : un CampingBooking occupe
+    # `people` personnes sur [from_date, to_date). Tarif €/pers/nuit (Catalog).
+    create_table :camping_bookings do |t|
+      t.string  :firstname
+      t.string  :lastname
+      t.string  :email
+      t.string  :phone
+      t.string  :group_name
+      t.date    :from_date
+      t.date    :to_date
+      t.integer :people, default: 1, null: false
+      t.string  :kind, default: "tente", null: false
+      t.string  :status
+      t.integer :price_cents
+      t.string  :token
+      t.text    :notes
+      t.datetime :deleted_at
+      t.timestamps
+    end
+    add_index :camping_bookings, :deleted_at
+    add_index :camping_bookings, [:from_date, :to_date]
+
+    # Van / camping-car — occupe le calendrier via StayItem. Capacité GLOBALE
+    # (nombre de véhicules) sur [from_date, to_date). Tarif forfait/nuit/véhicule.
+    create_table :van_bookings do |t|
+      t.string  :firstname
+      t.string  :lastname
+      t.string  :email
+      t.string  :phone
+      t.string  :group_name
+      t.date    :from_date
+      t.date    :to_date
+      t.integer :vehicles, default: 1, null: false
+      t.string  :status
+      t.integer :price_cents
+      t.string  :token
+      t.text    :notes
+      t.datetime :deleted_at
+      t.timestamps
+    end
+    add_index :van_bookings, :deleted_at
+    add_index :van_bookings, [:from_date, :to_date]
+
+    # Repas — commande datée rattachée DIRECTEMENT au séjour (pas d'occupation
+    # calendrier, pas de StayItem). `date` nullable pour tolérer les repas du
+    # funnel public (forme `{kind, people}` sans date). Tarif €/pers (Catalog).
+    create_table :meal_orders do |t|
+      t.references :stay, null: false, foreign_key: true
+      t.string  :kind
+      t.date    :date
+      t.integer :people, default: 1, null: false
+      t.integer :price_cents
+      t.datetime :deleted_at
+      t.timestamps
+    end
+    add_index :meal_orders, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_16_130000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -151,6 +151,27 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_16_130000) do
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_bundles_on_project_id"
     t.index ["team_id"], name: "index_bundles_on_team_id"
+  end
+
+  create_table "camping_bookings", force: :cascade do |t|
+    t.string "firstname"
+    t.string "lastname"
+    t.string "email"
+    t.string "phone"
+    t.string "group_name"
+    t.date "from_date"
+    t.date "to_date"
+    t.integer "people", default: 1, null: false
+    t.string "kind", default: "tente", null: false
+    t.string "status"
+    t.integer "price_cents"
+    t.string "token"
+    t.text "notes"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_camping_bookings_on_deleted_at"
+    t.index ["from_date", "to_date"], name: "index_camping_bookings_on_from_date_and_to_date"
   end
 
   create_table "customers", force: :cascade do |t|
@@ -402,6 +423,19 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_16_130000) do
     t.datetime "deleted_at", precision: nil
     t.boolean "show_on_reports", default: true
     t.boolean "available_for_bookings"
+  end
+
+  create_table "meal_orders", force: :cascade do |t|
+    t.bigint "stay_id", null: false
+    t.string "kind"
+    t.date "date"
+    t.integer "people", default: 1, null: false
+    t.integer "price_cents"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_meal_orders_on_deleted_at"
+    t.index ["stay_id"], name: "index_meal_orders_on_stay_id"
   end
 
   create_table "notes", force: :cascade do |t|
@@ -669,6 +703,26 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_16_130000) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "van_bookings", force: :cascade do |t|
+    t.string "firstname"
+    t.string "lastname"
+    t.string "email"
+    t.string "phone"
+    t.string "group_name"
+    t.date "from_date"
+    t.date "to_date"
+    t.integer "vehicles", default: 1, null: false
+    t.string "status"
+    t.integer "price_cents"
+    t.string "token"
+    t.text "notes"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_van_bookings_on_deleted_at"
+    t.index ["from_date", "to_date"], name: "index_van_bookings_on_from_date_and_to_date"
+  end
+
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.bigint "item_id", null: false
@@ -718,6 +772,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_16_130000) do
   add_foreign_key "lodging_compositions", "lodgings", column: "composite_lodging_id"
   add_foreign_key "lodging_rooms", "lodgings"
   add_foreign_key "lodging_rooms", "rooms"
+  add_foreign_key "meal_orders", "stays"
   add_foreign_key "payments", "bookings"
   add_foreign_key "payments", "stays"
   add_foreign_key "projects", "humans"

--- a/spec/models/camping_booking_spec.rb
+++ b/spec/models/camping_booking_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+# Epic #66, Phase 3 — CampingBooking : capacité GLOBALE du terrain, vérifiée nuit
+# par nuit contre TOTAL_CAPACITY (seules les résas `confirmed` comptent).
+RSpec.describe CampingBooking do
+  let(:d0) { Date.today + 40 }
+  let(:d1) { d0 + 1 }
+  let(:d2) { d0 + 2 }
+
+  def confirmed!(people:, from:, to:)
+    described_class.create!(firstname: "X", from_date: from, to_date: to, people: people, status: "confirmed", kind: "tente")
+  end
+
+  it "génère un token et exige un nombre de personnes positif" do
+    cb = described_class.create!(firstname: "A", from_date: d0, to_date: d1, people: 2, status: "pending")
+    expect(cb.token).to be_present
+    expect(described_class.new(firstname: "B", people: 0)).not_to be_valid
+  end
+
+  describe ".units_reserved_on" do
+    it "somme les personnes confirmées couvrant la nuit (from <= d < to)" do
+      confirmed!(people: 4, from: d0, to: d2) # couvre d0 et d1, pas d2
+      expect(described_class.units_reserved_on(d0)).to eq(4)
+      expect(described_class.units_reserved_on(d1)).to eq(4)
+      expect(described_class.units_reserved_on(d2)).to eq(0)
+    end
+
+    it "ignore les résas non confirmées" do
+      described_class.create!(firstname: "P", from_date: d0, to_date: d2, people: 4, status: "pending")
+      expect(described_class.units_reserved_on(d0)).to eq(0)
+    end
+  end
+
+  describe ".capacity_conflict_date" do
+    it "renvoie la première nuit dépassant la capacité, nil sinon" do
+      confirmed!(people: described_class::TOTAL_CAPACITY - 1, from: d0, to: d1)
+      # +2 personnes la nuit d0 → dépasse ; la nuit d1 est libre.
+      expect(described_class.capacity_conflict_date(units: 2, from: d0, to: d2)).to eq(d0)
+      expect(described_class.capacity_conflict_date(units: 1, from: d0, to: d2)).to be_nil
+    end
+
+    it "exclut une réservation donnée (édition)" do
+      own = confirmed!(people: described_class::TOTAL_CAPACITY, from: d0, to: d1)
+      expect(described_class.capacity_conflict_date(units: 1, from: d0, to: d1)).to eq(d0)
+      expect(described_class.capacity_conflict_date(units: 1, from: d0, to: d1, excluding_id: own.id)).to be_nil
+    end
+  end
+end

--- a/spec/models/meal_order_spec.rb
+++ b/spec/models/meal_order_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+# Epic #66, Phase 3 — MealOrder : commande de repas datée rattachée directement
+# au séjour (has_many), hors calendrier. `date` nullable (repas funnel sans date).
+RSpec.describe MealOrder do
+  let(:customer) { Customer.create!(email: "meal@example.com", first_name: "Meal", last_name: "Test") }
+  let(:stay) { Stay.create!(customer: customer, source: "manual", status: "pending") }
+
+  it "exige un type et un nombre de convives positif" do
+    expect(described_class.new(stay: stay, kind: nil, people: 2)).not_to be_valid
+    expect(described_class.new(stay: stay, kind: "buffet", people: 0)).not_to be_valid
+  end
+
+  it "tolère une date nulle (repas funnel sans date)" do
+    order = described_class.create!(stay: stay, kind: "buffet", people: 3, date: nil, price_cents: 3_600)
+    expect(order).to be_persisted
+    expect(order.date).to be_nil
+  end
+
+  it "expose un libellé lisible" do
+    expect(described_class.new(kind: "repas_vege_midi").label).to eq("Repas végé (midi)")
+    expect(described_class.new(kind: "inconnu").label).to eq("Inconnu")
+  end
+
+  it "est exclue du séjour après soft-delete (default_scope)" do
+    order = described_class.create!(stay: stay, kind: "buffet", people: 2, price_cents: 2_400)
+    expect(stay.meal_orders).to include(order)
+    order.soft_delete!(validate: false)
+    expect(stay.meal_orders.reload).to be_empty
+  end
+end

--- a/spec/models/stay_recompute_spaces_spec.rb
+++ b/spec/models/stay_recompute_spaces_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+# Epic #66, Phase 2 — `Stay#recompute_aggregates!` doit tolérer un séjour SANS
+# hébergement : dates + total dérivés des SpaceBooking, et surtout ne JAMAIS
+# écraser les dates à nil quand aucun bookable daté n'est présent.
+RSpec.describe Stay, "#recompute_aggregates! (espaces seuls, epic #66)" do
+  let!(:customer) { Customer.create!(email: "c@example.com", first_name: "C", customer_type: "individual") }
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+
+  def stay_with_space
+    stay = Stay.create!(customer: customer, source: "manual", status: "pending",
+                        arrival_date: arrival, departure_date: departure, total_amount_cents: 0)
+    space = Space.create!(name: "Grande Salle", capacity: 1)
+    sb = SpaceBooking.create!(firstname: "C", from_date: arrival, to_date: departure,
+                              status: "pending", price_cents: 29_000)
+    sb.space_reservations.create!(space: space, date: arrival, duration: "journee")
+    stay.stay_items.create!(bookable: sb)
+    stay
+  end
+
+  it "dérive dates et total depuis le SpaceBooking (sans Booking)" do
+    stay = stay_with_space
+    stay.recompute_aggregates!
+    stay.reload
+
+    expect(stay.total_amount_cents).to eq(29_000)
+    expect(stay.arrival_date).to eq(arrival)
+    expect(stay.departure_date).to eq(departure)
+  end
+
+  it "n'écrase pas les dates à nil quand aucun bookable daté n'existe" do
+    stay = Stay.create!(customer: customer, source: "manual", status: "pending",
+                        arrival_date: arrival, departure_date: departure, total_amount_cents: 5_000)
+    stay.recompute_aggregates!
+    stay.reload
+
+    expect(stay.arrival_date).to eq(arrival)
+    expect(stay.departure_date).to eq(departure)
+    expect(stay.total_amount_cents).to eq(0) # aucun bookable ni activité
+  end
+end

--- a/spec/requests/calendar_stays_grouping_spec.rb
+++ b/spec/requests/calendar_stays_grouping_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+# Epic #66, Phase 4 — Le calendrier racine bascule sur les SÉJOURS : il regroupe
+# et colore les occupations PAR `stay_id` (couleur stable par séjour, style
+# inline), tout en gardant UN BLOC PAR RESSOURCE occupée (chambre / espace /
+# camping-van) — ce qui préserve la représentation qui porte le veto Grand-Duc.
+RSpec.describe "Calendrier — regroupement par séjour (epic #66, Phase 4)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user)    { User.create!(email: "agent@les4sources.be", password: "password123") }
+  let(:lodging) { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+  let(:room) do
+    r = Room.create!(name: "Chambre 1", level: 1)
+    lodging.rooms << r
+    r
+  end
+  let(:space) { Space.create!(name: "Grande Salle", capacity: 5) }
+
+  before { sign_in user }
+
+  # Teinte attendue pour un séjour — même formule que CalendarHelper.
+  def hue_for(stay_id)
+    ((stay_id * CalendarHelper::GOLDEN_ANGLE) % 360).round
+  end
+
+  # Booking confirmé + ses réservations jour par jour + son Stay (via le service
+  # d'attachement réel, comme en production admin/OTA).
+  def stay_with_lodging(from:, to:, group: "Groupe Hébergement")
+    booking = Booking.create!(firstname: "Alex", group_name: group, lodging: lodging,
+                              from_date: from, to_date: to, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0)
+    (from...to).each { |date| Reservation.create!(booking: booking, room: room, date: date) }
+    stay = Stays::EnsureForBooking.call(booking)
+    [stay, booking]
+  end
+
+  describe "regroupement + couleur par séjour" do
+    it "pose data-stay-id et la couleur inline stable du séjour sur le bloc chambre" do
+      from = Date.today.next_occurring(:friday)
+      stay, _booking = stay_with_lodging(from: from, to: from + 1)
+
+      get "/"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("data-stay-id=\"#{stay.id}\"")
+      expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
+    end
+
+    it "groupe un séjour MULTI-RESSOURCES (hébergement + espace) sous le même séjour et la même couleur" do
+      from = Date.today.next_occurring(:friday)
+      stay, _booking = stay_with_lodging(from: from, to: from + 1)
+
+      # Un espace rattaché AU MÊME séjour (multi-ressources).
+      space_booking = SpaceBooking.create!(firstname: "Alex", group_name: "Groupe Hébergement",
+                                           from_date: from, to_date: from, status: "confirmed")
+      SpaceReservation.create!(space: space, space_booking: space_booking, date: from)
+      StayItem.create!(stay: stay, bookable: space_booking)
+
+      get "/"
+
+      # Le bloc chambre ET le bloc espace portent le même stay_id…
+      expect(response.body).to include("data-booking-day-entry=\"#{_booking.id}\"")
+      expect(response.body).to include("data-space-booking-day-entry=\"#{space_booking.id}\"")
+      # …et la même teinte de séjour.
+      expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to be >= 2
+      expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
+    end
+
+    it "attribue des couleurs DISTINCTES à deux séjours différents" do
+      from = Date.today.next_occurring(:friday)
+      stay_a, _a = stay_with_lodging(from: from, to: from + 1, group: "Séjour A")
+      # Deuxième chambre/hébergement pour un second séjour, même nuit.
+      other_room = Room.create!(name: "Chambre 2", level: 1)
+      lodging.rooms << other_room
+      booking_b = Booking.create!(firstname: "Bea", group_name: "Séjour B", lodging: lodging,
+                                  from_date: from, to_date: from + 1, adults: 1, children: 0, babies: 0,
+                                  status: "confirmed", booking_type: "lodging", price_cents: 0)
+      Reservation.create!(booking: booking_b, room: other_room, date: from)
+      stay_b = Stays::EnsureForBooking.call(booking_b)
+
+      get "/"
+
+      expect(hue_for(stay_a.id)).not_to eq(hue_for(stay_b.id))
+      expect(response.body).to include("hsl(#{hue_for(stay_a.id)}, 65%, 45%)")
+      expect(response.body).to include("hsl(#{hue_for(stay_b.id)}, 65%, 45%)")
+    end
+  end
+
+  describe "occupations chambres — anti-régression veto Grand-Duc" do
+    it "rend toujours un bloc par jour réservé avec le badge chambre" do
+      from = Date.today.next_occurring(:friday)
+      _stay, booking = stay_with_lodging(from: from, to: from + 2)
+
+      get "/"
+
+      # Deux nuits réservées → deux entrées jour (la source de vérité du veto).
+      expect(response.body.scan("data-booking-day-entry=\"#{booking.id}\"").size).to eq(2)
+      expect(response.body).to include(booking_path(booking))
+    end
+
+    it "retombe sur la couleur historique (par type) pour un booking SANS séjour" do
+      from = Date.today.next_occurring(:friday)
+      booking = Booking.create!(firstname: "Legacy", group_name: "Sans séjour", lodging: lodging,
+                                from_date: from, to_date: from + 1, adults: 2, children: 0, babies: 0,
+                                status: "confirmed", booking_type: "lodging", price_cents: 0)
+      Reservation.create!(booking: booking, room: room, date: from)
+      # PAS de Stay attaché.
+
+      get "/"
+
+      # Couleur historique (emerald pour un lodging confirmé), pas de data-stay-id.
+      expect(response.body).to include("border-emerald-500")
+      expect(response.body).to include("data-booking-day-entry=\"#{booking.id}\"")
+    end
+  end
+
+  describe "camping / van agrégés, groupés par séjour" do
+    it "rend un bloc « Camping » par nuit occupée, coloré par le séjour" do
+      from = Date.today.next_occurring(:friday)
+      to   = from + 2 # 2 nuits
+      camping = CampingBooking.create!(firstname: "Cam", group_name: "Groupe Camping",
+                                       from_date: from, to_date: to, people: 4,
+                                       status: "confirmed", kind: "tente")
+      customer = Customers::UpsertByEmail.call(email: "cam@example.com", attrs: { first_name: "Cam" })
+      stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                          arrival_date: from, departure_date: to)
+      StayItem.create!(stay: stay, bookable: camping)
+
+      get "/"
+
+      expect(response).to have_http_status(:ok)
+      # Une entrée camping par nuit (2), colorée par le séjour.
+      expect(response.body.scan("data-camping-booking-entry=\"#{camping.id}\"").size).to eq(2)
+      expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
+      expect(response.body).to include("Groupe Camping")
+    end
+  end
+
+  describe "vue Sourciers (anti-régression)" do
+    it "reste inchangée — aucun regroupement séjour n'y fuit" do
+      from = Date.today.next_occurring(:friday)
+      stay_with_lodging(from: from, to: from + 1)
+
+      get "/?view=organisation"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("data-booking-day-entry")
+      expect(response.body).not_to include("data-camping-booking-entry")
+    end
+  end
+end

--- a/spec/requests/stays_admin_camping_spec.rb
+++ b/spec/requests/stays_admin_camping_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+# Epic #66, Phase 3 — Camping / van / repas dans la composition du Séjour admin.
+# Le CRUD admin crée/édite un CampingBooking, un VanBooking (StayItem) et des
+# MealOrder (direct), permet un séjour camping-seul, et n'appelle jamais Stripe.
+RSpec.describe "Stays — camping / van / repas (epic #66, Phase 3)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-camping@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:lodging) { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 } # 2 nuits
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: "", status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  describe "POST /stays — séjour camping-seul" do
+    it "crée un CampingBooking + StayItem, sans Booking, avec dates au séjour" do
+      expect {
+        post stays_path, params: base_params(camping: { people: 4 })
+      }.to change(Stay, :count).by(1)
+       .and change(CampingBooking, :count).by(1)
+       .and change(Booking, :count).by(0)
+
+      stay = Stay.order(:created_at).last
+      cb = stay.stay_items.where(bookable_type: "CampingBooking").first.bookable
+      expect(cb.people).to eq(4)
+      expect(cb.from_date).to eq(arrival)
+      expect(cb.to_date).to eq(departure)
+      # 4 pers × 2 nuits × 7,50 € = 6 000 c.
+      expect(stay.total_amount_cents).to eq(6_000)
+      expect(stay.arrival_date).to eq(arrival)
+      expect(stay.payments).to be_empty
+    end
+  end
+
+  describe "POST /stays — van + repas avec hébergement" do
+    it "persiste VanBooking (StayItem) + MealOrder (direct)" do
+      expect {
+        post stays_path, params: base_params(
+          lodging_id: lodging.id,
+          van: { vehicles: 2 },
+          meals: { "0" => { kind: "buffet", date: arrival.iso8601, people: 3 } }
+        )
+      }.to change(VanBooking, :count).by(1)
+       .and change(MealOrder, :count).by(1)
+
+      stay = Stay.order(:created_at).last
+      van = stay.stay_items.where(bookable_type: "VanBooking").first.bookable
+      expect(van.vehicles).to eq(2)
+      meal = stay.meal_orders.first
+      expect(meal.kind).to eq("buffet")
+      expect(meal.people).to eq(3)
+      expect(meal.date).to eq(arrival)
+    end
+  end
+
+  describe "PATCH /stays/:id — édition d'un séjour camping-seul" do
+    def create_camping_only_stay
+      draft = Reservations::Draft.new(
+        lodging_id: nil, arrival_date: arrival, departure_date: departure,
+        first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222",
+        campings: [{ kind: "tente", people: 3, nights: 2 }]
+      )
+      Reservations::Builder.new(draft: draft, admin: true, source: "manual").tap(&:run!).stay
+    end
+
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: "", status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "préremplit le form d'édition avec le camping existant" do
+      stay = create_camping_only_stay
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Camping (tente)")
+      expect(response.body).to include('value="3"') # people prérempli
+    end
+
+    it "change le nombre de personnes et recalcule le total" do
+      stay = create_camping_only_stay
+      expect(stay.total_amount_cents).to eq(4_500) # 3 × 2 × 7,50 €
+
+      patch stay_path(stay), params: update_params(stay, camping: { people: 5 })
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay.reload
+      cb = stay.stay_items.where(bookable_type: "CampingBooking").first.bookable
+      expect(cb.people).to eq(5)
+      expect(stay.total_amount_cents).to eq(7_500) # 5 × 2 × 7,50 €
+    end
+
+    it "retire le camping (0 pers) sans autre composant → refusé (séjour vide)" do
+      stay = create_camping_only_stay
+      patch stay_path(stay), params: update_params(stay, camping: { people: 0 })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("hébergement, un espace ou un emplacement camping/van")
+    end
+  end
+
+  describe "capacité globale — force-dispo (création)" do
+    it "force le camping au-delà de la capacité avec avertissement" do
+      CampingBooking.create!(
+        firstname: "Occ", from_date: arrival, to_date: departure,
+        people: CampingBooking::TOTAL_CAPACITY, status: "confirmed", kind: "tente"
+      )
+      post stays_path, params: base_params(camping: { people: 2 }, force_availability: "1")
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to match(/forçant la disponibilité/i)
+      expect(CampingBooking.where(status: "pending").count).to eq(1)
+    end
+
+    it "bloque hors force" do
+      CampingBooking.create!(
+        firstname: "Occ", from_date: arrival, to_date: departure,
+        people: CampingBooking::TOTAL_CAPACITY, status: "confirmed", kind: "tente"
+      )
+      expect {
+        post stays_path, params: base_params(camping: { people: 2 })
+      }.not_to change(Stay, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to match(/complet/i)
+    end
+  end
+end

--- a/spec/requests/stays_admin_crud_spec.rb
+++ b/spec/requests/stays_admin_crud_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+# CRUD Séjour admin (epic #66, Phase 1) — le séjour devient le point d'entrée de
+# création composable côté admin (hébergement + activités), en réutilisant
+# `Reservations::Builder` en mode admin : aucun Stripe, aucun email forcé,
+# force-dispo avec avertissement, statut au choix, client existant ou à la volée.
+RSpec.describe "Stays — CRUD admin (epic #66)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-stays@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  # Hébergement tarifé au barème B2C (Pricing::Catalog) : La Hulotte = 485 € la
+  # 1re nuit + 260 € par nuit suivante. 2 nuits → 745 € (74 500 cents).
+  let!(:lodging)  { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+  let(:hulotte_two_nights_cents) { 74_500 }
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  # Crée un séjour admin directement via le Builder (helper pour edit/update/destroy).
+  def create_admin_stay(status: "pending")
+    draft = Reservations::Draft.new(
+      lodging_id: lodging.id, arrival_date: arrival, departure_date: departure,
+      adults: 2, first_name: "Alice", last_name: "Martin",
+      email: "alice@example.com", phone: "0470111222"
+    )
+    builder = Reservations::Builder.new(draft: draft, admin: true, status: status, source: "manual")
+    builder.run!
+    builder.stay
+  end
+
+  describe "GET /stays/new" do
+    it "affiche le formulaire de composition" do
+      get new_stay_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Nouveau séjour")
+      expect(response.body).to include("La Hulotte")
+      expect(response.body).to include("Forcer la disponibilité")
+    end
+  end
+
+  describe "POST /stays (create)" do
+    it "crée un séjour avec un nouveau client, une occupation d'hébergement et AUCUN paiement" do
+      expect {
+        post stays_path, params: base_params
+      }.to change(Stay, :count).by(1)
+       .and change(Customer, :count).by(1)
+       .and change(Booking, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      stay = Stay.order(:created_at).last
+      expect(stay.source).to eq("manual")
+      expect(stay.status).to eq("pending")
+      expect(stay.customer.email).to eq("alice@example.com")
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents)
+      # Décision figée : aucun paiement (donc aucun appel Stripe) à la création admin.
+      expect(stay.payments).to be_empty
+    end
+
+    it "réutilise un client existant sélectionné par id (pas de doublon)" do
+      customer = Customer.create!(email: "bob@example.com", first_name: "Bob", customer_type: "individual")
+      expect {
+        post stays_path, params: base_params(customer_mode: "existing", customer_id: customer.id, new_customer: {})
+      }.to change(Stay, :count).by(1).and change(Customer, :count).by(0)
+
+      expect(Stay.order(:created_at).last.customer).to eq(customer)
+    end
+
+    it "laisse l'admin choisir le statut confirmé" do
+      post stays_path, params: base_params(status: "confirmed")
+      expect(Stay.order(:created_at).last.status).to eq("confirmed")
+    end
+
+    it "bloque la création sur des dates indisponibles hors force" do
+      Unavailability.create!(lodging: lodging, date: arrival)
+      expect { post stays_path, params: base_params }.not_to change(Stay, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("plus disponibles")
+    end
+
+    it "force la création sur des dates indisponibles avec un avertissement" do
+      Unavailability.create!(lodging: lodging, date: arrival)
+      expect {
+        post stays_path, params: base_params(force_availability: "1")
+      }.to change(Stay, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to include("forçant la disponibilité")
+    end
+
+    it "attache les activités sélectionnées et les intègre au total" do
+      exp   = Experience.create!(name: "Balade ânes", fixed_price_cents: 4_000, price_cents: 1_500)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "10:00")
+
+      post stays_path, params: base_params(experiences: { "0" => { availability_id: avail.id, participants: 2 } })
+
+      stay = Stay.order(:created_at).last
+      expect(stay.experience_bookings.count).to eq(1)
+      # Activité : 40 € forfait + 15 €/pers × 2 = 70 € (7 000 cents). Total = 745 € + 70 €.
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents + 7_000)
+    end
+  end
+
+  describe "GET /stays/:id/edit" do
+    it "affiche le formulaire prérempli" do
+      stay = create_admin_stay
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Modifier le séjour ##{stay.id}")
+      expect(response.body).to include("La Hulotte")
+    end
+  end
+
+  describe "PATCH /stays/:id (update)" do
+    let!(:cheveche) { Lodging.create!(name: "La Chevêche", summary: "gîte") }
+
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: lodging.id, status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "modifie l'hébergement et recalcule le total" do
+      stay = create_admin_stay
+      patch stay_path(stay), params: update_params(stay, lodging_id: cheveche.id)
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay.reload
+      booking = stay.stay_items.where(bookable_type: "Booking").first.bookable
+      expect(booking.lodging_id).to eq(cheveche.id)
+      # La Chevêche = 275 € + 200 € = 475 € (47 500 cents) sur 2 nuits.
+      expect(stay.total_amount_cents).to eq(47_500)
+    end
+
+    it "bascule le statut en confirmé SANS envoyer d'email au client" do
+      stay = create_admin_stay
+      ActionMailer::Base.deliveries.clear
+      patch stay_path(stay), params: update_params(stay, status: "confirmed")
+
+      expect(stay.reload.status).to eq("confirmed")
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+
+    it "ajoute une activité à un séjour existant" do
+      stay  = create_admin_stay
+      exp   = Experience.create!(name: "Poterie", price_cents: 2_000)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "14:00")
+
+      expect {
+        patch stay_path(stay), params: update_params(stay, experiences: { "0" => { availability_id: avail.id, participants: 3 } })
+      }.to change { stay.experience_bookings.active.count }.from(0).to(1)
+
+      expect(stay.reload.total_amount_cents).to eq(hulotte_two_nights_cents + 6_000) # 20 €/pers × 3
+    end
+
+    it "retire une activité en passant ses participants à 0" do
+      stay  = create_admin_stay
+      exp   = Experience.create!(name: "Poterie", price_cents: 2_000)
+      avail = ExperienceAvailability.create!(experience: exp, available_on: arrival + 1, starts_at: "14:00")
+      stay.experience_bookings.create!(experience_availability: avail, participants: 2, status: "pending")
+
+      expect {
+        patch stay_path(stay), params: update_params(stay, experiences: { "0" => { availability_id: avail.id, participants: 0 } })
+      }.to change { stay.experience_bookings.active.count }.from(1).to(0)
+    end
+  end
+
+  describe "DELETE /stays/:id (destroy)" do
+    it "soft-supprime le séjour (jamais de hard destroy)" do
+      stay = create_admin_stay
+      delete stay_path(stay)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(Stay.exists?(stay.id)).to be(false)                     # hors default scope
+      expect(Stay.unscoped.find(stay.id).deleted_at).to be_present   # présent mais marqué supprimé
+    end
+  end
+end

--- a/spec/requests/stays_admin_spaces_spec.rb
+++ b/spec/requests/stays_admin_spaces_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+# Epic #66, Phase 2 — Espaces dans la composition du Séjour admin. Le CRUD admin
+# crée/édite un SpaceBooking + StayItem depuis les espaces choisis (form `halls`),
+# permet un séjour « espaces seuls » (sans hébergement), et n'appelle jamais
+# Stripe ni d'email client forcé.
+RSpec.describe "Stays — espaces (epic #66, Phase 2)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-spaces@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:lodging)      { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+  let(:arrival)       { Date.today + 30 }
+  let(:departure)     { Date.today + 32 }
+  let(:grande_salle_journee_cents) { 29_000 }
+  let(:hulotte_two_nights_cents)   { 74_500 }
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  def hall_param(kind: "grande_salle", date: nil, period: "journee")
+    { "0" => { kind: kind, date: (date || arrival).iso8601, period: period } }
+  end
+
+  describe "POST /stays — hébergement + espace" do
+    it "crée un SpaceBooking + StayItem et intègre l'espace au total" do
+      expect {
+        post stays_path, params: base_params(halls: hall_param)
+      }.to change(Stay, :count).by(1)
+       .and change(SpaceBooking, :count).by(1)
+       .and change(Booking, :count).by(1)
+
+      stay = Stay.order(:created_at).last
+      sb = stay.stay_items.where(bookable_type: "SpaceBooking").first.bookable
+      expect(sb.space_reservations.map(&:space)).to eq([grande_salle])
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents + grande_salle_journee_cents)
+      expect(stay.payments).to be_empty # aucun Stripe
+    end
+  end
+
+  describe "POST /stays — séjour espaces seuls (sans hébergement)" do
+    it "crée un séjour sans Booking, avec son SpaceBooking persisté" do
+      expect {
+        post stays_path, params: base_params(lodging_id: "", halls: hall_param)
+      }.to change(Stay, :count).by(1)
+       .and change(SpaceBooking, :count).by(1)
+       .and change(Booking, :count).by(0)
+
+      stay = Stay.order(:created_at).last
+      expect(stay.stay_items.where(bookable_type: "Booking")).to be_empty
+      expect(stay.stay_items.where(bookable_type: "SpaceBooking").count).to eq(1)
+      expect(stay.total_amount_cents).to eq(grande_salle_journee_cents)
+      expect(stay.arrival_date).to eq(arrival)
+      expect(stay.departure_date).to eq(departure)
+    end
+  end
+
+  describe "PATCH /stays/:id — édition d'un séjour espaces seuls" do
+    def create_spaces_only_stay
+      draft = Reservations::Draft.new(
+        lodging_id: nil, arrival_date: arrival, departure_date: departure,
+        first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222",
+        halls: [{ kind: "grande_salle", date: arrival.iso8601, period: "journee" }]
+      )
+      builder = Reservations::Builder.new(draft: draft, admin: true, source: "manual")
+      builder.run!
+      builder.stay
+    end
+
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: "", status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "préremplit le form d'édition avec l'espace existant" do
+      stay = create_spaces_only_stay
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Espaces")
+      # L'espace existant est présélectionné (grande_salle / journée) et chiffré.
+      expect(response.body).to include('selected="selected" value="grande_salle"')
+      expect(response.body).to include('selected="selected" value="journee"')
+      expect(response.body).to include("Grande salle — ")
+    end
+
+    it "change la période de l'espace et recalcule le total" do
+      stay = create_spaces_only_stay
+      expect(stay.total_amount_cents).to eq(grande_salle_journee_cents)
+
+      # journée → journée + soirée = 380 € (38 000 c) pour la grande salle.
+      patch stay_path(stay), params: update_params(stay, halls: hall_param(period: "journee_et_soiree"))
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay.reload
+      sb = stay.stay_items.where(bookable_type: "SpaceBooking").first.bookable
+      expect(sb.space_reservations.first.duration).to eq("journee_et_soiree")
+      expect(stay.total_amount_cents).to eq(38_000)
+    end
+
+    it "retire l'espace en vidant les lignes → refusé (séjour deviendrait vide)" do
+      stay = create_spaces_only_stay
+      patch stay_path(stay), params: update_params(stay) # ni lodging ni halls
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("hébergement ou un espace")
+    end
+  end
+
+  describe "capacité / force-dispo (édition)" do
+    it "force l'ajout d'un espace complet avec avertissement" do
+      # Grande salle complète à l'arrivée (capacity 1, une résa confirmée).
+      occ = SpaceBooking.create!(firstname: "Occ", from_date: arrival, to_date: arrival, status: "confirmed")
+      occ.space_reservations.create!(space: grande_salle, date: arrival, duration: "journee")
+
+      post stays_path, params: base_params(lodging_id: "", halls: hall_param, force_availability: "1")
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to match(/forçant la disponibilité/i)
+      expect(SpaceBooking.where(status: "pending").count).to eq(1)
+    end
+  end
+end

--- a/spec/requests/stays_admin_spaces_spec.rb
+++ b/spec/requests/stays_admin_spaces_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe "Stays — espaces (epic #66, Phase 2)", type: :request do
       stay = create_spaces_only_stay
       patch stay_path(stay), params: update_params(stay) # ni lodging ni halls
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("hébergement ou un espace")
+      # Phase 3 (epic #66) : la contrainte de composition s'élargit au camping/van.
+      expect(response.body).to include("hébergement, un espace ou un emplacement camping/van")
     end
   end
 

--- a/spec/services/reservations/builder_camping_spec.rb
+++ b/spec/services/reservations/builder_camping_spec.rb
@@ -1,0 +1,203 @@
+require "rails_helper"
+
+# Epic #66, Phase 3 — Camping / van / repas persistés. En mode admin, le Builder
+# crée un CampingBooking + un VanBooking (StayItem, occupent le calendrier) et des
+# MealOrder (has_many direct, hors calendrier). La part de prix de chacun est
+# EXTRAITE de `lodging_bundle_cents` (tags de catégorie) et portée par son propre
+# modèle → aucun double-compte. Le funnel public reste devis-only (inchangé).
+RSpec.describe Reservations::Builder, "camping / van / repas (epic #66, Phase 3)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 } # 2 nuits
+  let(:hulotte_two_nights_cents) { 74_500 }
+  let(:grande_salle_journee_cents) { 29_000 }
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  describe "persistance admin camping + van + repas" do
+    it "crée CampingBooking + VanBooking (StayItem) et MealOrder (direct)" do
+      d = draft(
+        lodging_id: hulotte.id,
+        campings: [{ kind: "tente", people: 3, nights: 2 }],
+        vans:     [{ nights: 2 }],
+        meals:    [{ kind: "buffet", date: arrival.iso8601, people: 4 }]
+      )
+      builder = described_class.new(draft: d, admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      camping = builder.camping_booking
+      van     = builder.van_booking
+      expect(camping).to be_persisted
+      expect(van).to be_persisted
+      expect(camping.people).to eq(3)
+      expect(van.vehicles).to eq(1)
+      # Camping 3 pers × 2 nuits × 7,50 € = 4 500 c ; van 2 nuits × 15 € = 3 000 c.
+      expect(camping.price_cents).to eq(4_500)
+      expect(van.price_cents).to eq(3_000)
+      # Occupent le calendrier via StayItem.
+      expect(builder.stay.stay_items.map(&:bookable)).to include(camping, van)
+      # Repas : has_many direct, PAS de StayItem.
+      expect(builder.stay.meal_orders.count).to eq(1)
+      meal = builder.stay.meal_orders.first
+      expect(meal.kind).to eq("buffet")
+      expect(meal.people).to eq(4)
+      expect(meal.date).to eq(arrival)
+      expect(meal.price_cents).to eq(4_800) # 4 × 12 €
+      # Occupations camping/van portent les dates du séjour.
+      expect(camping.from_date).to eq(arrival)
+      expect(camping.to_date).to eq(departure)
+      # Aucun Stripe.
+      expect(builder.stay.payments).to be_empty
+    end
+  end
+
+  describe "invariant de ventilation du total (sans double-compte)" do
+    let!(:experience) { Experience.create!(name: "Atelier vannerie", fixed_price_cents: 2_000, price_cents: 1_000, max_participants: 8) }
+    let!(:slot) { ExperienceAvailability.create!(experience: experience, available_on: arrival, starts_at: "10:00", max_participants: 8) }
+
+    it "Booking(hébergement pur) + SpaceBooking + Camping + Van + Meals + Experiences == total" do
+      d = draft(
+        lodging_id: hulotte.id,
+        halls:      [{ kind: "grande_salle", date: arrival.iso8601, period: "journee" }],
+        campings:   [{ kind: "tente", people: 3, nights: 2 }],
+        vans:       [{ nights: 2 }],
+        meals:      [{ kind: "buffet", date: arrival.iso8601, people: 4 }],
+        experiences: [{ id: experience.id, availability_id: slot.id, participants: 2 }]
+      )
+      builder = described_class.new(draft: d, admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      booking_cents  = builder.booking.price_cents
+      space_cents    = builder.space_booking.price_cents
+      camping_cents  = builder.camping_booking.price_cents
+      van_cents      = builder.van_booking.price_cents
+      meals_cents    = builder.stay.meal_orders.sum(:price_cents)
+      exp_cents      = builder.stay.experience_bookings.active.sum(&:price_cents)
+
+      # L'hébergement pur ne contient NI camping NI van NI repas NI espaces.
+      expect(booking_cents).to eq(hulotte_two_nights_cents)
+      expect(space_cents).to eq(grande_salle_journee_cents)
+      expect(camping_cents).to eq(4_500)
+      expect(van_cents).to eq(3_000)
+      expect(meals_cents).to eq(4_800)
+      expect(exp_cents).to eq(4_000) # 2 000 + 1 000 × 2
+
+      sum = booking_cents + space_cents + camping_cents + van_cents + meals_cents + exp_cents
+      expect(sum).to eq(builder.stay.total_amount_cents)
+      # Et recompute redonne exactement le même total.
+      builder.stay.recompute_aggregates!
+      expect(builder.stay.reload.total_amount_cents).to eq(sum)
+    end
+  end
+
+  describe "séjour camping-seul (sans hébergement ni espace)" do
+    let(:camping_only) do
+      draft(lodging_id: nil, campings: [{ kind: "tente", people: 4, nights: 2 }])
+    end
+
+    it "ne crée AUCUN Booking mais persiste le CampingBooking + dates au séjour" do
+      builder = described_class.new(draft: camping_only, admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      expect(builder.booking).to be_nil
+      camping = builder.camping_booking
+      expect(camping).to be_persisted
+      expect(builder.stay.stay_items.map(&:bookable)).to eq([camping])
+      # 4 pers × 2 nuits × 7,50 € = 6 000 c.
+      expect(builder.stay.total_amount_cents).to eq(6_000)
+      expect(builder.stay.arrival_date).to eq(arrival)
+      expect(builder.stay.departure_date).to eq(departure)
+    end
+
+    it "garde des agrégats corrects après recompute (dates non écrasées)" do
+      builder = described_class.new(draft: camping_only, admin: true, source: "manual")
+      builder.run
+      stay = builder.stay
+
+      stay.recompute_aggregates!
+      stay.reload
+      expect(stay.total_amount_cents).to eq(6_000)
+      expect(stay.arrival_date).to eq(arrival)
+      expect(stay.departure_date).to eq(departure)
+    end
+  end
+
+  describe "séjour van-seul" do
+    it "persiste le VanBooking et date le séjour" do
+      builder = described_class.new(
+        draft: draft(lodging_id: nil, vans: [{ nights: 2 }, { nights: 2 }]),
+        admin: true, source: "manual"
+      )
+      expect(builder.run).to be(true)
+      expect(builder.van_booking).to be_persisted
+      expect(builder.van_booking.vehicles).to eq(2)
+      # 2 véhicules × 2 nuits × 15 € = 6 000 c.
+      expect(builder.stay.total_amount_cents).to eq(6_000)
+      expect(builder.stay.arrival_date).to eq(arrival)
+    end
+  end
+
+  describe "capacité globale du camping (dispo + force)" do
+    def fill_camping!(people)
+      cb = CampingBooking.create!(
+        firstname: "Occ", from_date: arrival, to_date: departure,
+        people: people, status: "confirmed", kind: "tente"
+      )
+      cb
+    end
+
+    it "bloque hors force quand la capacité globale est dépassée" do
+      fill_camping!(CampingBooking::TOTAL_CAPACITY - 1) # reste 1 place
+      builder = described_class.new(
+        draft: draft(lodging_id: nil, campings: [{ kind: "tente", people: 5, nights: 2 }]),
+        admin: true, source: "manual"
+      )
+      expect(builder.run).to be(false)
+      expect(builder.error_message).to match(/complet/i)
+      expect(Stay.count).to eq(0)
+    end
+
+    it "force la création avec un avertissement" do
+      fill_camping!(CampingBooking::TOTAL_CAPACITY - 1)
+      builder = described_class.new(
+        draft: draft(lodging_id: nil, campings: [{ kind: "tente", people: 5, nights: 2 }]),
+        admin: true, source: "manual", skip_availability: true
+      )
+      expect(builder.run).to be(true)
+      expect(builder.availability_warning).to match(/forçant la disponibilité/i)
+      expect(builder.camping_booking).to be_persisted
+    end
+  end
+
+  describe "funnel public inchangé (camping/van/repas devis-only)" do
+    it "ne persiste NI CampingBooking NI VanBooking NI MealOrder" do
+      d = draft(
+        lodging_id: hulotte.id,
+        campings: [{ kind: "tente", people: 3, nights: 2 }],
+        meals:    [{ kind: "buffet", people: 4 }]
+      )
+      builder = described_class.new(draft: d) # PAS admin
+      expect(builder.run).to be(true)
+
+      expect(CampingBooking.count).to eq(0)
+      expect(VanBooking.count).to eq(0)
+      expect(builder.stay.meal_orders).to be_empty
+      # Le Booking public porte encore le bundle (camping + repas noyés).
+      # Total prévu = 74 500 (héberg) + 4 500 (camping) + 4 800 (repas) = 83 800 c.
+      expect(builder.stay.total_amount_cents).to eq(83_800)
+      expect(builder.booking.price_cents).to eq(83_800)
+    end
+  end
+end

--- a/spec/services/reservations/builder_spaces_spec.rb
+++ b/spec/services/reservations/builder_spaces_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+# Epic #66, Phase 2 — Espaces dans la composition du séjour. Le Builder persiste
+# désormais les espaces choisis (halls / space_slots) en un SpaceBooking +
+# StayItem, y compris pour un séjour « espaces seuls » (sans hébergement). La part
+# espaces vit sur le SpaceBooking ; l'hébergement porte le reste (aucun double-compte).
+RSpec.describe Reservations::Builder, "espaces (epic #66, Phase 2)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+  # Grande Salle → grande_salle (grille de pricing). Capacity 1 = salle exclusive.
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+  # grande_salle / journée (barème semaine des salles) = 290 €.
+  let(:grande_salle_journee_cents) { 29_000 }
+  let(:hulotte_two_nights_cents)   { 74_500 }
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      lodging_id: hulotte.id,
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  def hall(date: nil, kind: "grande_salle", period: "journee")
+    { kind: kind, date: (date || arrival).iso8601, period: period }
+  end
+
+  describe "hébergement + espace" do
+    it "crée un SpaceBooking + StayItem et ventile le prix sans double-compte" do
+      builder = described_class.new(draft: draft(halls: [hall]), admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      sb = builder.space_booking
+      expect(sb).to be_persisted
+      expect(builder.stay.stay_items.map(&:bookable)).to include(sb)
+      expect(sb.space_reservations.map(&:space)).to eq([grande_salle])
+      expect(sb.price_cents).to eq(grande_salle_journee_cents)
+
+      # Le Booking d'hébergement porte le reste (hors espaces) — pas de double-compte.
+      expect(builder.booking.price_cents).to eq(hulotte_two_nights_cents)
+      # Total prévu = hébergement + espace.
+      expect(builder.stay.total_amount_cents).to eq(hulotte_two_nights_cents + grande_salle_journee_cents)
+      # recompute redonne exactement le même total (Booking + SpaceBooking).
+      builder.stay.recompute_aggregates!
+      expect(builder.stay.reload.total_amount_cents).to eq(hulotte_two_nights_cents + grande_salle_journee_cents)
+    end
+  end
+
+  describe "séjour « espaces seuls » (sans hébergement)" do
+    let(:spaces_only) { draft(lodging_id: nil, halls: [hall]) }
+
+    it "ne crée AUCUN Booking mais persiste le SpaceBooking en StayItem" do
+      builder = described_class.new(draft: spaces_only, admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      expect(builder.booking).to be_nil
+      sb = builder.space_booking
+      expect(sb).to be_persisted
+      expect(builder.stay.stay_items.map(&:bookable)).to eq([sb])
+      expect(builder.stay.total_amount_cents).to eq(grande_salle_journee_cents)
+      expect(builder.stay.arrival_date).to eq(arrival)
+      expect(builder.stay.departure_date).to eq(departure)
+    end
+
+    it "garde des agrégats corrects après recompute (dates non écrasées à nil)" do
+      builder = described_class.new(draft: spaces_only, admin: true, source: "manual")
+      builder.run
+      stay = builder.stay
+
+      stay.recompute_aggregates!
+      stay.reload
+      expect(stay.total_amount_cents).to eq(grande_salle_journee_cents)
+      expect(stay.arrival_date).to eq(arrival)
+      expect(stay.departure_date).to eq(departure)
+    end
+  end
+
+  describe "disponibilité capacity-aware des espaces" do
+    def occupy_grande_salle!(date)
+      sb = SpaceBooking.create!(firstname: "Occ", from_date: date, to_date: date, status: "confirmed")
+      sb.space_reservations.create!(space: grande_salle, date: date, duration: "journee")
+    end
+
+    it "bloque un espace déjà complet hors force" do
+      occupy_grande_salle!(arrival)
+      builder = described_class.new(draft: draft(lodging_id: nil, halls: [hall]), admin: true, source: "manual")
+
+      expect(builder.run).to be(false)
+      expect(builder.error_message).to match(/complet/i)
+      expect(Stay.count).to eq(0)
+    end
+
+    it "force la création avec un avertissement" do
+      occupy_grande_salle!(arrival)
+      builder = described_class.new(
+        draft: draft(lodging_id: nil, halls: [hall]), admin: true, source: "manual", skip_availability: true
+      )
+
+      expect(builder.run).to be(true)
+      expect(builder.availability_warning).to match(/forçant la disponibilité/i)
+      expect(builder.space_booking).to be_persisted
+    end
+  end
+end


### PR DESCRIPTION
## Epic #66 — Phase 4 : Calendrier basé sur les séjours

> Empilée sur la Phase 3 (#69). Base = `feature/issue-66-phase3-camping-repas`.

Le calendrier (`pages#calendar`, route racine) regroupe et **colore les occupations par séjour** (`stay_id`) au lieu de les traiter par booking/space_booking isolés.

### Livré
- **Regroupement par séjour** : `Booking`/`SpaceBooking` → `has_one :stay, through: :stay_item`. Préchargement anti-N+1 (`preload(booking: [..., :stay])`, `space_booking: [..., :stay]`, camping/van `includes(:stay)`). Blocs triés par `[stay_id, start_time]` → un même séjour est adjacent.
- **Un bloc par ressource occupée conservé** (chambre/lodging/espace) — pas de fusion DOM, c'est ce qui porte le veto.
- **Couleur stable par séjour** : teinte HSL dérivée de `stay_id` (angle d'or), en **style inline** (contourne le JIT Tailwind, aucune classe dynamique). Logique factorisée dans `CalendarHelper` + `calendar_block_class` sur les décorateurs.
- **Camping/van intégrés** : étalés par nuit, blocs agrégés « Camping »/« Van » colorés par séjour (`data-stay-id`). Repas non affichés (hors calendrier, conforme).
- **Hooks Phase 5 prêts** : `data-stay-id` sur chaque bloc ; lien actuel (`booking_path`/`space_booking_path`) conservé (Phase 5 basculera vers `stay_path` + `stay-details`).

### ⚠️ Veto Grand-Duc — inchangé
Les requêtes room-based et l'affichage par ressource sont conservés à l'identique ; seule la couleur d'accent passe du type au séjour. Un booking sans séjour retombe sur les couleurs historiques. Spec anti-régression incluse.

### Tests
`bundle exec rspec` → **566 examples, 0 failures, 18 pending** (+7). Nouveau `calendar_stays_grouping_spec.rb`.

### Hors périmètre / trous
Modale Phase 5 à câbler (hooks prêts) · camping/van non cliquables (pas de route admin — à décider en Phase 5) · vérif navigateur = passe groupée fin d'epic · `ISA.md` mis à jour en fin d'epic.

Refs #66
