### PR TITLE
Fiabiliser le mapping des espaces + remonter les non résolus (issue #75)

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -46,7 +46,7 @@ class StaysController < BaseController
 
     if builder.run
       flash[:notice] = "Séjour créé."
-      flash[:alert]  = builder.availability_warning if builder.availability_warning
+      flash[:alert]  = combined_warning(builder)
       redirect_to recent_stays_path
     else
       @stay  = Stay.new(status: requested_status.presence || "pending")
@@ -74,7 +74,7 @@ class StaysController < BaseController
 
     if updater.run
       flash[:notice] = "Séjour mis à jour."
-      flash[:alert]  = updater.availability_warning if updater.availability_warning
+      flash[:alert]  = combined_warning(updater)
       redirect_to recent_stays_path
     else
       @quote = safe_quote(@draft)
@@ -94,6 +94,12 @@ class StaysController < BaseController
 
   def set_stay
     @stay = Stay.find(params[:id])
+  end
+
+  # Concatène l'avertissement de disponibilité (force-dispo) et celui des espaces
+  # non enregistrables (issue #75), pour un flash unique. nil si aucun des deux.
+  def combined_warning(service)
+    [service.availability_warning, service.space_warning].compact.join(" ").presence
   end
 
   def set_accounting_view
@@ -247,16 +253,21 @@ class StaysController < BaseController
     return [] if space_booking.nil?
 
     space_booking.space_reservations.map do |res|
-      key = space_key_for_name(res.space&.name)
+      key = space_key_for(res.space)
       next if key.nil?
       { kind: key, date: res.date&.iso8601, period: res.duration }
     end.compact
   end
 
-  # Space#name → clé de pricing (inverse de SpaceComposition::SPACE_NAMES_BY_KEY).
-  def space_key_for_name(name)
-    return nil if name.blank?
-    SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(name) }&.first
+  # `Space` → clé de pricing (inverse du mapping SpaceComposition). Résolution par
+  # le `code` stable d'abord (issue #75), puis repli sur le nom d'affichage.
+  def space_key_for(space)
+    return nil if space.nil?
+
+    by_code = SpaceComposition::SPACE_CODES_BY_KEY.find { |_key, code| code == space.code }&.first
+    return by_code if by_code
+
+    SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(space.name) }&.first
   end
 
   # Coordonnées client : soit un client existant sélectionné (on lit ses

--- a/app/services/concerns/space_composition.rb
+++ b/app/services/concerns/space_composition.rb
@@ -11,24 +11,54 @@
 #   - le montant de l'espace vient du devis B2C (`PricingModel`, part `:space`),
 #     jamais recalculé ici.
 #
-# ⚠️ MAPPING clé de pricing → `Space` (à surveiller — voir gap connu) : le funnel
-# public price les espaces avec des clés forfaitaires (`grande_salle`, …) qui ne
-# correspondent pas 1:1 aux `Space.name` en base (seed : « Tilleul », « Saule »).
-# On résout donc par une LISTE de noms candidats par clé, tolérante aux deux
-# conventions (nom marketing OU nom du seed). Si aucune `Space` ne matche, la
-# ligne reste dans le devis mais n'est pas persistée (voir `unresolved_space_keys`).
+# MAPPING clé de pricing → `Space` (issue #75) : le funnel public price les
+# espaces avec des clés forfaitaires (`grande_salle`, …) qui ne correspondent pas
+# 1:1 aux `Space.name` en base (seed : « Tilleul », « Saule »). On résout en
+# PRIORITÉ par le `Space.code` — identifiant STABLE et insensible au renommage
+# d'affichage (seed : TIL/SAU/CUI) — puis, en repli tolérant, par une liste de
+# noms candidats. Si aucune `Space` ne matche, la ligne reste dans le devis mais
+# n'est PAS persistée : elle est alors remontée à l'admin (`unresolved_space_keys`
+# / `unresolved_space_warning`) au lieu d'être perdue silencieusement.
 module SpaceComposition
   extend ActiveSupport::Concern
 
-  # Noms de `Space` acceptés pour chaque clé de pricing, par ordre de préférence.
-  # Le premier trouvé en base gagne. Cf. `PricingModel::SPACE_NAMES`.
+  # Résolution PRIMAIRE : clé de pricing → `Space.code` (identifiant stable, seed
+  # `db/seeds.rb`). Insensible au renommage d'affichage des `Space`.
+  SPACE_CODES_BY_KEY = {
+    "grande_salle" => "TIL",
+    "petite_salle" => "SAU",
+    "cuisine_pro"  => "CUI"
+  }.freeze
+
+  # Repli TOLÉRANT si aucun `code` ne matche : noms de `Space` acceptés par clé,
+  # par ordre de préférence (le premier trouvé gagne). Cf. `PricingModel::SPACE_NAMES`.
   SPACE_NAMES_BY_KEY = {
     "grande_salle" => ["Grande Salle", "Tilleul"],
     "petite_salle" => ["Petite Salle", "Saule"],
     "cuisine_pro"  => ["Cuisine professionnelle", "Cuisine pro"]
   }.freeze
 
+  # Libellés lisibles par clé, pour la remontée d'avertissement à l'admin.
+  SPACE_LABELS_BY_KEY = {
+    "grande_salle" => "Grande salle",
+    "petite_salle" => "Petite salle",
+    "cuisine_pro"  => "Cuisine professionnelle"
+  }.freeze
+
   private
+
+  # Avertissement (String) listant les espaces DEVISÉS mais NON persistables
+  # (aucune `Space` correspondante), ou nil si tout est résolu. Sert au contrôleur
+  # admin à ne jamais perdre un espace en silence.
+  def unresolved_space_warning(draft)
+    keys = unresolved_space_keys(draft)
+    return nil if keys.empty?
+
+    labels = keys.map { |k| SPACE_LABELS_BY_KEY[k] || k }
+    "Espace(s) non enregistrable(s) — aucune salle correspondante en base : " \
+      "#{labels.join(', ')}. Ils figurent au devis mais N'ONT PAS été réservés " \
+      "(vérifier le paramétrage des espaces)."
+  end
 
   # Le draft porte-t-il au moins un espace exploitable (résolu ou non) ?
   # Sert au gate « contenu réservable » (un séjour peut être espaces-seuls).
@@ -136,9 +166,19 @@ module SpaceComposition
     @space_by_key ||= {}
     return @space_by_key[key.to_s] if @space_by_key.key?(key.to_s)
 
-    names = SPACE_NAMES_BY_KEY[key.to_s]
-    space = names && Space.where(name: names).min_by { |s| names.index(s.name) || 99 }
-    @space_by_key[key.to_s] = space
+    @space_by_key[key.to_s] = resolve_space_for_key(key.to_s)
+  end
+
+  # Résolution en deux temps : d'abord le `Space.code` stable (insensible au
+  # renommage), sinon repli sur la liste de noms candidats.
+  def resolve_space_for_key(key)
+    if (code = SPACE_CODES_BY_KEY[key]).present?
+      by_code = Space.find_by(code: code)
+      return by_code if by_code
+    end
+
+    names = SPACE_NAMES_BY_KEY[key]
+    names && Space.where(name: names).min_by { |s| names.index(s.name) || 99 }
   end
 
   def parse_space_date(value)

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -28,7 +28,8 @@ module Reservations
     class DraftInvalid < StandardError; end
 
     attr_reader :draft, :stay, :customer, :booking, :space_booking,
-                :camping_booking, :van_booking, :payment, :availability_warning
+                :camping_booking, :van_booking, :payment, :availability_warning,
+                :space_warning
 
     # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
     # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
@@ -137,6 +138,9 @@ module Reservations
         # le solde se règle après coup depuis la page client /sejour/:token.
         @payment = build_payment!(quote) unless @admin
       end
+      # Espaces DEVISÉS mais non persistables (aucune `Space` correspondante) :
+      # on ne les perd pas en silence — le contrôleur admin remonte l'avertissement.
+      @space_warning = unresolved_space_warning(draft)
       true
     end
 

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -27,7 +27,7 @@ module Stays
 
     class Invalid < StandardError; end
 
-    attr_reader :stay, :availability_warning
+    attr_reader :stay, :availability_warning, :space_warning
 
     def initialize(stay:, draft:, status: nil, skip_availability: false, user: nil)
       @stay = stay
@@ -62,6 +62,9 @@ module Stays
         reconcile_experiences!
         @stay.recompute_aggregates!
       end
+      # Espaces DEVISÉS mais non persistables (aucune `Space` correspondante) :
+      # remontés à l'admin plutôt que perdus en silence (issue #75).
+      @space_warning = unresolved_space_warning(@draft)
       true
     end
 

--- a/spec/requests/stays_admin_unresolved_spaces_spec.rb
+++ b/spec/requests/stays_admin_unresolved_spaces_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+# Issue #75 — fiabiliser le mapping clé↔`Space` et ne JAMAIS perdre en silence un
+# espace devisé mais non persistable. Deux garanties :
+#   1. un espace dont la clé ne matche aucune `Space` → warning remonté (flash),
+#      pas de SpaceBooking fantôme ;
+#   2. la résolution s'appuie sur le `Space.code` STABLE, insensible au renommage
+#      de l'affichage.
+RSpec.describe "Stays — espaces non résolus & mapping stable (issue #75)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-unresolved@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:lodging) { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  def hall_param(kind:, period: "journee")
+    { "0" => { kind: kind, date: arrival.iso8601, period: period } }
+  end
+
+  describe "espace non résolu (aucune Space correspondante)" do
+    it "crée le séjour, ne persiste PAS de SpaceBooking et remonte un warning" do
+      # Aucune Space "Cuisine professionnelle"/code CUI en base.
+      expect(Space.find_by(code: "CUI")).to be_nil
+
+      expect {
+        post stays_path, params: base_params(halls: hall_param(kind: "cuisine_pro"))
+      }.to change(Stay, :count).by(1)
+       .and change(SpaceBooking, :count).by(0)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to match(/non enregistrable/i)
+      expect(flash[:alert]).to include("Cuisine professionnelle")
+    end
+  end
+
+  describe "espace résolu → persisté, pas de warning" do
+    it "persiste le SpaceBooking et ne remonte aucun warning d'espace" do
+      Space.create!(name: "Grande Salle", capacity: 1)
+
+      expect {
+        post stays_path, params: base_params(halls: hall_param(kind: "grande_salle"))
+      }.to change(SpaceBooking, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to be_blank
+    end
+  end
+
+  describe "résolution par le code stable (renommage de l'affichage)" do
+    it "résout grande_salle via Space.code même si le nom a changé" do
+      # Nom d'affichage renommé, HORS de la liste de noms candidats, mais code stable.
+      renamed = Space.create!(name: "Salle du Tilleul rénovée", code: "TIL", capacity: 1)
+
+      post stays_path, params: base_params(lodging_id: "", halls: hall_param(kind: "grande_salle"))
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay = Stay.order(:created_at).last
+      sb = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+      expect(sb).to be_present
+      expect(sb.space_reservations.map(&:space)).to eq([renamed])
+      expect(flash[:alert]).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
Closes #75

## Résumé
Fin de la **perte silencieuse d'espaces** : un espace devisé mais sans `Space` correspondante en base était compté dans le devis puis **jamais persisté**, sans aucun signal. Désormais il est **remonté à l'admin**, et le mapping clé↔`Space` s'appuie sur un **identifiant stable**.

- **Résolution par `Space.code` stable** (`grande_salle→TIL`, `petite_salle→SAU`, `cuisine_pro→CUI`, seed `db/seeds.rb`) en priorité, **repli** tolérant sur la liste de noms candidats. Insensible au renommage d'affichage des salles.
- **`unresolved_space_warning`** (concern `SpaceComposition`) exposé par `Reservations::Builder#space_warning` et `Stays::AdminUpdater#space_warning`.
- **`StaysController`** remonte l'avertissement en `flash[:alert]` au `create` **et** à l'`update`, concaténé avec l'avertissement force-dispo existant (`combined_warning`).
- **Mapping inverse** (préremplissage du form d'édition) fiabilisé par le `code` également.

## Critères d'acceptation
- [x] Espaces non résolus remontés à l'admin (flash explicite) au lieu d'être perdus
- [x] Mapping basé sur un identifiant stable (`Space.code`) plutôt que le nom d'affichage
- [x] Cohérence devis/persistance : tout espace devisé est soit persisté, soit signalé
- [x] Spec : clé non résolue → warning, pas de SpaceBooking ; clé résolue → persisté

## Tests
- `bundle exec rspec` : **587 exemples, 0 échec** (18 pending préexistants).
- Nouveau `spec/requests/stays_admin_unresolved_spaces_spec.rb` : (1) `cuisine_pro` sans Space → warning + aucun SpaceBooking ; (2) espace résolu → persisté, pas de warning ; (3) résolution par `code` malgré un nom renommé hors liste. `stays_admin_spaces_spec` (rétrocompat) reste vert.

## Aperçu
Le seul rendu visible est un **flash `alert`** réutilisant le partial de flash existant, déclenché par un cas limite (espace non mappé) qui exige des données de seed + une session authentifiée difficiles à reproduire en headless — pas de nouveau composant UI. Pas de capture dédiée ; le comportement est couvert par le request spec ci-dessus.

## À valider côté humain
- Vérifier que les `Space` de **prod** portent bien les codes `TIL`/`SAU`/`CUI` (sinon la résolution retombe sur les noms — toujours fonctionnelle, mais le code est l'identifiant robuste recommandé). Le warning signalera tout espace non mappé.