### PR TITLE
Capacités camping/van configurables (issue #78)

### DIFF
--- a/app/models/camping_booking.rb
+++ b/app/models/camping_booking.rb
@@ -27,9 +27,11 @@
 class CampingBooking < ApplicationRecord
   include GlobalCapacityBookable
 
-  # Capacité totale du terrain de camping, en PERSONNES. Valeur par défaut
-  # provisoire — À AJUSTER par Michael selon la capacité réelle du domaine.
+  # Capacité totale du terrain de camping, en PERSONNES. DÉFAUT provisoire,
+  # surchargeable sans redéploiement via `Setting` (issue #78) sous la clé
+  # `CAPACITY_SETTING_KEY` — la constante reste la valeur de repli.
   TOTAL_CAPACITY = 30
+  CAPACITY_SETTING_KEY = "camping_total_capacity".freeze
 
   # Inverse de la relation StayItem (mêmes conventions que Booking/SpaceBooking).
   has_one :stay_item, as: :bookable

--- a/app/models/concerns/global_capacity_bookable.rb
+++ b/app/models/concerns/global_capacity_bookable.rb
@@ -23,6 +23,16 @@ module GlobalCapacityBookable
   end
 
   class_methods do
+    # Capacité totale effective du domaine pour ce réservable. Lue depuis la
+    # config (`Setting`) quand le modèle déclare une `CAPACITY_SETTING_KEY`
+    # (issue #78 : ajustable sans redéploiement), sinon la constante `TOTAL_CAPACITY`.
+    # Le défaut reste `TOTAL_CAPACITY` tant que le paramètre n'est pas renseigné.
+    def total_capacity
+      return self::TOTAL_CAPACITY unless const_defined?(:CAPACITY_SETTING_KEY)
+
+      Setting.integer(self::CAPACITY_SETTING_KEY, default: self::TOTAL_CAPACITY)
+    end
+
     # Unités déjà CONFIRMÉES pour la nuit `date`, en excluant éventuellement une
     # réservation donnée (utile à l'édition d'un réservable existant).
     def units_reserved_on(date, excluding_id: nil)
@@ -33,7 +43,7 @@ module GlobalCapacityBookable
 
     # Unités restantes pour la nuit `date`.
     def remaining_on(date, excluding_id: nil)
-      [self::TOTAL_CAPACITY - units_reserved_on(date, excluding_id: excluding_id), 0].max
+      [total_capacity - units_reserved_on(date, excluding_id: excluding_id), 0].max
     end
 
     # Première nuit en conflit de capacité pour une demande, ou nil si tout passe.
@@ -41,8 +51,9 @@ module GlobalCapacityBookable
     def capacity_conflict_date(units:, from:, to:, excluding_id: nil)
       return nil if units.to_i < 1 || from.blank? || to.blank?
 
+      cap = total_capacity
       (from...to).find do |date|
-        units_reserved_on(date, excluding_id: excluding_id) + units.to_i > self::TOTAL_CAPACITY
+        units_reserved_on(date, excluding_id: excluding_id) + units.to_i > cap
       end
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: settings
+#
+#  id         :bigint           not null, primary key
+#  key        :string           not null
+#  value      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Magasin clé/valeur pour les paramètres globaux du domaine ajustables SANS
+# redéploiement (issue #78). Chaque paramètre est une ligne `key`/`value` ;
+# absence de ligne = on retombe sur le défaut fourni par l'appelant. Les valeurs
+# sont stockées en texte et converties à la lecture (cf. `.integer`).
+#
+# Lecture typée :
+#   Setting.integer("camping_total_capacity", default: 30)
+# Écriture (console ou futur écran admin) :
+#   Setting.set("camping_total_capacity", 45)
+class Setting < ApplicationRecord
+  validates :key, presence: true, uniqueness: true
+
+  # Valeur brute (String) d'un paramètre, ou nil si absent.
+  def self.[](key)
+    find_by(key: key.to_s)&.value
+  end
+
+  # Valeur entière d'un paramètre, ou `default` si absent/illisible.
+  def self.integer(key, default: nil)
+    raw = self[key]
+    return default if raw.blank?
+
+    Integer(raw, exception: false) || default
+  end
+
+  # Crée ou met à jour un paramètre. Renvoie l'enregistrement.
+  def self.set(key, value)
+    record = find_or_initialize_by(key: key.to_s)
+    record.update!(value: value.to_s)
+    record
+  end
+end

--- a/app/models/van_booking.rb
+++ b/app/models/van_booking.rb
@@ -26,9 +26,11 @@
 class VanBooking < ApplicationRecord
   include GlobalCapacityBookable
 
-  # Capacité totale en VÉHICULES. Valeur par défaut provisoire — À AJUSTER par
-  # Michael selon le nombre réel de places véhicules du domaine.
+  # Capacité totale en VÉHICULES. DÉFAUT provisoire, surchargeable sans
+  # redéploiement via `Setting` (issue #78) sous la clé `CAPACITY_SETTING_KEY`
+  # — la constante reste la valeur de repli.
   TOTAL_CAPACITY = 5
+  CAPACITY_SETTING_KEY = "van_total_capacity".freeze
 
   has_one :stay_item, as: :bookable
   has_one :stay, through: :stay_item

--- a/db/migrate/20260719120000_create_settings.rb
+++ b/db/migrate/20260719120000_create_settings.rb
@@ -1,0 +1,16 @@
+class CreateSettings < ActiveRecord::Migration[7.0]
+  # Petit magasin clé/valeur pour les paramètres globaux du domaine ajustables
+  # SANS redéploiement (issue #78). Premier usage : les capacités globales
+  # camping (personnes) et van (véhicules), aujourd'hui figées en constantes.
+  # Table vide par défaut → chaque paramètre absent retombe sur son défaut code.
+  def change
+    create_table :settings do |t|
+      t.string :key, null: false
+      t.string :value
+
+      t.timestamps
+    end
+
+    add_index :settings, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_18_120000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_19_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -548,6 +548,14 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_18_120000) do
     t.datetime "updated_at", null: false
     t.integer "price_cents"
     t.index ["human_id"], name: "index_services_on_human_id"
+  end
+
+  create_table "settings", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_settings_on_key", unique: true
   end
 
   create_table "space_bookings", force: :cascade do |t|

--- a/spec/models/camping_booking_spec.rb
+++ b/spec/models/camping_booking_spec.rb
@@ -45,4 +45,20 @@ RSpec.describe CampingBooking do
       expect(described_class.capacity_conflict_date(units: 1, from: d0, to: d1, excluding_id: own.id)).to be_nil
     end
   end
+
+  describe ".total_capacity (configurable — issue #78)" do
+    it "vaut la constante par défaut sans config" do
+      expect(described_class.total_capacity).to eq(described_class::TOTAL_CAPACITY)
+    end
+
+    it "est surchargée par le Setting et ajuste le veto de capacité" do
+      Setting.set(described_class::CAPACITY_SETTING_KEY, described_class::TOTAL_CAPACITY + 10)
+      expect(described_class.total_capacity).to eq(described_class::TOTAL_CAPACITY + 10)
+
+      confirmed!(people: described_class::TOTAL_CAPACITY, from: d0, to: d1)
+      # +5 dépasserait l'ancien plafond mais tient sous le plafond surchargé.
+      expect(described_class.capacity_conflict_date(units: 5, from: d0, to: d1)).to be_nil
+      expect(described_class.remaining_on(d0)).to eq(10)
+    end
+  end
 end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+# Magasin clé/valeur des paramètres globaux ajustables sans redéploiement (issue #78).
+RSpec.describe Setting do
+  it "exige une clé unique" do
+    described_class.create!(key: "foo", value: "1")
+    expect(described_class.new(key: nil)).not_to be_valid
+    expect(described_class.new(key: "foo", value: "2")).not_to be_valid
+  end
+
+  describe ".[]" do
+    it "renvoie la valeur brute ou nil" do
+      described_class.create!(key: "foo", value: "bar")
+      expect(described_class["foo"]).to eq("bar")
+      expect(described_class["absent"]).to be_nil
+    end
+  end
+
+  describe ".integer" do
+    it "retombe sur le défaut quand absent ou illisible" do
+      expect(described_class.integer("absent", default: 42)).to eq(42)
+      described_class.set("bad", "pas-un-nombre")
+      expect(described_class.integer("bad", default: 7)).to eq(7)
+    end
+
+    it "convertit la valeur stockée en entier" do
+      described_class.set("n", 45)
+      expect(described_class.integer("n", default: 0)).to eq(45)
+    end
+  end
+
+  describe ".set" do
+    it "crée puis met à jour la même clé" do
+      described_class.set("k", 1)
+      described_class.set("k", 2)
+      expect(described_class.where(key: "k").count).to eq(1)
+      expect(described_class.integer("k", default: 0)).to eq(2)
+    end
+  end
+end

--- a/spec/models/van_booking_spec.rb
+++ b/spec/models/van_booking_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+# VanBooking : capacité GLOBALE en véhicules, configurable sans redéploiement (issue #78).
+RSpec.describe VanBooking do
+  let(:d0) { Date.today + 40 }
+  let(:d1) { d0 + 1 }
+
+  def confirmed!(vehicles:, from:, to:)
+    described_class.create!(firstname: "X", from_date: from, to_date: to, vehicles: vehicles, status: "confirmed")
+  end
+
+  describe ".total_capacity (configurable — issue #78)" do
+    it "vaut la constante par défaut sans config" do
+      expect(described_class.total_capacity).to eq(described_class::TOTAL_CAPACITY)
+    end
+
+    it "est surchargée par le Setting et ajuste le veto de capacité" do
+      Setting.set(described_class::CAPACITY_SETTING_KEY, described_class::TOTAL_CAPACITY + 3)
+      expect(described_class.total_capacity).to eq(described_class::TOTAL_CAPACITY + 3)
+
+      confirmed!(vehicles: described_class::TOTAL_CAPACITY, from: d0, to: d1)
+      expect(described_class.capacity_conflict_date(units: 3, from: d0, to: d1)).to be_nil
+      expect(described_class.remaining_on(d0)).to eq(3)
+    end
+
+    it "n'affecte pas la capacité camping (clé distincte)" do
+      Setting.set(described_class::CAPACITY_SETTING_KEY, 99)
+      expect(CampingBooking.total_capacity).to eq(CampingBooking::TOTAL_CAPACITY)
+    end
+  end
+end


### PR DESCRIPTION
Closes #78

## Résumé
Sort les capacités globales du terrain (`CampingBooking::TOTAL_CAPACITY = 30`, `VanBooking::TOTAL_CAPACITY = 5`) des constantes en dur vers une config éditable **sans redéploiement**.

- **`Setting`** — nouveau modèle clé/valeur (`key` unique, `value` texte) + migration `create_settings`. Lecture typée `Setting.integer(key, default:)`, écriture `Setting.set(key, value)`.
- **`GlobalCapacityBookable.total_capacity`** — lit `Setting` quand le modèle déclare `CAPACITY_SETTING_KEY`, sinon retombe sur `TOTAL_CAPACITY`. `remaining_on` et `capacity_conflict_date` utilisent désormais `total_capacity`.
- **`CampingBooking` / `VanBooking`** — déclarent `CAPACITY_SETTING_KEY` (`camping_total_capacity` / `van_total_capacity`). Constantes conservées comme **valeurs de repli**.

Ajustement en prod (sans redéploiement), via console :
```ruby
Setting.set("camping_total_capacity", 45)
Setting.set("van_total_capacity", 8)
```

## Critères d'acceptation
- [x] Mécanisme de config (modèle `Setting` clé/valeur + migration)
- [x] Le concern lit la capacité depuis la config
- [x] Défauts 30 pers / 5 véhicules conservés si config absente
- [ ] UI admin d'édition — **laissée en suivi** (marquée « optionnelle, si simple » dans l'issue). Édition possible via console/DB sans redéploiement, ce qui satisfait la DoD. Une PR ultérieure pourra ajouter un petit écran admin.
- [x] Specs : défaut sans config ; surcharge via config → veto de capacité ajusté

## Tests
- `bundle exec rspec` : **594 exemples, 0 échec** (18 pending préexistants).
- Nouveaux specs : `setting_spec.rb`, capacité configurable dans `camping_booking_spec.rb` + nouveau `van_booking_spec.rb` (défaut, surcharge, isolation des clés).

## Aperçu
Aucun rendu visible (migration + configuration backend) → pas de capture d'écran.

## À valider côté humain
- Choix du modèle `Setting` clé/valeur (vs ENV/credentials) — retenu car aucune config n'existait et l'édition à chaud était l'objectif.
- Opportunité d'un petit écran admin pour éditer ces deux valeurs (suivi).