### PR TITLE
Epic #81 Phase 1 — Rattacher les SpaceBooking orphelins (Stays::EnsureForSpaceBooking + backfill)

### DIFF
--- a/app/services/space_bookings/create_service.rb
+++ b/app/services/space_bookings/create_service.rb
@@ -27,7 +27,15 @@ module SpaceBookings
       spaces = get_spaces
       if !spaces.nil? && available?(spaces)
         build_space_reservations(spaces, @space_booking.duration)
-        @space_booking.save!
+        # Stay-first (epic #81, Phase 1) : tout SpaceBooking créé côté admin obtient
+        # automatiquement un Stay + Customer, comme le canal Booking. SpaceBooking et
+        # Stay sont persistés dans la MÊME transaction — un échec de Stay annule le
+        # space_booking pour ne jamais laisser d'orphelin. Les effets de bord (email,
+        # abonnement) restent hors transaction.
+        ActiveRecord::Base.transaction do
+          @space_booking.save!
+          Stays::EnsureForSpaceBooking.call(@space_booking)
+        end
         notify_customer_on_create
         create_subscription(from: @space_booking)
       end

--- a/app/services/stays/ensure_for_space_booking.rb
+++ b/app/services/stays/ensure_for_space_booking.rb
@@ -1,0 +1,88 @@
+module Stays
+  # Garantit qu'un SpaceBooking porte un Stay (epic #81, Phase 1). Pendant du
+  # canal Booking (Stays::EnsureForBooking) : comble le trou par lequel les
+  # SpaceBooking créés en admin direct (SpaceBookings::CreateService) restaient
+  # orphelins, sans Stay.
+  #
+  # IDEMPOTENT :
+  #   - si le SpaceBooking a déjà un Stay vivant (has_one :stay through stay_item),
+  #     on le renvoie sans rien créer ;
+  #   - sinon on upserte le Customer par email (service partagé), on crée le Stay
+  #     et le StayItem qui le relie au SpaceBooking.
+  #
+  # N'écrit JAMAIS sur le SpaceBooking (zéro perte de donnée). Ne pose PAS de
+  # legacy_origin : ce n'est pas une reprise legacy mais le canal courant admin —
+  # l'idempotence repose sur la présence du Stay vivant, pas sur un marqueur
+  # d'import.
+  #
+  # SpaceBooking soft-deleted : on ne crée RIEN et on renvoie nil. Un séjour ne
+  # s'attache qu'à une réservation d'espace vivante (l'invariant du backfill est
+  # borné aux SpaceBooking vivants).
+  #
+  # Appelé par SpaceBookings::CreateService (tout nouveau space_booking admin) et
+  # par la rake stays:backfill_missing (rattrapage rétroactif).
+  class EnsureForSpaceBooking
+    def self.call(space_booking)
+      new(space_booking).call
+    end
+
+    def initialize(space_booking)
+      @space_booking = space_booking
+    end
+
+    def call
+      # Un SpaceBooking soft-deleted ne reçoit pas de Stay : rien à ancrer.
+      return nil if @space_booking.deleted?
+
+      existing = live_stay_for(@space_booking)
+      return existing if existing.present?
+
+      ActiveRecord::Base.transaction do
+        customer = Customers::UpsertByEmail.call(
+          email: @space_booking.email,
+          attrs: customer_attrs
+        )
+        stay = Stay.create!(
+          customer: customer,
+          # Pas de canal OTA pour les espaces : la saisie est toujours admin.
+          source: "manual",
+          status: @space_booking.status,
+          arrival_date: @space_booking.from_date,
+          departure_date: @space_booking.to_date,
+          total_amount_cents: @space_booking.price_cents.to_i
+        )
+        # On n'arrive ici que si live_stay_for est nil (pas de StayItem vivant →
+        # Stay vivant). Un StayItem vivant PEUT toutefois subsister en pointant
+        # vers un Stay soft-deleted (état latent improbable) : dans ce cas on le
+        # REPOINTE vers le Stay neuf plutôt que d'en créer un second. find_or_
+        # initialize garantit exactement UN StayItem vivant par space_booking.
+        item = StayItem.find_or_initialize_by(bookable: @space_booking)
+        item.stay = stay
+        item.save!
+        stay
+      end
+    end
+
+    private
+
+    # Clé d'idempotence : le Stay VIVANT rattaché au space_booking, lu FRAÎCHEMENT
+    # en base (StayItem live + Stay live) plutôt que via le cache d'association —
+    # sinon un même objet passé deux fois (ou dont l'association a été chargée
+    # avant la création du stay) recréerait un doublon. Robuste au re-run comme à
+    # l'objet en mémoire non rechargé.
+    def live_stay_for(space_booking)
+      StayItem.find_by(bookable: space_booking)&.stay
+    end
+
+    def customer_attrs
+      group_name = @space_booking.group_name.presence
+      {
+        first_name: @space_booking.firstname,
+        last_name: @space_booking.lastname,
+        phone: @space_booking.phone,
+        organization_name: group_name,
+        customer_type: group_name.present? ? "organization" : "individual"
+      }
+    end
+  end
+end

--- a/lib/tasks/stays.rake
+++ b/lib/tasks/stays.rake
@@ -1,6 +1,7 @@
 namespace :stays do
-  desc "Rattache un Stay à tout Booking qui n'en a pas (idempotent) — epic #26 Phase 3"
+  desc "Rattache un Stay à tout Booking ET SpaceBooking qui n'en a pas (idempotent) — epic #26 Phase 3, epic #81 Phase 1"
   task backfill_missing: :environment do
+    # --- Bookings (epic #26, Phase 3) -------------------------------------
     created = 0
     skipped = 0
     seen = 0
@@ -23,13 +24,45 @@ namespace :stays do
 
     remaining = bookings_without_live_stay
 
-    puts "=== Backfill stays (epic #26, Phase 3) ==="
+    puts "=== Backfill stays — Bookings (epic #26, Phase 3) ==="
     puts "Bookings vus                 : #{seen}"
     puts "Déjà rattachés (skip)        : #{skipped}"
     puts "Stays créés                  : #{created}"
     puts "Bookings encore sans Stay    : #{remaining}"
     abort("ÉCHEC : #{remaining} booking(s) sans Stay après backfill.") if remaining.positive?
     puts "OK — 0 Booking sans Stay."
+
+    # --- SpaceBookings (epic #81, Phase 1) --------------------------------
+    # On ne couvre QUE les SpaceBooking vivants : un SpaceBooking soft-deleted
+    # n'ancre aucun Stay (cf. Stays::EnsureForSpaceBooking, qui renvoie nil pour
+    # un enregistrement supprimé). Le default scope de SpaceBooking les exclut
+    # donc naturellement du find_each comme du compteur.
+    sb_created = 0
+    sb_skipped = 0
+    sb_seen = 0
+    sb_before = space_bookings_without_live_stay
+
+    SpaceBooking.find_each do |space_booking|
+      sb_seen += 1
+      if space_booking.stay.present?
+        sb_skipped += 1
+        next
+      end
+      Stays::EnsureForSpaceBooking.call(space_booking)
+      sb_created += 1
+    end
+
+    sb_after = space_bookings_without_live_stay
+
+    puts ""
+    puts "=== Backfill stays — SpaceBookings (epic #81, Phase 1) ==="
+    puts "SpaceBookings vus                 : #{sb_seen}"
+    puts "Déjà rattachés (skip)             : #{sb_skipped}"
+    puts "Stays créés                       : #{sb_created}"
+    puts "SpaceBookings sans Stay (avant)   : #{sb_before}"
+    puts "SpaceBookings sans Stay (après)   : #{sb_after}"
+    abort("ÉCHEC : #{sb_after} space_booking(s) sans Stay après backfill.") if sb_after.positive?
+    puts "OK — 0 SpaceBooking sans Stay."
   end
 end
 
@@ -47,4 +80,17 @@ def bookings_without_live_stay
   Booking.with_deleted do
     Booking.unscoped.where.not(id: linked_ids).count
   end
+end
+
+# Compte les SpaceBooking VIVANTS dépourvus d'un Stay VIVANT. Même définition
+# d'« orphelin » que Stays::EnsureForSpaceBooking#live_stay_for et que
+# space_booking.stay : StayItem vivant pointant vers un Stay vivant. On borne aux
+# SpaceBooking vivants (default scope) et aux stay_id vivants (sous-select
+# explicite `Stay.select(:id)`, car `joins(:stay)` n'appliquerait pas le default
+# scope de la table jointe et compterait les Stays soft-deleted).
+def space_bookings_without_live_stay
+  linked_ids = StayItem
+    .where(bookable_type: "SpaceBooking", stay_id: Stay.select(:id))
+    .pluck(:bookable_id)
+  SpaceBooking.where.not(id: linked_ids).count
 end

--- a/spec/services/space_bookings/create_service_spec.rb
+++ b/spec/services/space_bookings/create_service_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+# Couvre l'AC3 de la Phase 1 (epic #81) AU POINT D'ENTRÉE réel du canal admin :
+# SpaceBookings::CreateService#run. Tout SpaceBooking créé ici doit repartir avec
+# un Stay et un Customer upserté par email — comme le canal Booking.
+RSpec.describe SpaceBookings::CreateService do
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+
+  def params(overrides = {})
+    ActionController::Parameters.new(
+      space_booking: {
+        firstname: "Nadia",
+        lastname: "Bianchi",
+        email: "Nadia@Example.com",
+        from_date: Date.today + 30,
+        to_date: Date.today + 33,
+        duration: "journee",
+        price: "300",
+        status: "pending",
+        space_ids: [grande_salle.id]
+      }.merge(overrides)
+    )
+  end
+
+  it "crée un SpaceBooking ET son Stay + Customer (canal admin)" do
+    service = described_class.new
+
+    expect(service.run(params)).to be(true)
+
+    space_booking = service.space_booking.reload
+    expect(space_booking.stay).to be_present
+    expect(space_booking.stay.customer.email).to eq("nadia@example.com")
+    expect(space_booking.stay.source).to eq("manual")
+  end
+
+  it "upserte le même Customer pour deux space_bookings au même email" do
+    described_class.new.tap { |s| s.run(params(email: "repeat@example.com")) }
+    described_class.new.tap do |s|
+      s.run(params(email: "repeat@example.com", from_date: Date.today + 60, to_date: Date.today + 62))
+    end
+
+    expect(Customer.where(email: "repeat@example.com").count).to eq(1)
+  end
+end

--- a/spec/services/stays/ensure_for_space_booking_spec.rb
+++ b/spec/services/stays/ensure_for_space_booking_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe Stays::EnsureForSpaceBooking do
+  def build_space_booking(**attrs)
+    SpaceBooking.create!({
+      firstname: "Zoé",
+      lastname: "Durand",
+      email: "zoe@example.com",
+      phone: "+32470112233",
+      from_date: Date.new(2026, 8, 1),
+      to_date: Date.new(2026, 8, 4),
+      status: "pending",
+      price_cents: 30_000
+    }.merge(attrs))
+  end
+
+  describe "création d'un Stay pour un SpaceBooking qui n'en a pas" do
+    it "crée le Stay, le StayItem et upserte le Customer par email" do
+      space_booking = build_space_booking
+
+      stay = described_class.call(space_booking)
+
+      expect(stay).to be_persisted
+      expect(space_booking.reload.stay).to eq(stay)
+      expect(stay.customer.email).to eq("zoe@example.com")
+      expect(stay.customer.phone).to eq("+32470112233")
+      expect(stay.stay_items.map(&:bookable)).to contain_exactly(space_booking)
+    end
+
+    it "recopie dates, statut et montant depuis le space_booking sans le muter" do
+      space_booking = build_space_booking
+
+      expect { described_class.call(space_booking) }
+        .not_to change { space_booking.reload.attributes }
+
+      stay = space_booking.reload.stay
+      expect(stay.arrival_date).to eq(Date.new(2026, 8, 1))
+      expect(stay.departure_date).to eq(Date.new(2026, 8, 4))
+      expect(stay.status).to eq("pending")
+      expect(stay.total_amount_cents).to eq(30_000)
+    end
+
+    it "attribue toujours source 'manual' (pas de canal OTA pour les espaces)" do
+      stay = described_class.call(build_space_booking)
+      expect(stay.source).to eq("manual")
+    end
+
+    it "rattache un space_booking sans email exploitable au Customer fourre-tout" do
+      stay = described_class.call(build_space_booking(email: nil))
+      expect(stay.customer.catch_all?).to be(true)
+    end
+
+    it "crée un Customer organisation quand group_name est présent" do
+      stay = described_class.call(
+        build_space_booking(email: "asso@example.com", group_name: "Les Amis")
+      )
+      expect(stay.customer.customer_type).to eq("organization")
+      expect(stay.customer.organization_name).to eq("Les Amis")
+    end
+  end
+
+  describe "idempotence" do
+    it "renvoie le Stay existant sans en créer un second" do
+      space_booking = build_space_booking
+      first = described_class.call(space_booking)
+
+      second = nil
+      expect { second = described_class.call(space_booking) }.not_to change(Stay, :count)
+      expect(second).to eq(first)
+      expect(StayItem.where(bookable: space_booking).count).to eq(1)
+    end
+  end
+
+  describe "SpaceBooking soft-deleted" do
+    it "ne crée aucun Stay et renvoie nil" do
+      space_booking = build_space_booking
+      space_booking.soft_delete!(validate: false)
+
+      result = nil
+      expect { result = described_class.call(space_booking) }.not_to change(Stay, :count)
+      expect(result).to be_nil
+      expect(StayItem.where(bookable: space_booking).count).to eq(0)
+    end
+  end
+
+  # État latent (improbable mais possible) : un StayItem VIVANT pointant vers un
+  # Stay soft-deleted. `space_booking.stay` (double scope vivant) vaut alors nil,
+  # donc le service est rappelé. Sans le repoint, il créerait un 2e StayItem vivant
+  # (unicité scoped sur stay_id ⇒ autorisé) et divergerait du compteur du backfill.
+  describe "état latent : StayItem vivant → Stay soft-deleted" do
+    def build_latent_state
+      space_booking = build_space_booking(email: "latent@example.com")
+      dead_stay = described_class.call(space_booking)
+      dead_stay.soft_delete!(validate: false)
+      # Le soft-delete du Stay cascade sur son StayItem : on le ressuscite pour
+      # reconstruire l'état exact « StayItem vivant → Stay mort ».
+      StayItem.with_deleted do
+        StayItem.unscoped
+          .find_by(bookable_id: space_booking.id, bookable_type: "SpaceBooking")
+          .update_column(:deleted_at, nil)
+      end
+      [space_booking.reload, dead_stay]
+    end
+
+    it "repointe le StayItem orphelin au lieu d'en créer un second" do
+      space_booking, dead_stay = build_latent_state
+      expect(space_booking.stay).to be_nil
+      expect(StayItem.where(bookable: space_booking).count).to eq(1)
+
+      new_stay = described_class.call(space_booking)
+
+      expect(StayItem.where(bookable: space_booking).count).to eq(1)
+      expect(new_stay.id).not_to eq(dead_stay.id)
+      expect(space_booking.reload.stay).to eq(new_stay)
+    end
+  end
+end

--- a/spec/tasks/stays_backfill_missing_spec.rb
+++ b/spec/tasks/stays_backfill_missing_spec.rb
@@ -65,4 +65,52 @@ RSpec.describe "stays:backfill_missing", type: :task do
 
     expect(Booking.with_deleted { Booking.unscoped.find(booking.id).stay }).to be_present
   end
+
+  # --- SpaceBookings (epic #81, Phase 1) ---------------------------------
+  def build_space_booking(**attrs)
+    SpaceBooking.create!({
+      firstname: "Backfill",
+      email: "sb-backfill@example.com",
+      from_date: Date.new(2026, 11, 1),
+      to_date: Date.new(2026, 11, 3),
+      status: "confirmed",
+      price_cents: 20_000
+    }.merge(attrs))
+  end
+
+  it "rattache plusieurs SpaceBookings orphelins : 0 orphelin après exécution" do
+    sb1 = build_space_booking(email: "sb-a@example.com")
+    sb2 = build_space_booking(email: "sb-b@example.com")
+
+    run_task
+
+    expect(sb1.reload.stay).to be_present
+    expect(sb2.reload.stay).to be_present
+    expect(sb1.reload.stay.source).to eq("manual")
+  end
+
+  it "est idempotente sur les SpaceBookings : un second passage ne crée aucun Stay" do
+    build_space_booking(email: "sb-c@example.com")
+    run_task
+    count_after_first = Stay.count
+
+    expect { run_task }.not_to change(Stay, :count)
+    expect(Stay.count).to eq(count_after_first)
+  end
+
+  it "ne recrée pas de Stay pour un SpaceBooking déjà rattaché" do
+    space_booking = build_space_booking(email: "sb-d@example.com")
+    existing = Stays::EnsureForSpaceBooking.call(space_booking)
+
+    expect { run_task }.not_to change(Stay, :count)
+    expect(space_booking.reload.stay).to eq(existing)
+  end
+
+  it "ignore les SpaceBookings soft-deleted (aucun Stay créé pour eux)" do
+    space_booking = build_space_booking(email: "sb-deleted@example.com")
+    space_booking.soft_delete!(validate: false)
+
+    expect { run_task }.not_to change { StayItem.where(bookable_type: "SpaceBooking").count }
+    expect(StayItem.where(bookable: space_booking).count).to eq(0)
+  end
 end


### PR DESCRIPTION
## Epic #81 — Phase 1 : rattacher les `SpaceBooking` orphelins

Ferme le trou critique identifié au cadrage : il n'existait pas d'équivalent `EnsureForBooking` pour les espaces, donc tout `SpaceBooking` saisi en admin direct était **orphelin sans `Stay`**. Prérequis absolu des Phases 2 (fusion), 8 (édition unifiée) et 9 (retrait).

### Contenu
- **`Stays::EnsureForSpaceBooking`** — calque exact du canal Booking : upsert `Customer` via `Customers::UpsertByEmail` (fourre-tout si email inexploitable), crée `Stay` + `StayItem`, **idempotent** (clé lue fraîchement en base : StayItem vivant → Stay vivant), gère l'état latent « StayItem vivant → Stay soft-deleted » par repoint (pas de doublon).
- **`SpaceBookings::CreateService`** — appelle le service après `save!`, **dans la même transaction** : si le rattachement lève, le SpaceBooking est rollbacké (zéro orphelin possible). Structure identique au canal Booking.
- **`stays:backfill_missing`** — étendue aux SpaceBooking orphelins, compteurs avant/après, `abort` si l'invariant `SpaceBooking vivants sans Stay vivant == 0` n'est pas tenu après exécution (recomptage réel).
- **Specs** : 15 nouveaux exemples (service, hook CreateService, backfill — orphelin rattaché, idempotence ×2, soft-deleted ignoré, état latent, invariant). Suite : **633 examples, 0 failures**.

### Revue Forge : SHIP AVEC RÉSERVES
Rollback transactionnel, idempotence (y compris cas tordu), cohérence de la définition d'« orphelin » et absence d'erreur Ruby/Rails : tous vérifiés ✅. Une seule réserve, et c'est une **décision produit à trancher à la review** :

> **❓ Question pour Michael — asymétrie soft-deleted.** Le backfill Booking couvre TOUT l'historique (`with_deleted`) : un Booking annulé/supprimé reçoit quand même un Stay. Le backfill SpaceBooking ne couvre que les **vivants** (conforme au critère écrit de l'epic). Conséquence : les SpaceBooking soft-deleted d'avant cette PR n'auront jamais de Stay, alors que leurs homologues Booking en ont un. En régime permanent les deux canaux convergent (un SpaceBooking rattaché puis supprimé garde son Stay) — l'asymétrie est purement historique.
>
> **A.** Garder tel quel (invariant « vivants seulement » = comportement voulu) → mergeable en l'état.
> **B.** Parité totale avec Booking (passer la boucle en `with_deleted`, retirer le guard) → je pousse un commit correctif avant merge.

Findings mineurs (N+1 borné à l'échelle de claudy, aimant Customer fourre-tout sur emails legacy, `live_stay_for` non déterministe si double StayItem vivant) : tous **partagés avec le canal Booking existant**, donc hors périmètre — tracés ici pour mémoire.

### Après merge
`bundle exec rake stays:backfill_missing` à lancer en prod (affiche les comptes avant/après et s'interrompt si l'invariant n'est pas atteint).
