### PR TITLE
Séjour admin — autocomplete client dans le form (issue #74)

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -103,7 +103,10 @@ class StaysController < BaseController
   # Données partagées par les vues new/edit.
   def prepare_form
     @lodgings  = bookable_lodgings
-    @customers = Customer.order(:organization_name, :last_name, :first_name).limit(1_000)
+    # Client existant : autocomplete via `customers/search` (issue #74). On ne
+    # précharge plus TOUS les clients — seul le client courant (édition) alimente
+    # le `<select>` de repli sans-JS. La recherche dynamique fait le reste.
+    @customers = Customer.where(id: @stay&.customer_id).to_a
     @assignable_availabilities = ExperienceAvailability.for_user(current_user)
                                                        .upcoming
                                                        .includes(:experience)

--- a/app/frontend/controllers/customer_search_controller.js
+++ b/app/frontend/controllers/customer_search_controller.js
@@ -1,0 +1,115 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Autocomplete « Client existant » du form Séjour admin (issue #74). Remplace le
+// <select> listant tous les clients par une recherche dynamique sur
+// customers/search (fetch JSON, debounce ~250 ms). La source de vérité reste le
+// <select name="stay[customer_id]"> (toujours soumis) : le contrôleur le masque
+// quand JS est actif et pilote sa valeur à la sélection. Sans JS, le <select>
+// (réduit au client courant) reste utilisable — dégradation gracieuse.
+//
+// Usage (dans stays/_form) :
+//   div(data-controller="customer-search" data-customer-search-url-value="<%= search_customers_path %>")
+//     select[name="stay[customer_id]"] (data-customer-search-target="select")
+//     div(data-customer-search-target="searchWrap")
+//       input(data-customer-search-target="searchInput" data-action="input->customer-search#search")
+//       div(data-customer-search-target="results")
+//     div(data-customer-search-target="chosen")
+//       span(data-customer-search-target="chosenLabel")
+//       button(data-action="customer-search#clear")
+export default class extends Controller {
+  static targets = ["select", "searchWrap", "searchInput", "results", "chosen", "chosenLabel"]
+  static values = { url: String }
+
+  connect() {
+    // JS actif : on masque le <select> de repli et on montre la recherche.
+    this.selectTarget.classList.add("hidden")
+    if (this.selectTarget.value) {
+      // Édition : un client est déjà sélectionné → afficher son libellé.
+      this.showChosen(this.selectedLabel())
+    } else {
+      this.showSearch()
+    }
+  }
+
+  search() {
+    clearTimeout(this._timer)
+    const q = this.searchInputTarget.value.trim()
+    if (q.length < 2) {
+      this.resultsTarget.innerHTML = ""
+      return
+    }
+    this._timer = setTimeout(() => this.runSearch(q), 250)
+  }
+
+  async runSearch(q) {
+    try {
+      const response = await fetch(`${this.urlValue}?q=${encodeURIComponent(q)}`, {
+        headers: { Accept: "application/json" },
+      })
+      this.renderResults(await response.json())
+    } catch (_e) {
+      this.resultsTarget.innerHTML = ""
+    }
+  }
+
+  renderResults(customers) {
+    if (!customers.length) {
+      this.resultsTarget.innerHTML = '<div class="px-3 py-2 text-sm text-gray-500">Aucun client trouvé.</div>'
+      return
+    }
+    this.resultsTarget.innerHTML = customers
+      .map(
+        (c) =>
+          `<button type="button" data-action="customer-search#pick" data-id="${c.id}" data-label="${this.escape(c.name || c.email)}" class="block w-full text-left px-3 py-2 text-sm hover:bg-indigo-50">${this.escape(c.name || "")} <span class="text-gray-400">${this.escape(c.email || "")}</span></button>`
+      )
+      .join("")
+  }
+
+  pick(event) {
+    const { id, label } = event.currentTarget.dataset
+    this.setSelectValue(id, label)
+    this.showChosen(label)
+    this.resultsTarget.innerHTML = ""
+    this.searchInputTarget.value = ""
+  }
+
+  clear() {
+    this.selectTarget.value = ""
+    this.showSearch()
+    this.searchInputTarget.focus()
+  }
+
+  // Garantit une <option> pour l'id choisi puis la sélectionne (le <select>
+  // porte name="stay[customer_id]" et est la valeur soumise).
+  setSelectValue(id, label) {
+    let option = Array.from(this.selectTarget.options).find((o) => o.value === String(id))
+    if (!option) {
+      option = new Option(label, id)
+      this.selectTarget.add(option)
+    }
+    this.selectTarget.value = String(id)
+  }
+
+  selectedLabel() {
+    const option = this.selectTarget.selectedOptions[0]
+    return option ? option.textContent.trim() : ""
+  }
+
+  showChosen(label) {
+    if (this.hasChosenLabelTarget) this.chosenLabelTarget.textContent = label
+    this.chosenTarget.classList.remove("hidden")
+    this.searchWrapTarget.classList.add("hidden")
+  }
+
+  showSearch() {
+    this.chosenTarget.classList.add("hidden")
+    this.searchWrapTarget.classList.remove("hidden")
+    this.resultsTarget.innerHTML = ""
+  }
+
+  escape(str) {
+    const div = document.createElement("div")
+    div.textContent = str ?? ""
+    return div.innerHTML
+  }
+}

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -18,9 +18,19 @@
           input type="radio" name="stay[customer_mode]" value="new" data-action="change->stay-form#toggleCustomer"
           | Nouveau client
 
-      .space-y-1(data-stay-form-target="existingPanel")
+      / Client existant — autocomplete (issue #74) : recherche dynamique via
+      / customers/search. Le <select> reste le fallback sans-JS (réduit au client
+      / courant en édition) ; le contrôleur customer-search le masque et pilote sa
+      / valeur à la sélection d'un résultat.
+      .space-y-1(data-stay-form-target="existingPanel" data-controller="customer-search" data-customer-search-url-value=search_customers_path)
         label.block.text-sm.font-medium.text-gray-700 Sélectionner un client
-        = select_tag "stay[customer_id]", options_for_select(@customers.map { |c| [c.name.presence || c.email, c.id] }, selected_customer_id), include_blank: "— Choisir un client —", class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+        = select_tag "stay[customer_id]", options_for_select(@customers.map { |c| [c.name.presence || c.email, c.id] }, selected_customer_id), include_blank: "— Choisir un client —", data: { "customer-search-target": "select" }, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+        .relative.space-y-1.hidden(data-customer-search-target="searchWrap")
+          = text_field_tag :customer_query, nil, placeholder: "Rechercher un client (nom, email)…", autocomplete: "off", data: { "customer-search-target": "searchInput", action: "input->customer-search#search" }, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          .border.border-gray-100.rounded-md.divide-y.divide-gray-50.bg-white.shadow-sm.max-h-48.overflow-y-auto(data-customer-search-target="results")
+        .flex.items-center.justify-between.gap-2.text-sm.hidden(data-customer-search-target="chosen")
+          span.text-gray-900.font-medium(data-customer-search-target="chosenLabel")
+          button type="button" data-action="customer-search#clear" class="text-indigo-600 hover:underline" Changer
 
       .space-y-2.hidden(data-stay-form-target="newPanel")
         .grid.grid-cols-2.gap-2

--- a/spec/requests/stays_customer_autocomplete_spec.rb
+++ b/spec/requests/stays_customer_autocomplete_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+# Issue #74 — autocomplete client dans le form de composition Séjour admin.
+# Réutilise l'endpoint existant customers/search (JSON) ; le form câble un champ
+# de recherche piloté par le contrôleur Stimulus customer-search, avec fallback
+# <select> sans-JS.
+RSpec.describe "Stays — autocomplete client (issue #74)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-autocomplete@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+
+  describe "GET /customers/search" do
+    it "renvoie le JSON attendu { id, name, email }" do
+      Customer.create!(first_name: "Zoé", last_name: "Dupont", email: "zoe@example.com", customer_type: "individual")
+      get search_customers_path, params: { q: "Zoé" }, headers: { "Accept" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.first).to include("id", "name", "email")
+      expect(body.first["email"]).to eq("zoe@example.com")
+    end
+  end
+
+  describe "POST /stays avec un client sélectionné (customer_id)" do
+    it "rattache le séjour au bon client" do
+      customer = Customer.create!(first_name: "Alice", last_name: "Martin", email: "alice@example.com", customer_type: "individual")
+
+      post stays_path, params: {
+        stay: {
+          customer_mode: "existing", customer_id: customer.id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0, lodging_id: hulotte.id, status: "pending"
+        }
+      }
+      expect(response).to redirect_to(recent_stays_path)
+      expect(Stay.order(:created_at).last.customer).to eq(customer)
+    end
+  end
+
+  describe "câblage du form" do
+    it "le form new expose la recherche client (controller + select fallback)" do
+      get new_stay_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-controller="customer-search"')
+      expect(response.body).to include("customer-search-target=\"select\"")
+      expect(response.body).to include("customer-search-target=\"searchInput\"")
+      expect(response.body).to include(search_customers_path)
+    end
+
+    it "le form edit pré-affiche le client courant dans le <select> de repli" do
+      customer = Customer.create!(first_name: "Bob", last_name: "Durand", email: "bob@example.com", customer_type: "individual")
+      stay = Stay.create!(customer: customer, source: "manual", status: "pending",
+                          arrival_date: arrival, departure_date: departure, total_amount_cents: 0)
+
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("selected=\"selected\" value=\"#{customer.id}\"")
+    end
+  end
+end


### PR DESCRIPTION
Closes #74

## Résumé
Le sélecteur « Client existant » du form Séjour admin (un `<select>` chargeant jusqu'à 1000 clients) devient un **champ de recherche dynamique** interrogeant l'endpoint existant `customers/search`.

- **Recherche debouncée (~250 ms)** sur `customers/search` (fetch JSON `[{id, name, email}]`), liste de résultats, sélection d'un résultat.
- **Source de vérité = le `<select name="stay[customer_id]">`** (toujours soumis) : le contrôleur Stimulus `customer-search` le masque quand JS est actif et pilote sa valeur à la sélection (option ajoutée à la volée si besoin). Bouton « Changer » pour rouvrir la recherche.
- **`prepare_form` ne précharge plus tous les clients** — seul le client courant (édition) alimente le `<select>` de repli. C'est là le cœur du gain (fin du chargement de 1000 lignes).
- **Dégradation gracieuse sans JS** : le `<select>` (réduit au client courant en édition) reste utilisable ; en création sans JS, le toggle « Nouveau client » reste disponible.
- Réutilise le pattern éprouvé de `reassign_form_controller.js`.

## Critères d'acceptation
- [x] Champ de recherche interrogeant `customers/search` (fetch JSON, debounce ~250 ms) + liste de résultats
- [x] Sélection → renseigne le `customer_id` soumis + affiche le client choisi
- [x] Toggle existant/nouveau (`stay-form`) reste fonctionnel (panneaux inchangés)
- [x] Création ET édition (client courant pré-affiché en édition)
- [x] Dégradation gracieuse sans JS (`<select>` de repli)
- [x] Aucune régression `stays_admin_crud_spec`

## Tests
- `bundle exec rspec` : **591 exemples, 0 échec** (18 pending préexistants).
- `spec/requests/stays_customer_autocomplete_spec.rb` : `customers/search` renvoie `{id, name, email}` ; création avec `customer_id` → séjour rattaché au bon client ; le form `new` câble la recherche (controller + targets + URL) ; le form `edit` pré-affiche le client courant dans le `<select>` de repli.

## ⚠️ Vérification — limite honnête
L'**endpoint** et le **câblage rendu** sont couverts par request specs. Le **comportement JS live** (frappe → résultats → sélection → soumission) **n'a PAS pu être vérifié en runtime** dans ce run headless (form derrière Devise, pas d'infra de test système JS). Le contrôleur suit le pattern éprouvé de `reassign_form_controller.js`. **À valider dans un navigateur authentifié.**

## Aperçu
Pas de capture : l'autocomplete n'apparaît qu'après interaction JS sur une page authentifiée (non exécutable en headless). Voir la limite ci-dessus.