### PR TITLE
Funnel public — persister camping/van/repas à total constant (issue #79)

### DIFF
--- a/app/decorators/stay_decorator.rb
+++ b/app/decorators/stay_decorator.rb
@@ -94,17 +94,29 @@ class StayDecorator < ApplicationDecorator
   # Lignes du séjour-composite : un réservable (Booking / SpaceBooking) par ligne,
   # avec ses dates et son montant. Alimente la page client /sejour/:token.
   def item_lines
-    object.stay_items.map do |item|
+    lines = object.stay_items.map do |item|
       bookable = item.bookable
       next if bookable.nil?
 
       {
         kind: item.bookable_type,
         name: item_label(bookable),
-        date_range: bookable.decorate.try(:date_range),
+        date_range: bookable_date_range(bookable),
         amount: h.humanized_money_with_symbol(Money.new(bookable.try(:price_cents).to_i))
       }
     end.compact
+
+    # Repas (issue #79) : ce ne sont PAS des `stay_items` (has_many direct), mais
+    # ils comptent dans le total — on les ajoute aux lignes pour que la
+    # décomposition somme bien au total affiché (aucun écart lignes ≠ total).
+    lines + object.meal_orders.map do |meal|
+      {
+        kind: "MealOrder",
+        name: meal_line_label(meal),
+        date_range: meal.date.present? ? h.l(meal.date, format: :long) : nil,
+        amount: h.humanized_money_with_symbol(Money.new(meal.price_cents.to_i))
+      }
+    end
   end
 
   # Total formaté pour la page client. Volontairement PAS nommé `total_amount` :
@@ -136,9 +148,31 @@ class StayDecorator < ApplicationDecorator
     when SpaceBooking
       spaces = bookable.try(:spaces)&.map(&:name)&.compact_blank
       spaces.presence&.join(", ") || h.t("public.stays.items.space")
+    when CampingBooking
+      h.t("public.stays.items.camping")
+    when VanBooking
+      h.t("public.stays.items.van")
     else
       h.t("public.stays.items.other")
     end
+  end
+
+  # Libellé d'une ligne repas (ex. « Repas — Buffet pain-fromages »).
+  def meal_line_label(meal)
+    "#{h.t('public.stays.items.meal')} — #{meal.label}"
+  end
+
+  # Plage de dates d'un bookable pour la page client. Utilise son décorateur
+  # dédié quand il existe (Booking/SpaceBooking) ; à défaut (CampingBooking /
+  # VanBooking, sans décorateur), dérive directement de from/to_date (issue #79).
+  def bookable_date_range(bookable)
+    bookable.decorate.try(:date_range)
+  rescue Draper::UninferrableDecoratorError
+    from = bookable.try(:from_date)
+    to   = bookable.try(:to_date)
+    return nil if from.blank? && to.blank?
+
+    "#{from.present? ? h.l(from, format: :long) : '?'} → #{to.present? ? h.l(to, format: :long) : '?'}"
   end
 
   # Nom/prénom + nom de groupe issus du booking sous-jacent.

--- a/app/services/concerns/camping_composition.rb
+++ b/app/services/concerns/camping_composition.rb
@@ -28,6 +28,30 @@ module CampingComposition
     draft_camping_people(draft).positive?
   end
 
+  # Occupation SIMULTANÉE (pic) de personnes camping — valeur à PERSISTER sur le
+  # `CampingBooking`, qui couvre toute la fenêtre en UN enregistrement. Les deux
+  # représentations du draft convergent : admin = une entrée `{people, nights}`,
+  # public = une entrée `{people, nights: 1}` par nuit (issue #79). Le pic = max
+  # des `people` par entrée — cohérent avec le prix (people × nuits == person-nuits
+  # facturées) sur le cas uniforme, et identique à la valeur admin actuelle.
+  def draft_camping_peak_people(draft)
+    Array(draft.campings).map { |e| symbol(e)[:people].to_i }.max.to_i
+  end
+
+  # Véhicules SIMULTANÉS (pic) à persister sur le `VanBooking`. Admin encode N
+  # véhicules en N entrées couvrant toute la fenêtre (`nights == window`) ; le
+  # public encode la présence par nuit en 1 entrée `{nights: 1}` par nuit (issue
+  # #79, où le funnel plafonne de fait à un van). Le pic = nombre d'entrées
+  # couvrant la fenêtre entière (admin) ; à défaut (public), 1.
+  def draft_van_peak_vehicles(draft)
+    entries = Array(draft.vans).map { |e| symbol(e) }
+    return 0 if entries.empty?
+
+    window   = [draft.nights, 1].max
+    spanning = entries.count { |e| e[:nights].to_i >= window }
+    spanning.positive? ? spanning : 1
+  end
+
   # Nombre de véhicules demandés — une entrée `vans` = un véhicule (contrat
   # PricingModel : `van_lines` produit une ligne par entrée).
   def draft_van_vehicles(draft)
@@ -82,7 +106,7 @@ module CampingComposition
       group_name:  draft.group_name,
       from_date:   draft.arrival_date,
       to_date:     draft.departure_date,
-      people:      [draft_camping_people(draft), 1].max,
+      people:      [draft_camping_peak_people(draft), 1].max,
       kind:        "tente",
       status:      status,
       price_cents: price_cents
@@ -105,7 +129,7 @@ module CampingComposition
       group_name:  draft.group_name,
       from_date:   draft.arrival_date,
       to_date:     draft.departure_date,
-      vehicles:    [draft_van_vehicles(draft), 1].max,
+      vehicles:    [draft_van_peak_vehicles(draft), 1].max,
       status:      status,
       price_cents: price_cents
     )

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -111,16 +111,15 @@ module Reservations
         # « espaces seuls »). Sa part de prix vient du devis (`spaces_cents`) —
         # l'hébergement porte `lodging_bundle_cents`, donc aucun double-compte.
         @space_booking = build_space_booking_for!(@stay, quote)
-        # Camping / van / repas (epic #66, Phase 3) — PERSISTÉS UNIQUEMENT côté
-        # admin. Le funnel public reste devis-only pour ces éléments (leur montant
-        # est noyé dans `lodging_bundle_cents` du Booking, comportement historique
-        # inchangé). Côté admin, chacun devient son propre modèle et le Booking
-        # d'hébergement porte `lodging_only_cents` (extraction sans double-compte).
-        if @admin
-          @camping_booking = build_camping_booking_for!(@stay, quote)
-          @van_booking     = build_van_booking_for!(@stay, quote)
-          create_meal_orders!(@stay, draft)
-        end
+        # Camping / van / repas (epic #66, Phase 3 ; alignement public issue #79) —
+        # PERSISTÉS DANS TOUS LES CANAUX. Chacun devient son propre modèle et le
+        # Booking d'hébergement porte `lodging_only_cents` (extraction SANS
+        # double-compte, cf. `lodging_price_cents`). Ce n'est qu'une RE-VENTILATION :
+        # le TOTAL du séjour et l'ACOMPTE restent identiques à avant (invariant #79),
+        # car ils dérivent du devis (`quote`), inchangé par cette ventilation.
+        @camping_booking = build_camping_booking_for!(@stay, quote)
+        @van_booking     = build_van_booking_for!(@stay, quote)
+        create_meal_orders!(@stay, draft)
         # Sélections d'activités du funnel (epic #55, Phase 4) : chaque créneau
         # choisi devient un ExperienceBooking `pending` rattaché au Stay — de la
         # MÊME nature que ceux du rail email, donc soumis à la validation porteur.
@@ -308,13 +307,10 @@ module Reservations
         payment_status: "pending",
         platform: "web",
         lodging_id: draft.lodging_id,
-        # Prix de l'occupation d'hébergement (epic #66, Phase 3) :
-        #   - Canal ADMIN → `lodging_only_cents` : hébergement PUR (camping / van /
-        #     repas sont extraits sur leurs propres modèles). Invariant admin :
-        #     Booking + SpaceBooking + CampingBooking + VanBooking + MealOrder(s)
-        #     + ExperienceBooking(s) == total du séjour.
-        #   - Canal PUBLIC → `lodging_bundle_cents` : comportement historique
-        #     INCHANGÉ (camping / van / repas noyés dans le Booking, devis-only).
+        # Prix de l'occupation d'hébergement = hébergement PUR (`lodging_only_cents`),
+        # dans TOUS les canaux (issue #79) : camping / van / repas sont extraits sur
+        # leurs propres modèles. Invariant : Booking + SpaceBooking + CampingBooking
+        # + VanBooking + MealOrder(s) + ExperienceBooking(s) == total du séjour.
         price_cents: lodging_price_cents(quote),
         shown_price_cents: lodging_price_cents(quote)
       )
@@ -343,10 +339,10 @@ module Reservations
       @booking.save!
     end
 
-    # Part de prix portée par le Booking d'hébergement selon le canal (voir
-    # `build_booking!`). Admin : hébergement pur ; public : bundle historique.
+    # Part de prix portée par le Booking d'hébergement : hébergement PUR dans tous
+    # les canaux (issue #79) — camping/van/repas vivent sur leurs propres modèles.
     def lodging_price_cents(quote)
-      @admin ? quote.lodging_only_cents : quote.lodging_bundle_cents
+      quote.lodging_only_cents
     end
 
     def build_payment!(quote)

--- a/config/locales/public.en.yml
+++ b/config/locales/public.en.yml
@@ -18,6 +18,9 @@ en:
       items:
         lodging: "Accommodation"
         space: "Space"
+        camping: "Camping"
+        van: "Van / campervan"
+        meal: "Meal"
         other: "Service"
       payment_status:
         pending: "Awaiting payment"

--- a/config/locales/public.fr.yml
+++ b/config/locales/public.fr.yml
@@ -14,6 +14,9 @@ fr:
       items:
         lodging: "Hébergement"
         space: "Espace"
+        camping: "Camping"
+        van: "Van / camping-car"
+        meal: "Repas"
         other: "Prestation"
       payment_status:
         pending: "En attente de paiement"

--- a/config/locales/public.nl.yml
+++ b/config/locales/public.nl.yml
@@ -18,6 +18,9 @@ nl:
       items:
         lodging: "Verblijf"
         space: "Ruimte"
+        camping: "Camping"
+        van: "Camper"
+        meal: "Maaltijd"
         other: "Dienst"
       payment_status:
         pending: "In afwachting van betaling"

--- a/spec/requests/public/stays_spec.rb
+++ b/spec/requests/public/stays_spec.rb
@@ -101,4 +101,24 @@ RSpec.describe "Public::Stays (/sejour/:token)", type: :request do
       expect(response.body).to include(I18n.t("public.stays.balance.experiences_confirmed"))
     end
   end
+
+  # Issue #79 — le funnel public persiste camping/van/repas : la page /sejour doit
+  # les afficher en lignes distinctes (repas inclus, bien que non `stay_items`) et
+  # rester cohérente (décomposition qui somme au total).
+  describe "GET /sejour/:token — composition camping + repas (issue #79)" do
+    it "affiche les lignes camping et repas" do
+      camping = CampingBooking.create!(firstname: "Alex", from_date: Date.today + 10,
+                                       to_date: Date.today + 12, people: 3, status: "pending",
+                                       kind: "tente", price_cents: 4_500)
+      stay.stay_items.create!(bookable: camping)
+      stay.meal_orders.create!(kind: "buffet", people: 4, price_cents: 4_800) # sans date
+      stay.update!(total_amount_cents: 48_500 + 4_500 + 4_800)
+
+      get "/sejour/#{stay.token}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(I18n.t("public.stays.items.camping"))
+      expect(response.body).to include(I18n.t("public.stays.items.meal"))
+    end
+  end
 end

--- a/spec/services/reservations/builder_camping_spec.rb
+++ b/spec/services/reservations/builder_camping_spec.rb
@@ -181,23 +181,27 @@ RSpec.describe Reservations::Builder, "camping / van / repas (epic #66, Phase 3)
     end
   end
 
-  describe "funnel public inchangé (camping/van/repas devis-only)" do
-    it "ne persiste NI CampingBooking NI VanBooking NI MealOrder" do
+  describe "funnel public — persistance camping/repas à total constant (issue #79)" do
+    it "persiste CampingBooking + MealOrder et re-ventile SANS changer le total" do
       d = draft(
         lodging_id: hulotte.id,
         campings: [{ kind: "tente", people: 3, nights: 2 }],
         meals:    [{ kind: "buffet", people: 4 }]
       )
-      builder = described_class.new(draft: d) # PAS admin
+      builder = described_class.new(draft: d) # PAS admin (funnel public)
       expect(builder.run).to be(true)
 
-      expect(CampingBooking.count).to eq(0)
-      expect(VanBooking.count).to eq(0)
-      expect(builder.stay.meal_orders).to be_empty
-      # Le Booking public porte encore le bundle (camping + repas noyés).
-      # Total prévu = 74 500 (héberg) + 4 500 (camping) + 4 800 (repas) = 83 800 c.
+      # Camping / repas désormais persistés (comme le canal admin).
+      expect(CampingBooking.count).to eq(1)
+      expect(builder.stay.meal_orders.count).to eq(1)
+      expect(builder.camping_booking.people).to eq(3)   # 3 pers (camping 4 500 c)
+      expect(builder.camping_booking.price_cents).to eq(4_500)
+      expect(builder.stay.meal_orders.first.price_cents).to eq(4_800)
+
+      # INVARIANT #79 : total prévu STRICTEMENT inchangé = 74 500 + 4 500 + 4 800.
       expect(builder.stay.total_amount_cents).to eq(83_800)
-      expect(builder.booking.price_cents).to eq(83_800)
+      # Le Booking ne porte plus que l'hébergement PUR (extraction sans double-compte).
+      expect(builder.booking.price_cents).to eq(74_500)
     end
   end
 end

--- a/spec/services/reservations/builder_spec.rb
+++ b/spec/services/reservations/builder_spec.rb
@@ -49,13 +49,15 @@ RSpec.describe Reservations::Builder do
         draft(lodging_id: nil, per_night_resources: { "tente" => ["2", "2"] })
       end
 
-      it "ne crée AUCUN Booking" do
+      it "ne crée AUCUN Booking d'hébergement (le camping est persisté à part)" do
         builder = described_class.new(draft: camping_draft)
         expect(builder.run).to be(true)
 
+        # Aucun Booking d'hébergement (le « Booking fantôme » ne réapparaît pas)…
         expect(builder.booking).to be_nil
-        expect(builder.stay.stay_items).to be_empty
-        expect(builder.stay.bookables).to be_empty
+        expect(builder.stay.stay_items.where(bookable_type: "Booking")).to be_empty
+        # …mais le camping public est désormais persisté sur son propre modèle (issue #79).
+        expect(builder.stay.stay_items.where(bookable_type: "CampingBooking").count).to eq(1)
       end
 
       it "rattache quand même le paiement au Stay" do

--- a/spec/services/reservations/public_persist_invariant_spec.rb
+++ b/spec/services/reservations/public_persist_invariant_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+# Issue #79 — le funnel PUBLIC persiste désormais camping / van / repas sur leurs
+# propres modèles (comme le canal admin). C'est une RE-VENTILATION : le TOTAL du
+# séjour et l'ACOMPTE doivent rester STRICTEMENT identiques — seul le Booking
+# passe de `lodging_bundle_cents` à `lodging_only_cents`, le reste vivant sur
+# CampingBooking / VanBooking / MealOrder.
+RSpec.describe Reservations::Builder, "funnel public — persistance à total constant (issue #79)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 } # 2 nuits
+
+  # Draft PUBLIC : camping par-nuit (per_night_resources) + repas sans date.
+  let(:draft) do
+    Reservations::Draft.new(
+      lodging_id: hulotte.id,
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233",
+      per_night_resources: { "tente" => ["2", "2"] }, # 2 pers, 2 nuits
+      meals: [{ kind: "buffet", people: 3 }]           # public : sans date
+    )
+  end
+
+  # Valeurs de RÉFÉRENCE issues du devis (source unique, inchangée par la
+  # ventilation) = ce que le total et l'acompte valaient AVANT le changement.
+  let(:quote) { draft.quote }
+
+  it "persiste camping + repas SANS changer le total ni l'acompte" do
+    builder = described_class.new(draft: draft) # admin: false (funnel public)
+    expect(builder.run).to be(true)
+
+    stay = builder.stay
+
+    # INVARIANT #79 : total et acompte strictement inchangés (== devis).
+    expect(stay.total_amount_cents).to eq(quote.total_excluding_experiences_cents)
+    expect(builder.payment.amount_cents).to eq(quote.deposit_cents)
+
+    # Camping / repas désormais PERSISTÉS (avant : noyés dans le Booking).
+    camping = stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
+    expect(camping).to be_present
+    expect(camping.people).to eq(2)                 # pic simultané, pas 2+2
+    expect(camping.price_cents).to eq(quote.camping_cents)
+    expect(camping.price_cents).to eq(750 * 2 * 2)  # 7,50 € × 2 pers × 2 nuits
+
+    meal = stay.meal_orders.first
+    expect(meal).to be_present
+    expect(meal.date).to be_nil                     # repas public sans date (nullable)
+    expect(meal.price_cents).to eq(quote.meals_cents)
+
+    # Le Booking d'hébergement porte l'hébergement PUR (extraction sans double-compte).
+    booking = stay.stay_items.where(bookable_type: "Booking").first.bookable
+    expect(booking.price_cents).to eq(quote.lodging_only_cents)
+
+    # Ventilation exhaustive : la somme des parts redonne exactement le total.
+    parts = booking.price_cents + camping.price_cents + stay.meal_orders.sum(:price_cents)
+    expect(parts).to eq(stay.total_amount_cents)
+  end
+
+  it "ne modifie PAS un séjour public sans camping/van/repas (lodging_only == bundle)" do
+    plain = Reservations::Draft.new(
+      lodging_id: hulotte.id, arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    )
+    builder = described_class.new(draft: plain)
+    expect(builder.run).to be(true)
+
+    booking = builder.stay.stay_items.where(bookable_type: "Booking").first.bookable
+    # Sans camping/van/repas, lodging_only == lodging_bundle → Booking inchangé.
+    expect(booking.price_cents).to eq(plain.quote.lodging_bundle_cents)
+    expect(builder.stay.total_amount_cents).to eq(plain.quote.total_excluding_experiences_cents)
+    expect(CampingBooking.count).to eq(0)
+    expect(MealOrder.count).to eq(0)
+  end
+end


### PR DESCRIPTION
Closes #79

## Résumé
Le funnel **public natif** persiste désormais camping / van / repas sur leurs propres modèles (`CampingBooking` / `VanBooking` / `MealOrder`), comme le canal admin — au lieu de les noyer dans `lodging_bundle_cents` du `Booking`.

## ⚠️ Invariant critique respecté
**Le TOTAL et l'ACOMPTE ne changent PAS d'un centime.** Ils dérivent du devis (`quote`), inchangé par cette ventilation. Seul le `Booking` passe de `lodging_bundle_cents` à `lodging_only_cents` ; camping/van/repas portent leur part (`camping_cents` / `van_cents` / `meals_cents`), sans double-compte. **Prouvé en spec.**

## Détails
- **Builder** : retrait de la garde `if @admin` autour de `build_camping_booking_for!` / `build_van_booking_for!` / `create_meal_orders!` — persistés dans tous les canaux. `lodging_price_cents` renvoie `lodging_only_cents` partout.
- **Pic simultané** (`draft_camping_peak_people` / `draft_van_peak_vehicles`) : la forme publique « par nuit » (`per_night_resources`) ne gonfle plus les compteurs `people`/`vehicles` persistés (2 pers × 2 nuits ≠ 4 pers). Valeurs **identiques** au canal admin (zéro régression admin) — important pour le veto de capacité (#78).
- **Page `/sejour/:token`** (effet de bord évité, cf. AC) : `item_lines` inclut désormais les repas (qui ne sont pas des `stay_items`) et libelle camping/van/repas au lieu de « Prestation » ; `bookable_date_range` devient robuste sans décorateur dédié (corrige un bug latent : `CampingBooking#decorate` levait `Draper::UninferrableDecoratorError`). La décomposition somme bien au total.
- **`MealOrder.date`** déjà nullable → repas publics sans date tolérés.
- i18n `camping`/`van`/`meal` ajoutés en FR/EN/NL.

## Hors périmètre (noté)
- Migration des séjours publics **déjà créés** (explicitement hors périmètre).
- Le funnel public ne pose toujours **pas** de veto de capacité camping/van à la création (comportement historique — c'était déjà le cas, aucun record n'existait). À traiter séparément si souhaité.

## Critères d'acceptation
- [x] Builder crée camping/van/repas aussi quand `admin: false`
- [x] Booking public → `lodging_only_cents` ; total ET acompte identiques (invariant prouvé)
- [x] `MealOrder.date` nullable toléré
- [x] Aucun effet de bord sur le paiement Stripe public ni la page `/sejour/:token`
- [x] Aucune régression des specs funnel public

## Tests
- `bundle exec rspec` : **587 exemples, 0 échec** (18 pending préexistants).
- Nouveau `spec/services/reservations/public_persist_invariant_spec.rb` : total == `quote.total_excluding_experiences_cents`, acompte == `quote.deposit_cents`, camping/repas persistés, `people == 2` (pic), Booking == `lodging_only_cents`, somme des parts == total ; + cas sans camping (Booking inchangé).
- Specs mises à jour (`builder_camping_spec`, `builder_spec`) : elles asseyaient l'ancien « devis-only » public → réécrites vers la persistance à total constant.
- Nouveau cas dans `spec/requests/public/stays_spec.rb` : la page `/sejour` affiche les lignes camping + repas.

## 📸 Aperçu
Page `/sejour/:token` d'un séjour public hébergement + camping + repas (total cohérent, lignes distinctes) :

![Page /sejour — hébergement + camping + repas (issue #79)](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260719-034959-page-sejour--hbergement--camping--repas-issue-79.png)

## À valider côté humain
- Confirmer qu'on veut bien voir camping/van/repas détaillés sur la page client `/sejour` (avant : une seule ligne hébergement au montant bundle).