### PR TITLE
Epic #81 Phase 2 — Fusion de séjours depuis le calendrier (Stays::MergeService + mode fusion)

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -146,7 +146,94 @@ class StaysController < BaseController
     redirect_to recent_stays_path, notice: "Séjour supprimé."
   end
 
+  # --- Fusion de séjours depuis le calendrier (epic #81, Phase 2) -----------
+  # Trois fragments SERVEUR successifs. Aucune vérité n'est recalculée en JS :
+  # l'étape A (désignation) comme l'étape B (aperçu) sortent d'ici.
+
+  # Étape A — cartes radio de désignation du survivant, avec présélection
+  # intelligente motivée. Reçoit `stay_ids[]` (+ éventuel `target_id` pour
+  # re-cocher la cible au retour depuis l'aperçu).
+  def merge_setup
+    @stays = load_merge_stays
+    return render_merge_guard if @stays.size < 2
+
+    preselected = @stays.find { |s| s.id == params[:target_id].to_i }
+    suggested, reason = helpers.suggested_merge_target(@stays)
+    @target = preselected || suggested
+    @suggested_id = suggested&.id
+    @suggested_reason = reason
+
+    render partial: "stays/merge_setup",
+           layout: false,
+           formats: [:html],
+           locals: { stays: @stays, target: @target, suggested_id: @suggested_id, suggested_reason: @suggested_reason }
+  end
+
+  # Étape B — aperçu dry-run (Stays::MergePreview). Reçoit `target_id` + `stay_ids[]`.
+  def merge_preview
+    stays = load_merge_stays
+    return render_merge_guard if stays.size < 2
+
+    target = stays.find { |s| s.id == params[:target_id].to_i } || stays.min_by(&:id)
+    sources = stays.reject { |s| s.id == target.id }
+
+    preview = Stays::MergePreview.new(target: target, sources: sources).call
+    render partial: "stays/merge_preview", layout: false, formats: [:html], locals: { preview: preview, error: nil }
+  end
+
+  # Commit — Stays::MergeService, puis redirection calendrier (mois du début du
+  # survivant) + flash détaillé. En cas d'échec, re-rendu du fragment d'aperçu
+  # avec l'erreur DANS le dialog (422). Appelé en fetch JSON par le contrôleur
+  # Stimulus (le flash persiste jusqu'au GET de redirection qui l'affiche).
+  def merge
+    stays = load_merge_stays
+    return render_merge_guard if stays.size < 2
+
+    target = stays.find { |s| s.id == params[:target_id].to_i } || stays.min_by(&:id)
+    sources = stays.reject { |s| s.id == target.id }
+
+    service = Stays::MergeService.new(target: target, sources: sources)
+    if service.run
+      target.reload
+      flash[:notice] = merge_success_message(target, sources)
+      render json: {
+        redirect: root_path(date: target.arrival_date&.strftime("%Y-%m-%d"), stay_merge_done: 1)
+      }
+    else
+      preview = Stays::MergePreview.new(target: target, sources: sources).call
+      render partial: "stays/merge_preview",
+             layout: false,
+             formats: [:html],
+             status: :unprocessable_entity,
+             locals: { preview: preview, error: service.error_message }
+    end
+  end
+
   private
+
+  # Séjours candidats à la fusion, préchargés pour éviter les N+1 des aperçus.
+  def load_merge_stays
+    ids = Array(params[:stay_ids]).map(&:to_i).uniq.reject(&:zero?)
+    Stay.where(id: ids)
+        .includes(:customer, :meal_orders, experience_bookings: { experience_availability: :experience }, stay_items: :bookable)
+        .to_a
+  end
+
+  # Garde-fou serveur : moins de 2 séjours résolus = fusion impossible (422).
+  def render_merge_guard
+    render partial: "stays/merge_error",
+           layout: false,
+           formats: [:html],
+           status: :unprocessable_entity,
+           locals: { message: "Sélectionne au moins deux séjours existants à fusionner." }
+  end
+
+  def merge_success_message(target, sources)
+    ids = sources.map { |s| "##{s.id}" }.join(" et ")
+    total = helpers.humanized_money_with_symbol(target.total_amount)
+    balance = helpers.humanized_money_with_symbol(Money.new(target.amount_due_cents))
+    "Séjour#{'s' if sources.size > 1} #{ids} fusionné#{'s' if sources.size > 1} dans ##{target.id} — total recalculé : #{total}, solde : #{balance}."
+  end
 
   def set_stay
     @stay = Stay.find(params[:id])

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -174,7 +174,8 @@ class StaysController < BaseController
     stays = load_merge_stays
     return render_merge_guard if stays.size < 2
 
-    target = stays.find { |s| s.id == params[:target_id].to_i } || stays.min_by(&:id)
+    target = resolve_merge_target(stays)
+    return render_merge_guard(message: "Le séjour survivant ne fait pas partie de la sélection.") if target.nil?
     sources = stays.reject { |s| s.id == target.id }
 
     preview = Stays::MergePreview.new(target: target, sources: sources).call
@@ -189,7 +190,8 @@ class StaysController < BaseController
     stays = load_merge_stays
     return render_merge_guard if stays.size < 2
 
-    target = stays.find { |s| s.id == params[:target_id].to_i } || stays.min_by(&:id)
+    target = resolve_merge_target(stays)
+    return render_merge_guard(message: "Le séjour survivant ne fait pas partie de la sélection.") if target.nil?
     sources = stays.reject { |s| s.id == target.id }
 
     service = Stays::MergeService.new(target: target, sources: sources)
@@ -219,13 +221,23 @@ class StaysController < BaseController
         .to_a
   end
 
+  # Résout le survivant STRICTEMENT parmi les séjours postés : un `target_id`
+  # forgé hors sélection ne doit jamais retomber silencieusement sur un autre
+  # séjour (le survivant serait choisi à l'insu de l'admin). Sans `target_id`
+  # (ouverture de l'étape B sans passer par A), repli déterministe : plus petit id.
+  def resolve_merge_target(stays)
+    return stays.min_by(&:id) if params[:target_id].blank?
+
+    stays.find { |s| s.id == params[:target_id].to_i }
+  end
+
   # Garde-fou serveur : moins de 2 séjours résolus = fusion impossible (422).
-  def render_merge_guard
+  def render_merge_guard(message: "Sélectionne au moins deux séjours existants à fusionner.")
     render partial: "stays/merge_error",
            layout: false,
            formats: [:html],
            status: :unprocessable_entity,
-           locals: { message: "Sélectionne au moins deux séjours existants à fusionner." }
+           locals: { message: message }
   end
 
   def merge_success_message(target, sources)

--- a/app/frontend/controllers/stay_merge_controller.js
+++ b/app/frontend/controllers/stay_merge_controller.js
@@ -16,6 +16,8 @@ import { Controller } from "@hotwired/stimulus"
 const GOLDEN_ANGLE = 137.508
 const STORAGE_ACTIVE = "claudy.stayMerge.active"
 const STORAGE_SELECTION = "claudy.stayMerge.selection"
+const STORAGE_STAMP = "claudy.stayMerge.stamp"
+const SELECTION_TTL_MS = 60 * 60 * 1000 // sélection périmée au-delà d'une heure
 
 export default class extends Controller {
   static targets = ["bar", "chips", "count", "mergeButton", "dialog", "dialogContent", "toggleButton", "banner"]
@@ -259,6 +261,13 @@ export default class extends Controller {
   async commit(event) {
     event.preventDefault()
     const form = event.currentTarget
+    // Désarme le bouton : le serveur est protégé contre le double POST, mais
+    // inutile d'envoyer une requête vouée au 422.
+    const submitButton = form.querySelector("button, input[type=submit]")
+    if (submitButton) {
+      if (submitButton.disabled) return
+      submitButton.disabled = true
+    }
     try {
       const response = await fetch(form.action, {
         method: "POST",
@@ -330,7 +339,16 @@ export default class extends Controller {
     try {
       const raw = sessionStorage.getItem(STORAGE_SELECTION)
       const parsed = raw ? JSON.parse(raw) : []
-      return Array.isArray(parsed) ? parsed : []
+      if (!Array.isArray(parsed)) return []
+      // Sélection périmée (> 60 min) : on repart à neuf plutôt que de ré-entrer
+      // en mode fusion avec des séjours choisis il y a longtemps.
+      const stampRaw = sessionStorage.getItem(STORAGE_STAMP)
+      const stamp = stampRaw ? parseInt(stampRaw, 10) : 0
+      if (!stamp || Date.now() - stamp > SELECTION_TTL_MS) {
+        this.clearStorage()
+        return []
+      }
+      return parsed
     } catch (_e) {
       return []
     }
@@ -338,10 +356,12 @@ export default class extends Controller {
 
   persistSelection() {
     sessionStorage.setItem(STORAGE_SELECTION, JSON.stringify(this.selection))
+    sessionStorage.setItem(STORAGE_STAMP, String(Date.now()))
   }
 
   clearStorage() {
     sessionStorage.removeItem(STORAGE_ACTIVE)
     sessionStorage.removeItem(STORAGE_SELECTION)
+    sessionStorage.removeItem(STORAGE_STAMP)
   }
 }

--- a/app/frontend/controllers/stay_merge_controller.js
+++ b/app/frontend/controllers/stay_merge_controller.js
@@ -76,12 +76,21 @@ export default class extends Controller {
 
   applyModeChrome(on) {
     this.element.classList.toggle("merge-mode", on)
-    if (this.hasBannerTarget) this.bannerTarget.classList.toggle("hidden", !on)
+    if (this.hasBannerTarget) {
+      // Le bandeau est un conteneur flex : `hidden` et `flex` se toggleent
+      // ensemble, sinon il s'affiche en block et écrase sa mise en page.
+      this.bannerTarget.classList.toggle("hidden", !on)
+      this.bannerTarget.classList.toggle("flex", on)
+    }
     if (this.hasToggleButtonTarget) {
       this.toggleButtonTarget.setAttribute("aria-pressed", on ? "true" : "false")
-      this.toggleButtonTarget.classList.toggle("bg-indigo-600", on)
-      this.toggleButtonTarget.classList.toggle("text-white", on)
-      this.toggleButtonTarget.classList.toggle("border-indigo-600", on)
+      // Swap COMPLET des classes d'état : ajouter bg-indigo-600 sans retirer
+      // bg-white laisse gagner bg-white (ordre CSS Tailwind) → texte blanc sur
+      // fond blanc. Chaque classe de base a son pendant actif.
+      const activeClasses = ["bg-indigo-600", "text-white", "border-indigo-600", "hover:bg-indigo-700"]
+      const baseClasses = ["bg-white", "text-gray-700", "border-gray-300", "hover:bg-gray-50"]
+      activeClasses.forEach((c) => this.toggleButtonTarget.classList.toggle(c, on))
+      baseClasses.forEach((c) => this.toggleButtonTarget.classList.toggle(c, !on))
     }
   }
 
@@ -136,7 +145,6 @@ export default class extends Controller {
     const ids = new Set(this.selection.map((s) => String(s.id)))
     this.element.classList.toggle("has-selection", this.selection.length > 0)
 
-    const seen = new Set()
     this.element.querySelectorAll("[data-stay-id]").forEach((block) => {
       const id = String(block.dataset.stayId)
       const selected = ids.has(id)
@@ -144,12 +152,9 @@ export default class extends Controller {
       if (selected) {
         const hue = this.hueFor(id)
         block.style.boxShadow = `0 0 0 2px hsl(${hue} 65% 45%), 0 0 0 5px hsl(${hue} 70% 90%)`
-        if (!seen.has(id)) {
-          seen.add(id)
-          this.addBadge(block, hue)
-        } else {
-          this.removeBadge(block)
-        }
+        // Badge ✓ sur CHAQUE bloc du séjour : chaque fragment confirme sa
+        // sélection, le ring seul est trop discret sur les petits blocs.
+        this.addBadge(block, hue)
       } else {
         block.style.boxShadow = ""
         this.removeBadge(block)
@@ -193,8 +198,12 @@ export default class extends Controller {
     }
     if (this.hasMergeButtonTarget) {
       this.mergeButtonTarget.disabled = count < 2
-      this.mergeButtonTarget.title = count < 2 ? "Sélectionne au moins 2 séjours" : "Fusionner les séjours sélectionnés"
-      this.mergeButtonTarget.textContent = `Fusionner ${count} séjours`
+      // Libellé explicite VISIBLE quand la sélection est insuffisante (un title
+      // seul est invisible au tactile), accord correct sinon.
+      this.mergeButtonTarget.textContent =
+        count < 2 ? "Sélectionne au moins 2 séjours" : `Fusionner ${count} séjours`
+      this.mergeButtonTarget.title =
+        count < 2 ? "Sélectionne au moins 2 séjours" : "Fusionner les séjours sélectionnés"
     }
     if (this.hasChipsTarget) this.renderChips()
   }

--- a/app/frontend/controllers/stay_merge_controller.js
+++ b/app/frontend/controllers/stay_merge_controller.js
@@ -1,0 +1,347 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Mode fusion de séjours depuis le calendrier admin (epic #81, Phase 2).
+//
+// Parti pris : la teinte unique de chaque séjour (stay_hue, angle d'or — même
+// formule que CalendarHelper) porte toute l'identité visuelle. On clique un bloc,
+// c'est TOUT le séjour qui s'allume de sa couleur à travers la grille.
+//
+// Le mode et la sélection survivent à la navigation entre mois (rechargements
+// simple_calendar) via sessionStorage. Les étapes A (désignation) et B (aperçu)
+// du dialog sont des fragments SERVEUR (fetch) : aucune vérité recalculée en JS.
+//
+// Placé sur le wrapper du calendrier, à côté de stay-details. En mode actif, un
+// handler en phase CAPTURE neutralise l'ouverture de la modale séjour pour
+// transformer le clic en sélection. Mode inactif = zéro interférence.
+const GOLDEN_ANGLE = 137.508
+const STORAGE_ACTIVE = "claudy.stayMerge.active"
+const STORAGE_SELECTION = "claudy.stayMerge.selection"
+
+export default class extends Controller {
+  static targets = ["bar", "chips", "count", "mergeButton", "dialog", "dialogContent", "toggleButton", "banner"]
+  static values = { setupUrl: String, previewUrl: String, reset: Boolean }
+
+  connect() {
+    // Fusion tout juste réalisée (redirection ?stay_merge_done=1) : on repart propre.
+    if (this.resetValue) {
+      this.clearStorage()
+    }
+
+    this.active = sessionStorage.getItem(STORAGE_ACTIVE) === "1"
+    this.selection = this.readSelection()
+    this.lastTargetId = null
+
+    this.boundClick = this.handleClick.bind(this)
+    this.boundKeydown = this.handleKeydown.bind(this)
+    // Capture pour passer AVANT l'action bubble stay-details#open des overlays.
+    this.element.addEventListener("click", this.boundClick, true)
+    window.addEventListener("keydown", this.boundKeydown)
+
+    if (this.active) {
+      this.applyModeChrome(true)
+    }
+    this.applySelectionStyles()
+    this.renderBar()
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this.boundClick, true)
+    window.removeEventListener("keydown", this.boundKeydown)
+  }
+
+  // --- Bascule du mode -------------------------------------------------------
+  toggle() {
+    this.active ? this.exitMode() : this.enterMode()
+  }
+
+  enterMode() {
+    this.active = true
+    sessionStorage.setItem(STORAGE_ACTIVE, "1")
+    this.applyModeChrome(true)
+    this.applySelectionStyles()
+    this.renderBar()
+  }
+
+  exitMode() {
+    this.active = false
+    this.selection = []
+    this.clearStorage()
+    this.applyModeChrome(false)
+    this.applySelectionStyles()
+    this.renderBar()
+    if (this.hasDialogTarget && this.dialogTarget.open) this.dialogTarget.close()
+  }
+
+  applyModeChrome(on) {
+    this.element.classList.toggle("merge-mode", on)
+    if (this.hasBannerTarget) this.bannerTarget.classList.toggle("hidden", !on)
+    if (this.hasToggleButtonTarget) {
+      this.toggleButtonTarget.setAttribute("aria-pressed", on ? "true" : "false")
+      this.toggleButtonTarget.classList.toggle("bg-indigo-600", on)
+      this.toggleButtonTarget.classList.toggle("text-white", on)
+      this.toggleButtonTarget.classList.toggle("border-indigo-600", on)
+    }
+  }
+
+  // --- Sélection d'un séjour entier -----------------------------------------
+  handleClick(event) {
+    if (!this.active) return
+    const block = event.target.closest("[data-stay-id]")
+    if (!block) return
+    const id = block.dataset.stayId
+    if (!id) return
+
+    // Neutralise l'ouverture de la modale / la navigation du lien du bloc.
+    event.preventDefault()
+    event.stopPropagation()
+    this.toggleStay(block)
+  }
+
+  toggleStay(block) {
+    const id = String(block.dataset.stayId)
+    const existing = this.selection.findIndex((s) => String(s.id) === id)
+    if (existing >= 0) {
+      this.selection.splice(existing, 1)
+    } else {
+      this.selection.push({
+        id,
+        label: block.dataset.stayLabel || `Séjour #${id}`,
+        dates: block.dataset.stayDates || ""
+      })
+    }
+    this.persistSelection()
+    this.applySelectionStyles()
+    this.renderBar()
+  }
+
+  clearSelection() {
+    this.selection = []
+    this.persistSelection()
+    this.applySelectionStyles()
+    this.renderBar()
+  }
+
+  removeChip(event) {
+    const id = String(event.currentTarget.dataset.stayId)
+    this.selection = this.selection.filter((s) => String(s.id) !== id)
+    this.persistSelection()
+    this.applySelectionStyles()
+    this.renderBar()
+  }
+
+  // --- Rendu de la sélection (teinte séjour, estompage, badge ✓) -------------
+  applySelectionStyles() {
+    const ids = new Set(this.selection.map((s) => String(s.id)))
+    this.element.classList.toggle("has-selection", this.selection.length > 0)
+
+    const seen = new Set()
+    this.element.querySelectorAll("[data-stay-id]").forEach((block) => {
+      const id = String(block.dataset.stayId)
+      const selected = ids.has(id)
+      block.classList.toggle("merge-selected", selected)
+      if (selected) {
+        const hue = this.hueFor(id)
+        block.style.boxShadow = `0 0 0 2px hsl(${hue} 65% 45%), 0 0 0 5px hsl(${hue} 70% 90%)`
+        if (!seen.has(id)) {
+          seen.add(id)
+          this.addBadge(block, hue)
+        } else {
+          this.removeBadge(block)
+        }
+      } else {
+        block.style.boxShadow = ""
+        this.removeBadge(block)
+      }
+    })
+  }
+
+  addBadge(block, hue) {
+    if (block.querySelector(":scope > .merge-selection-badge")) return
+    const badge = document.createElement("span")
+    badge.className = "merge-selection-badge"
+    badge.style.backgroundColor = `hsl(${hue} 65% 45%)`
+    badge.textContent = "✓"
+    badge.setAttribute("aria-hidden", "true")
+    block.appendChild(badge)
+  }
+
+  removeBadge(block) {
+    const badge = block.querySelector(":scope > .merge-selection-badge")
+    if (badge) badge.remove()
+  }
+
+  // --- Bottom bar : chips + compteur + bouton --------------------------------
+  renderBar() {
+    if (!this.hasBarTarget) return
+    const count = this.selection.length
+
+    if (count === 0) {
+      this.barTarget.classList.add("translate-y-full")
+      this.barTarget.hidden = true
+      if (this.hasChipsTarget) this.chipsTarget.innerHTML = ""
+      return
+    }
+
+    this.barTarget.hidden = false
+    // rAF pour laisser le hidden=false s'appliquer avant la transition d'entrée.
+    requestAnimationFrame(() => this.barTarget.classList.remove("translate-y-full"))
+
+    if (this.hasCountTarget) {
+      this.countTarget.textContent = `${count} séjour${count > 1 ? "s" : ""} sélectionné${count > 1 ? "s" : ""}`
+    }
+    if (this.hasMergeButtonTarget) {
+      this.mergeButtonTarget.disabled = count < 2
+      this.mergeButtonTarget.title = count < 2 ? "Sélectionne au moins 2 séjours" : "Fusionner les séjours sélectionnés"
+      this.mergeButtonTarget.textContent = `Fusionner ${count} séjours`
+    }
+    if (this.hasChipsTarget) this.renderChips()
+  }
+
+  renderChips() {
+    this.chipsTarget.innerHTML = ""
+    this.selection.forEach((stay) => {
+      const hue = this.hueFor(stay.id)
+      const chip = document.createElement("span")
+      chip.className = "inline-flex items-center gap-1.5 flex-shrink-0 rounded-full border border-gray-200 bg-white pl-2 pr-1 py-1 text-xs text-gray-700"
+
+      const dot = document.createElement("span")
+      dot.className = "inline-block h-2.5 w-2.5 rounded-full flex-shrink-0"
+      dot.style.backgroundColor = `hsl(${hue} 65% 45%)`
+      chip.appendChild(dot)
+
+      const label = document.createElement("span")
+      label.className = "whitespace-nowrap"
+      const parts = [`#${stay.id}`, stay.label, stay.dates].filter((p) => p && p.length)
+      label.textContent = parts.join(" · ")
+      chip.appendChild(label)
+
+      const remove = document.createElement("button")
+      remove.type = "button"
+      remove.className = "ml-0.5 text-gray-400 hover:text-gray-600 px-1"
+      remove.textContent = "×"
+      remove.setAttribute("aria-label", `Retirer le séjour #${stay.id}`)
+      remove.dataset.stayId = stay.id
+      remove.dataset.action = "stay-merge#removeChip"
+      chip.appendChild(remove)
+
+      this.chipsTarget.appendChild(chip)
+    })
+  }
+
+  // --- Dialog 2 étapes (fragments serveur) -----------------------------------
+  async openDialog() {
+    if (this.selection.length < 2) return
+    this.setDialogLoading()
+    this.dialogTarget.showModal()
+    await this.loadSetup()
+  }
+
+  async loadSetup(targetId = null) {
+    const params = {}
+    if (targetId) params.target_id = targetId
+    await this.injectFragment(this.setupUrlValue, params)
+  }
+
+  async showPreview() {
+    const checked = this.dialogContentTarget.querySelector('input[name="target_id"]:checked')
+    this.lastTargetId = checked ? checked.value : null
+    this.setDialogLoading()
+    await this.injectFragment(this.previewUrlValue, this.lastTargetId ? { target_id: this.lastTargetId } : {})
+  }
+
+  async backToSetup() {
+    this.setDialogLoading()
+    await this.loadSetup(this.lastTargetId)
+  }
+
+  // Commit : le button_to (form réel) est intercepté ici pour rester DANS le
+  // dialog en cas d'erreur (422) et suivre la redirection en cas de succès.
+  async commit(event) {
+    event.preventDefault()
+    const form = event.currentTarget
+    try {
+      const response = await fetch(form.action, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new FormData(form)
+      })
+      const contentType = response.headers.get("content-type") || ""
+      if (response.ok && contentType.includes("json")) {
+        const data = await response.json()
+        window.location.href = data.redirect
+      } else {
+        // Garde-fou serveur : on ré-injecte le fragment d'aperçu avec l'erreur.
+        this.dialogContentTarget.innerHTML = await response.text()
+      }
+    } catch (_e) {
+      this.dialogContentTarget.innerHTML =
+        '<div class="px-6 py-8 text-center text-sm text-red-600">Erreur réseau — réessaie.</div>'
+    }
+  }
+
+  closeDialog(event) {
+    if (event) event.preventDefault()
+    if (this.hasDialogTarget && this.dialogTarget.open) this.dialogTarget.close()
+  }
+
+  // --- Helpers ---------------------------------------------------------------
+  setDialogLoading() {
+    this.dialogContentTarget.innerHTML =
+      '<div class="px-6 py-8 text-center text-sm text-gray-500">Chargement…</div>'
+  }
+
+  async injectFragment(url, extraParams) {
+    const body = new URLSearchParams()
+    this.selection.forEach((s) => body.append("stay_ids[]", s.id))
+    Object.entries(extraParams).forEach(([k, v]) => body.append(k, v))
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "X-CSRF-Token": this.csrfToken(),
+          Accept: "text/html"
+        },
+        body: body.toString()
+      })
+      this.dialogContentTarget.innerHTML = await response.text()
+    } catch (_e) {
+      this.dialogContentTarget.innerHTML =
+        '<div class="px-6 py-8 text-center text-sm text-red-600">Erreur de chargement.</div>'
+    }
+  }
+
+  hueFor(id) {
+    return Math.round((Number(id) * GOLDEN_ANGLE) % 360)
+  }
+
+  csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content || ""
+  }
+
+  handleKeydown(event) {
+    if (event.key !== "Escape") return
+    // Le dialog ouvert gère son propre Échap (fermeture native).
+    if (this.hasDialogTarget && this.dialogTarget.open) return
+    if (this.active) this.exitMode()
+  }
+
+  readSelection() {
+    try {
+      const raw = sessionStorage.getItem(STORAGE_SELECTION)
+      const parsed = raw ? JSON.parse(raw) : []
+      return Array.isArray(parsed) ? parsed : []
+    } catch (_e) {
+      return []
+    }
+  }
+
+  persistSelection() {
+    sessionStorage.setItem(STORAGE_SELECTION, JSON.stringify(this.selection))
+  }
+
+  clearStorage() {
+    sessionStorage.removeItem(STORAGE_ACTIVE)
+    sessionStorage.removeItem(STORAGE_SELECTION)
+  }
+}

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -22,6 +22,32 @@ module CalendarHelper
     "border-left-color: hsl(#{hue}, 65%, 45%); background-color: hsl(#{hue}, 70%, 96%);"
   end
 
+  # --- Méta séjour pour les chips de fusion (epic #81) ---------------------
+  # Posées en `data-stay-label` / `data-stay-dates` à côté du `data-stay-id`
+  # existant sur chaque bloc calendrier. Le contrôleur Stimulus `stay-merge`
+  # construit ses chips de bottom bar depuis ces attributs — pas de recalcul.
+
+  # Nom client court pour la chip (le nom du client de la modale est déjà long).
+  def stay_short_label(stay)
+    stay&.customer&.name.presence || "Séjour ##{stay&.id}"
+  end
+
+  # Dates compactes, ex. « 12–15 sept. » (même mois) ou « 30 août – 2 sept. ».
+  def stay_short_dates(stay)
+    return nil if stay.nil?
+
+    from = stay.arrival_date
+    to   = stay.departure_date
+    return nil if from.blank? && to.blank?
+    return abbr_day_month(from || to) if from.blank? || to.blank?
+
+    if from.month == to.month && from.year == to.year
+      "#{from.day}–#{to.day} #{abbr_month(from)}"
+    else
+      "#{abbr_day_month(from)} – #{abbr_day_month(to)}"
+    end
+  end
+
   def button_to_next_month(current_date, data = {}, options = {})
     link_to(params.permit(:date, :no_title, :view).merge(date: current_date.next_month), class: "btn-page-header-with-icon", data: data) do
       if options[:no_label].nil?
@@ -78,4 +104,15 @@ module CalendarHelper
   # def calendar(date = Date.today, from = "public", &block)
   #   Calendar.new(self, date, from, block).table
   # end
+
+  private
+
+  # Mois abrégé FR sans point superflu (ex. « sept. », « août »).
+  def abbr_month(date)
+    I18n.t("date.abbr_month_names")[date.month]
+  end
+
+  def abbr_day_month(date)
+    "#{date.day} #{abbr_month(date)}"
+  end
 end

--- a/app/helpers/stays_merge_helper.rb
+++ b/app/helpers/stays_merge_helper.rb
@@ -1,0 +1,87 @@
+module StaysMergeHelper
+  # --- Présélection intelligente du séjour survivant (epic #81) --------------
+  # Ordre de préférence :
+  #   1. un séjour qui PORTE DÉJÀ des paiements encaissés (ancre de paiement — on
+  #      évite de déplacer l'historique comptable) ;
+  #   2. à égalité, le séjour avec le PLUS D'OCCUPATIONS (composition la plus riche) ;
+  #   3. puis le PLUS ANCIEN (plus petit id).
+  # Renvoie `[stay, reason_key]` — la raison motive le badge « suggéré ».
+  def suggested_merge_target(stays)
+    return [nil, nil] if stays.blank?
+
+    paying = stays.select { |s| s.amount_paid_cents.positive? }
+
+    if paying.present?
+      target = paying.max_by { |s| [s.stay_items.size, -s.id] }
+      return [target, :payments]
+    end
+
+    max_items = stays.map { |s| s.stay_items.size }.max
+    richest = stays.select { |s| s.stay_items.size == max_items }
+
+    if richest.size == 1 && max_items.positive?
+      [richest.first, :occupations]
+    else
+      [stays.min_by(&:id), :oldest]
+    end
+  end
+
+  MERGE_SUGGESTION_REASONS = {
+    payments:    "porte déjà des paiements",
+    occupations: "composition la plus riche",
+    oldest:      "le plus ancien"
+  }.freeze
+
+  def merge_suggestion_reason(key)
+    MERGE_SUGGESTION_REASONS[key]
+  end
+
+  # Résumé compact de la composition d'un séjour : « 1 hébergement · 1 espace ·
+  # 2 repas ». N'affiche que les catégories présentes.
+  def stay_composition_summary(stay)
+    decorator = stay.decorate
+    parts = []
+    parts << pluralize_fr(decorator.lodging_bookings.size, "hébergement")
+    parts << pluralize_fr(decorator.space_bookings.size, "espace")
+    parts << pluralize_fr(decorator.camping_bookings.size, "camping", plural: "campings")
+    parts << pluralize_fr(decorator.van_bookings.size, "van")
+    parts << pluralize_fr(stay.experience_bookings.active.size, "activité", plural: "activités")
+    parts << pluralize_fr(stay.meal_orders.size, "repas", plural: "repas")
+    present = parts.compact
+    present.any? ? present.join(" · ") : "aucune composition"
+  end
+
+  # Résumé des paiements d'un séjour : « 2 paiements · 450 € encaissés » ou
+  # « aucun paiement » — pour la carte de désignation de cible.
+  def stay_payments_summary(stay)
+    paid = stay.payments.paid
+    count = paid.count
+    return "aucun paiement encaissé" if count.zero?
+
+    "#{pluralize_fr(count, 'paiement')} · #{humanized_money_with_symbol(Money.new(stay.amount_paid_cents))} encaissé#{'s' if count > 1}"
+  end
+
+  # Libellé français d'une catégorie de composition (titre de section d'aperçu).
+  MERGE_TYPE_LABELS = {
+    lodging:  "Hébergements",
+    space:    "Espaces",
+    camping:  "Camping",
+    van:      "Van",
+    activity: "Activités",
+    meal:     "Repas"
+  }.freeze
+
+  def merge_type_label(type)
+    MERGE_TYPE_LABELS.fetch(type, type.to_s.humanize)
+  end
+
+  private
+
+  # Pluralisation FR minimale (« 0 X » renvoie nil pour être filtré).
+  def pluralize_fr(count, singular, plural: nil)
+    return nil if count.to_i.zero?
+
+    word = count.to_i > 1 ? (plural || "#{singular}s") : singular
+    "#{count} #{word}"
+  end
+end

--- a/app/models/experience_booking.rb
+++ b/app/models/experience_booking.rb
@@ -31,6 +31,12 @@ class ExperienceBooking < ApplicationRecord
   belongs_to :experience_availability
   belongs_to :stay
 
+  # Audit (epic #81) : seul modèle rapatrié par la fusion de séjours qui n'avait
+  # pas encore d'historique (Stay/StayItem/MealOrder/Payment l'ont déjà). Un
+  # changement de `stay_id` (rattachement à un autre séjour) est ainsi tracé.
+  # Table `versions` par défaut (PK bigint compatible, contrairement à Payment).
+  has_paper_trail
+
   delegate :experience, to: :experience_availability
 
   validates :participants, numericality: { greater_than: 0 }

--- a/app/services/stays/merge_preview.rb
+++ b/app/services/stays/merge_preview.rb
@@ -1,0 +1,163 @@
+module Stays
+  # Aperçu (dry-run) d'une fusion de séjours SANS RIEN MUTER. Calcule le résultat
+  # qu'aurait `Stays::MergeService` : client conservé, dates en union, composition
+  # complète groupée par type (avec provenance), nouveau total, déjà payé, solde,
+  # et les avertissements pertinents.
+  #
+  # Garantie anti-divergence (epic #81) : la projection ici reproduit EXACTEMENT
+  # l'arithmétique de `Stay#recompute_aggregates!` (total + dates) et de
+  # `Stay#amount_paid_cents` (union `payments.stay_id` ∪ `payments.booking_id`)
+  # appliquée à l'ensemble fusionné. Un test de cohérence vérifie que, sur un même
+  # jeu de données, preview == résultat réel de la fusion.
+  class MergePreview
+    # Une ligne de composition projetée (hébergement, espace, repas, activité…).
+    CompositionItem = Struct.new(:type, :label, :origin_stay_id, :from_target, :amount_cents, keyword_init: true)
+    Warning = Struct.new(:kind, :message, keyword_init: true)
+    SourceRef = Struct.new(:id, :customer_name, keyword_init: true)
+
+    # Regroupe le résultat projeté pour la vue.
+    Result = Struct.new(
+      :target, :customer_name, :arrival_date, :departure_date,
+      :total_cents, :paid_cents, :balance_cents,
+      :composition, :sources, :warnings,
+      keyword_init: true
+    )
+
+    attr_reader :target, :sources
+
+    def initialize(target:, sources:)
+      @target = target
+      @sources = Array(sources).compact
+    end
+
+    def call
+      arrival, departure = projected_dates
+
+      Result.new(
+        target:         target,
+        customer_name:  target.customer&.name,
+        arrival_date:   arrival,
+        departure_date: departure,
+        total_cents:    projected_total_cents,
+        paid_cents:     projected_paid_cents,
+        balance_cents:  projected_total_cents - projected_paid_cents,
+        composition:    projected_composition,
+        sources:        sources.map { |s| SourceRef.new(id: s.id, customer_name: s.customer&.name) },
+        warnings:       build_warnings
+      )
+    end
+
+    private
+
+    def all_stays
+      @all_stays ||= [target, *sources]
+    end
+
+    # --- Total : mirror de `recompute_aggregates!` sur l'ensemble fusionné ----
+    # bookables (hébergement/espaces/camping/van) + activités ACTIVES + repas.
+    def projected_total_cents
+      all_stays.sum { |stay| computed_total_cents(stay) }
+    end
+
+    def computed_total_cents(stay)
+      stay.bookables.sum { |b| b.try(:price_cents).to_i } +
+        stay.experience_bookings.active.sum(&:price_cents) +
+        stay.meal_orders.sum { |m| m.price_cents.to_i }
+    end
+
+    # --- Déjà payé : mirror de `Stay#amount_paid_cents` post-fusion -----------
+    # Après fusion, la cible porte tous les StayItem (donc tous les booking_ids)
+    # et tous les `payments.stay_id` ré-ancrés. On projette exactement cette
+    # relation union pour ne jamais diverger du réel.
+    def projected_paid_cents
+      Payment.where(stay_id: all_stays.map(&:id))
+             .or(Payment.where(booking_id: projected_booking_ids))
+             .paid.sum(:amount_cents)
+    end
+
+    def projected_booking_ids
+      all_stays.flat_map do |stay|
+        stay.stay_items.select { |item| item.bookable_type == "Booking" }.map(&:bookable_id)
+      end
+    end
+
+    # --- Dates : mirror exact de `recompute_aggregates!` sur l'union ----------
+    def projected_dates
+      items = all_stays.flat_map(&:bookables)
+      arrivals   = items.filter_map { |b| b.try(:from_date) }
+      departures = items.filter_map { |b| b.try(:to_date) }
+
+      if arrivals.any? || departures.any?
+        [arrivals.min || target.arrival_date, departures.max || target.departure_date]
+      else
+        # Séjours sans bookable daté (activités/repas seuls) : dériver des dates
+        # portées par ces éléments, sinon conserver celles de la cible.
+        derived = all_stays.flat_map(&:activity_and_meal_dates)
+        derived.any? ? [derived.min, derived.max] : [target.arrival_date, target.departure_date]
+      end
+    end
+
+    # --- Composition projetée, groupée par type, avec provenance --------------
+    def projected_composition
+      items = []
+      all_stays.each do |stay|
+        from_target = stay.id == target.id
+        decorator = stay.decorate
+
+        decorator.lodging_bookings.each { |b| items << item(:lodging, decorator.item_label(b), stay, from_target, b.try(:price_cents)) }
+        decorator.space_bookings.each  { |b| items << item(:space,   decorator.item_label(b), stay, from_target, b.try(:price_cents)) }
+        decorator.camping_bookings.each { |b| items << item(:camping, decorator.item_label(b), stay, from_target, b.try(:price_cents)) }
+        decorator.van_bookings.each    { |b| items << item(:van,     decorator.item_label(b), stay, from_target, b.try(:price_cents)) }
+        stay.experience_bookings.active.each { |eb| items << item(:activity, eb.experience.name, stay, from_target, eb.price_cents) }
+        stay.meal_orders.each          { |m| items << item(:meal, m.label, stay, from_target, m.price_cents) }
+      end
+      items
+    end
+
+    def item(type, label, stay, from_target, amount_cents)
+      CompositionItem.new(
+        type:           type,
+        label:          label,
+        origin_stay_id: stay.id,
+        from_target:    from_target,
+        amount_cents:   amount_cents.to_i
+      )
+    end
+
+    # --- Avertissements contextuels (ambre) -----------------------------------
+    def build_warnings
+      warnings = []
+
+      overwritten = sources.select { |s| s.customer_id != target.customer_id }
+      if overwritten.any?
+        names = overwritten.map { |s| s.customer&.name }.compact_blank.uniq.join(", ")
+        warnings << Warning.new(
+          kind: :different_customers,
+          message: "Clients différents : le client de la cible (#{target.customer&.name}) est conservé, ces clients seront écartés — #{names}."
+        )
+      end
+
+      sources.each do |source|
+        next unless source.payments.pending.any?
+
+        warnings << Warning.new(
+          kind: :pending_payment,
+          message: "Le séjour ##{source.id} porte un paiement en attente — vérifier avant de fusionner."
+        )
+      end
+
+      dupes = all_stays
+              .select { |s| s.arrival_date.present? && s.departure_date.present? }
+              .group_by { |s| [s.arrival_date, s.departure_date] }
+              .select { |_dates, group| group.size > 1 }
+      dupes.each do |dates, group|
+        warnings << Warning.new(
+          kind: :identical_dates,
+          message: "Dates identiques (#{I18n.l(dates.first, format: :long)} → #{I18n.l(dates.last, format: :long)}) entre les séjours #{group.map { |s| "##{s.id}" }.join(', ')} — possible doublon."
+        )
+      end
+
+      warnings
+    end
+  end
+end

--- a/app/services/stays/merge_service.rb
+++ b/app/services/stays/merge_service.rb
@@ -34,15 +34,28 @@ module Stays
       return false unless valid_operands?
 
       catch_error(context: { target: target.id, sources: sources.map(&:id) }) do
-        ActiveRecord::Base.transaction do
+        result = ActiveRecord::Base.transaction do
+          # Verrou pessimiste : deux fusions concurrentes sur des ensembles qui
+          # se recoupent (deux onglets, cibles croisées) passeraient toutes deux
+          # les garde-fous lus hors transaction, et pourraient éparpiller des
+          # occupations sur des séjours archivés. On verrouille les lignes puis
+          # on re-vérifie l'état sous le verrou.
+          raise ActiveRecord::Rollback unless lock_operands!
+
           sources.each { |source| absorb!(source) }
           # Les associations de la cible ont changé en base : on recharge avant de
           # recalculer, sinon `recompute_aggregates!` lirait un cache périmé.
           target.reload
           target.recompute_aggregates!
-          target.set_payment_status
+          # `set_payment_status` est non-bang (partagé avec le webhook Stripe) :
+          # ici, un échec silencieux violerait le tout-ou-rien de la fusion.
+          unless target.set_payment_status
+            set_error_message("Le statut de paiement n'a pas pu être recalculé : #{validation_errors_for(target)}")
+            raise ActiveRecord::Rollback
+          end
           true
         end
+        result || false
       end
     end
 
@@ -60,6 +73,25 @@ module Stays
 
       return set_error_message("La cible est déjà supprimée.") && false if soft_deleted?(target)
       return set_error_message("Une source est déjà supprimée.") && false if sources.any? { |s| soft_deleted?(s) }
+
+      true
+    end
+
+    # Verrouille toutes les lignes concernées (FOR UPDATE, ordre d'id stable
+    # pour éviter les deadlocks) et re-vérifie sous le verrou qu'aucun séjour
+    # n'a été supprimé entre les garde-fous et la transaction.
+    def lock_operands!
+      ids = ([target.id] + sources.map(&:id)).sort
+      locked = Stay.unscoped.where(id: ids).lock("FOR UPDATE").to_a
+
+      if locked.size != ids.size
+        set_error_message("Un des séjours n'existe plus.")
+        return false
+      end
+      if locked.any? { |stay| stay.deleted_at.present? }
+        set_error_message("Un des séjours vient d'être supprimé (fusion concurrente ?). Recharge la page.")
+        return false
+      end
 
       true
     end

--- a/app/services/stays/merge_service.rb
+++ b/app/services/stays/merge_service.rb
@@ -1,0 +1,111 @@
+module Stays
+  # Fusion de séjours (epic #81, Phase 2). Réunit plusieurs Stay saisis
+  # séparément — typiquement d'anciens Booking / SpaceBooking d'un même séjour
+  # client, saisis chacun de leur côté — en un seul. Outil d'assainissement de
+  # l'historique (jusqu'à 2023) : la robustesse sur données legacy imparfaites
+  # prime, d'où des garde-fous stricts et une exécution tout-ou-rien.
+  #
+  # Calqué sur Customers::MergeService (source→cible, transaction, PaperTrail,
+  # soft-delete des sources vidées).
+  #
+  # Règle déterministe : la CIBLE gagne. On ne touche JAMAIS au customer_id de
+  # la cible, même si une source porte un client différent. Toutes les
+  # occupations des sources migrent vers la cible :
+  #   - StayItem (tous les bookables : Booking, SpaceBooking, CampingBooking,
+  #     VanBooking) ;
+  #   - MealOrder et ExperienceBooking (rattachés en direct via stay_id) ;
+  #   - Payment (ancre stay_id, désormais obligatoire — issue #26 Phase 4).
+  # Puis chaque source vidée est soft-deletée, et les agrégats de la cible sont
+  # recalculés (dates = union, total recalculé, statut de paiement réévalué).
+  class MergeService < ServiceBase
+    attr_reader :target, :sources, :items_moved
+
+    def self.call(target:, sources:)
+      new(target: target, sources: sources).run
+    end
+
+    def initialize(target:, sources:)
+      @target = target
+      @sources = Array(sources).compact
+      @items_moved = 0
+    end
+
+    def run
+      return false unless valid_operands?
+
+      catch_error(context: { target: target.id, sources: sources.map(&:id) }) do
+        ActiveRecord::Base.transaction do
+          sources.each { |source| absorb!(source) }
+          # Les associations de la cible ont changé en base : on recharge avant de
+          # recalculer, sinon `recompute_aggregates!` lirait un cache périmé.
+          target.reload
+          target.recompute_aggregates!
+          target.set_payment_status
+          true
+        end
+      end
+    end
+
+    private
+
+    # Garde-fous : refuse toute fusion ambiguë ou dangereuse plutôt que de
+    # corrompre des données legacy. Chaque refus pose un message explicite.
+    def valid_operands?
+      return set_error_message("La cible est requise.") && false if target.nil?
+      return set_error_message("Au moins une source est requise pour une fusion.") && false if sources.empty?
+      return set_error_message("La cible ne peut pas figurer parmi les sources.") && false if sources.any? { |s| s.id == target.id }
+
+      ids = sources.map(&:id)
+      return set_error_message("Une même source est présente plusieurs fois.") && false if ids.uniq.length != ids.length
+
+      return set_error_message("La cible est déjà supprimée.") && false if soft_deleted?(target)
+      return set_error_message("Une source est déjà supprimée.") && false if sources.any? { |s| soft_deleted?(s) }
+
+      true
+    end
+
+    # Migre toutes les occupations d'une source vers la cible, puis la vide.
+    def absorb!(source)
+      move_stay_items!(source)
+      move_direct!(source.meal_orders)
+      move_direct!(source.experience_bookings)
+      move_payments!(source)
+
+      # Source désormais vidée de toutes ses occupations : soft-delete (comme
+      # Customers::MergeService, validate: false pour ne pas buter sur d'éventuels
+      # invariants legacy).
+      source.soft_delete!(validate: false)
+    end
+
+    # StayItem polymorphe : Booking / SpaceBooking / CampingBooking / VanBooking.
+    def move_stay_items!(source)
+      source.stay_items.find_each do |item|
+        item.update!(stay_id: target.id) # tracé PaperTrail
+        @items_moved += 1
+      end
+    end
+
+    # Éléments rattachés en direct au séjour (MealOrder, ExperienceBooking) :
+    # simple bascule du stay_id.
+    def move_direct!(relation)
+      relation.find_each do |record|
+        record.update!(stay_id: target.id)
+        @items_moved += 1
+      end
+    end
+
+    # Paiements rattachés à la source par leur ANCRE réelle (stay_id). On ne
+    # s'appuie pas sur Stay#payments (qui unit aussi le lien historique
+    # booking_id) : la fusion déplace l'ancre, pas les rattachements dérivés.
+    def move_payments!(source)
+      Payment.where(stay_id: source.id).find_each do |payment|
+        payment.update!(stay_id: target.id) # tracé via PaymentVersion (PaperTrail)
+        @items_moved += 1
+      end
+    end
+
+    def soft_deleted?(stay)
+      stay.deleted_at.present?
+    end
+  end
+end

--- a/app/services/stays/merge_service.rb
+++ b/app/services/stays/merge_service.rb
@@ -73,7 +73,11 @@ module Stays
 
       # Source désormais vidée de toutes ses occupations : soft-delete (comme
       # Customers::MergeService, validate: false pour ne pas buter sur d'éventuels
-      # invariants legacy).
+      # invariants legacy). Le reload est OBLIGATOIRE : si l'appelant a préchargé
+      # stay_items (includes du contrôleur), la cascade dependent: :destroy du
+      # soft-delete relirait le cache d'association et supprimerait les items
+      # pourtant déjà migrés vers la cible.
+      source.reload
       source.soft_delete!(validate: false)
     end
 

--- a/app/services/stays/merge_service.rb
+++ b/app/services/stays/merge_service.rb
@@ -1,0 +1,67 @@
+module Stays
+  # Fusion de séjours (epic #81). Rapatrie TOUTE la composition d'un ou plusieurs
+  # séjours SOURCES sur un séjour CIBLE (le « survivant »), puis soft-delete les
+  # sources vidées. Sert l'assainissement de l'historique : des dizaines de
+  # doublons legacy (Tally / OTA / imports) à recoller à la main.
+  #
+  # Ce qui migre vers la cible (chaque déplacement est tracé par PaperTrail) :
+  #   - les `StayItem` (hébergement / espace / camping / van) ;
+  #   - les `ExperienceBooking` (activités) ;
+  #   - les `MealOrder` (repas) ;
+  #   - les `Payment` ancrés DIRECTEMENT sur le séjour (`payments.stay_id`). Les
+  #     paiements ancrés via le booking suivent automatiquement leur StayItem.
+  #
+  # Règles fixes :
+  #   - le CLIENT conservé est celui de la CIBLE (comme Customers::MergeService,
+  #     « la cible gagne ») ;
+  #   - dates recalculées en UNION (min arrivée / max départ) via
+  #     `recompute_aggregates!` — même source de vérité que partout ;
+  #   - total et statut de paiement recalculés depuis la composition rapatriée.
+  #
+  # `Stays::MergePreview` calcule le MÊME résultat en dry-run (aperçu serveur) ;
+  # un test de cohérence garantit que preview == fusion réelle.
+  class MergeService < ServiceBase
+    attr_reader :target, :sources, :merged_count
+
+    def initialize(target:, sources:)
+      @target = target
+      @sources = Array(sources).compact
+      @merged_count = 0
+    end
+
+    def run
+      return set_error_message("Séjour cible manquant.") && false if target.nil?
+      return set_error_message("Sélectionne au moins deux séjours à fusionner.") && false if sources.empty?
+      return set_error_message("La cible ne peut pas figurer parmi les sources.") && false if sources.any? { |s| s.id == target.id }
+
+      catch_error(context: { target: target.id, sources: sources.map(&:id) }) do
+        ActiveRecord::Base.transaction do
+          sources.each { |source| absorb!(source) }
+
+          target.reload
+          target.recompute_aggregates! # total + dates (union) — source unique de vérité
+          target.set_payment_status    # statut de paiement d'après l'encaissé rapatrié
+
+          true
+        end
+      end
+    end
+
+    private
+
+    # Rapatrie toute la composition d'un séjour source sur la cible, puis le
+    # soft-delete une fois vidé. Chaque `update!` est tracé (PaperTrail).
+    def absorb!(source)
+      source.stay_items.each         { |item| item.update!(stay_id: target.id) }
+      source.experience_bookings.each { |eb|  eb.update!(stay_id: target.id) }
+      source.meal_orders.each        { |meal| meal.update!(stay_id: target.id) }
+      # Paiements ancrés directement sur le séjour (issue #26) : à ré-ancrer.
+      # Ceux liés via le booking suivent leur StayItem sans action.
+      Payment.where(stay_id: source.id).find_each { |payment| payment.update!(stay_id: target.id) }
+
+      source.reload
+      source.soft_delete!(validate: false)
+      @merged_count += 1
+    end
+  end
+end

--- a/app/views/pages/calendar.html.slim
+++ b/app/views/pages/calendar.html.slim
@@ -11,9 +11,13 @@
 - if @calendar_view == :organisation
   = render "pages/calendar/organisation"
 - else
-  / Enveloppe la grille dans le contrôleur stay-details : les blocs du calendrier
-  / ouvrent la modale séjour (epic #66, Phase 5) qui vit à la fin, dans la même
-  / portée Stimulus.
-  div(data-controller="stay-details")
+  / Enveloppe la grille dans les contrôleurs stay-details ET stay-merge (epic #81) :
+  / les blocs ouvrent la modale séjour (Phase 5) ou, en mode fusion, se sélectionnent.
+  / `stay_merge_done` (posé par la redirection post-fusion) déclenche le nettoyage
+  / du sessionStorage et la sortie du mode côté contrôleur.
+  div(data-controller="stay-details stay-merge" data-stay-merge-setup-url-value=merge_setup_stays_path data-stay-merge-preview-url-value=merge_preview_stays_path data-stay-merge-reset-value=params[:stay_merge_done].present?)
+    = render "pages/calendar/merge_toolbar"
     = render "pages/calendar/bookings"
     = render "pages/calendar/stay_modal"
+    = render "pages/calendar/merge_dialog"
+    = render "pages/calendar/merge_bottom_bar"

--- a/app/views/pages/calendar/_bookings.html.slim
+++ b/app/views/pages/calendar/_bookings.html.slim
@@ -37,7 +37,7 @@
                    space_booking: space_booking
           div[data-popper-arrow]
 
-      div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{space_booking.calendar_block_class}" style=block_style data-space-booking-day-entry=space_booking.id data-stay-id=stay&.id)
+      div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{space_booking.calendar_block_class}" style=block_style data-space-booking-day-entry=space_booking.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
         .block.min-w-0.w-full
           div.min-w-0
             strong.block.min-w-0.break-words

--- a/app/views/pages/calendar/_day_bookings.html.slim
+++ b/app/views/pages/calendar/_day_bookings.html.slim
@@ -19,7 +19,7 @@
                  booking: booking
         div[data-popper-arrow]
 
-    div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_block_class}" style=block_style data-booking-day-entry=booking.id data-stay-id=stay&.id)
+    div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_block_class}" style=block_style data-booking-day-entry=booking.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
       .block.min-w-0.w-full
         div.min-w-0
           strong.block.min-w-0.break-words
@@ -50,7 +50,7 @@
   - @grouped_camping_bookings[date].sort_by { |cb| [cb.stay&.id.to_i, cb.from_date.to_s] }.each do |camping|
     - stay = camping.stay
     - block_style = stay ? stay_block_style(stay.id) : "border-left-color: #0d9488; background-color: #f0fdfa;"
-    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"hover:cursor-pointer hover:shadow-xl" if stay} #{"opacity-50" unless camping.confirmed?}" style=block_style data-camping-booking-entry=camping.id data-stay-id=stay&.id)
+    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"hover:cursor-pointer hover:shadow-xl" if stay} #{"opacity-50" unless camping.confirmed?}" style=block_style data-camping-booking-entry=camping.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
       .block.min-w-0.w-full
         strong.block.min-w-0.break-words.text-gray-700
           = camping.group_name.presence || camping.name.presence || "Camping"
@@ -65,7 +65,7 @@
   - @grouped_van_bookings[date].sort_by { |vb| [vb.stay&.id.to_i, vb.from_date.to_s] }.each do |van|
     - stay = van.stay
     - block_style = stay ? stay_block_style(stay.id) : "border-left-color: #0d9488; background-color: #f0fdfa;"
-    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"hover:cursor-pointer hover:shadow-xl" if stay} #{"opacity-50" unless van.confirmed?}" style=block_style data-van-booking-entry=van.id data-stay-id=stay&.id)
+    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"hover:cursor-pointer hover:shadow-xl" if stay} #{"opacity-50" unless van.confirmed?}" style=block_style data-van-booking-entry=van.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
       .block.min-w-0.w-full
         strong.block.min-w-0.break-words.text-gray-700
           = van.group_name.presence || van.name.presence || "Van"

--- a/app/views/pages/calendar/_merge_bottom_bar.html.slim
+++ b/app/views/pages/calendar/_merge_bottom_bar.html.slim
@@ -1,0 +1,15 @@
+/ Barre d'action contextuelle de fusion (epic #81, Phase 2). Fixée en bas,
+/ masquée (translate-y-full) tant qu'aucun séjour n'est sélectionné. Les chips
+/ sont construites côté client depuis les data-attributes des blocs (label +
+/ dates), le contrôleur stay-merge en pilote l'affichage.
+.stay-merge-bar.fixed.bottom-0.inset-x-0.z-30.translate-y-full.bg-white.border-t.border-gray-200(data-stay-merge-target="bar" hidden=true style="box-shadow: 0 -4px 12px rgba(0,0,0,0.08);")
+  .max-w-6xl.mx-auto.px-4.py-3.flex.items-center.gap-4.flex-wrap
+    / Chips (scrollables horizontalement en mobile).
+    .flex-1.min-w-0.flex.items-center.gap-2.overflow-x-auto(data-stay-merge-target="chips")
+
+    .flex.items-center.gap-3.flex-shrink-0
+      span.text-sm.text-gray-500(data-stay-merge-target="count" aria-live="polite")
+      button.text-sm.font-medium.text-gray-500.hover:text-gray-700(type="button" data-action="stay-merge#clearSelection")
+        | Tout désélectionner
+      button.inline-flex.items-center.rounded-md.bg-indigo-600.px-4.py-2.text-sm.font-medium.text-white.shadow-sm.hover:bg-indigo-700.disabled:opacity-50.disabled:cursor-not-allowed(type="button" data-stay-merge-target="mergeButton" data-action="stay-merge#openDialog" disabled=true title="Sélectionne au moins 2 séjours")
+        | Fusionner

--- a/app/views/pages/calendar/_merge_dialog.html.slim
+++ b/app/views/pages/calendar/_merge_dialog.html.slim
@@ -1,0 +1,8 @@
+/ Dialog natif de fusion (epic #81, Phase 2) — 2 étapes (désignation puis
+/ aperçu) alimentées par fetch des fragments serveur, injectés dans le contenu.
+/ Même pattern que la modale séjour (stay-details) : <dialog> + Stimulus.
+dialog.rounded-lg.p-0.shadow-xl.w-full.max-w-lg.backdrop:bg-black/40(data-stay-merge-target="dialog")
+  .flex.justify-end.px-3.pt-3
+    button.text-gray-400.hover:text-gray-600(type="button" data-action="stay-merge#closeDialog" aria-label="Fermer")
+      | ✕
+  div(data-stay-merge-target="dialogContent")

--- a/app/views/pages/calendar/_merge_toolbar.html.slim
+++ b/app/views/pages/calendar/_merge_toolbar.html.slim
@@ -18,7 +18,9 @@ css:
   .stay-merge-bar { transition: transform .15s ease; }
 
 .flex.items-center.gap-3.mb-4
-  button.inline-flex.items-center.gap-1.5.rounded-md.border.border-gray-300.bg-white.px-3.py-1.5.text-sm.font-medium.text-gray-700.shadow-sm.hover:bg-gray-50(type="button" data-stay-merge-target="toggleButton" data-action="stay-merge#toggle" aria-pressed="false")
+  / `gap-1.5` / `py-1.5` en attribut class : la notation à points de Slim
+  / scinderait `gap-1.5` en deux classes (`gap-1` + `5`).
+  button.inline-flex.items-center.rounded-md.border.border-gray-300.bg-white.px-3.text-sm.font-medium.text-gray-700.shadow-sm.hover:bg-gray-50(class="gap-1.5 py-1.5" type="button" data-stay-merge-target="toggleButton" data-action="stay-merge#toggle" aria-pressed="false")
     svg.h-4.w-4(xmlns="http://www.w3.org/2000/svg" fill="none" viewbox="0 0 24 24" stroke-width="1.8" stroke="currentColor")
       path(stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5")
     span Fusionner des séjours

--- a/app/views/pages/calendar/_merge_toolbar.html.slim
+++ b/app/views/pages/calendar/_merge_toolbar.html.slim
@@ -1,0 +1,30 @@
+/ Barre-outil de fusion (epic #81, Phase 2) — vue mois uniquement. Le bouton
+/ bascule le MODE FUSION ; il vit DANS la portée du contrôleur stay-merge (les
+/ actions Stimulus ne se lient qu'à l'intérieur de l'élément-contrôleur, d'où sa
+/ place ici plutôt que dans l'entête de page global).
+css:
+  .merge-mode [data-stay-id] { transition: opacity .15s ease, box-shadow .15s ease; cursor: pointer; }
+  .merge-mode.has-selection [data-stay-id]:not(.merge-selected) { opacity: .45; }
+  /* En mode fusion, le lien-overlay du bloc est neutralisé : le clic sélectionne
+     le séjour au lieu d'ouvrir la modale (la capture JS le double par sécurité). */
+  .merge-mode [data-stay-id] a[data-action~="stay-details#open"] { pointer-events: none; }
+  .merge-selection-badge {
+    position: absolute; top: 2px; right: 2px; z-index: 5;
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 18px; height: 18px; border-radius: 9999px;
+    color: #fff; font-size: 11px; line-height: 1; font-weight: 700;
+    box-shadow: 0 1px 2px rgba(0,0,0,.25);
+  }
+  .stay-merge-bar { transition: transform .15s ease; }
+
+.flex.items-center.gap-3.mb-4
+  button.inline-flex.items-center.gap-1.5.rounded-md.border.border-gray-300.bg-white.px-3.py-1.5.text-sm.font-medium.text-gray-700.shadow-sm.hover:bg-gray-50(type="button" data-stay-merge-target="toggleButton" data-action="stay-merge#toggle" aria-pressed="false")
+    svg.h-4.w-4(xmlns="http://www.w3.org/2000/svg" fill="none" viewbox="0 0 24 24" stroke-width="1.8" stroke="currentColor")
+      path(stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5")
+    span Fusionner des séjours
+
+/ Bandeau contextuel du mode fusion (affiché par le contrôleur).
+.hidden.items-center.justify-between.gap-3.rounded-md.border.border-indigo-200.bg-indigo-50.px-4.py-2.mb-4.text-sm.text-indigo-800(data-stay-merge-target="banner")
+  span Mode fusion — clique les séjours à fusionner, puis désigne le survivant.
+  button.font-medium.text-indigo-700.hover:text-indigo-900(type="button" data-action="stay-merge#toggle")
+    | Quitter

--- a/app/views/stays/_merge_error.html.slim
+++ b/app/views/stays/_merge_error.html.slim
@@ -1,0 +1,8 @@
+/ Fragment d'erreur de garde-fou serveur (epic #81) — rendu DANS le dialog de
+/ fusion (jamais perdu), status 422. Ex. moins de deux séjours résolus.
+.px-6.py-8(data-merge-step="error")
+  .rounded-md.border.border-red-200.bg-red-50.px-4.py-3.text-sm.text-red-700(role="alert")
+    = message
+  .mt-6.flex.justify-end
+    button.text-sm.font-medium.text-gray-600.hover:text-gray-800(type="button" data-action="stay-merge#closeDialog")
+      | Fermer

--- a/app/views/stays/_merge_preview.html.slim
+++ b/app/views/stays/_merge_preview.html.slim
@@ -21,7 +21,7 @@
   .mt-4.rounded-lg.border.border-gray-200.bg-white.p-4(style="border-left-width: 4px; border-left-color: hsl(#{target_hue}, 65%, 45%);")
     .flex.items-center.flex-wrap.gap-2
       span.font-semibold.text-gray-900 Séjour ##{target.id}
-      span.inline-flex.items-center.rounded-full.bg-indigo-50.px-2.py-0.5.text-xs.font-medium.text-indigo-700 survivant
+      span.inline-flex.items-center.rounded-full.bg-indigo-50.px-2.text-xs.font-medium.text-indigo-700(class="py-0.5") survivant
       span.text-gray-700 = preview.customer_name
     .mt-1.text-sm.text-gray-500
       - if preview.arrival_date.present? || preview.departure_date.present?

--- a/app/views/stays/_merge_preview.html.slim
+++ b/app/views/stays/_merge_preview.html.slim
@@ -1,0 +1,85 @@
+/ Étape B de la fusion (epic #81, Phase 2) — aperçu dry-run SERVEUR (source de
+/ vérité). Tout ce qui est affiché ici sort de Stays::MergePreview : jamais
+/ recalculé en JS. Le commit est un button_to (form réel) intercepté par le
+/ contrôleur Stimulus stay-merge pour rester DANS le dialog en cas d'erreur.
+- target = preview.target
+- target_hue = stay_hue(target.id)
+- all_ids = [target.id, *preview.sources.map(&:id)]
+- ordered_types = %i[lodging space camping van activity meal]
+- grouped = preview.composition.group_by(&:type)
+
+.px-6.py-5(data-merge-step="preview")
+  - if error.present?
+    .mb-4.rounded-md.border.border-red-200.bg-red-50.px-4.py-3.text-sm.text-red-700(role="alert")
+      = error
+
+  h3.text-lg.font-semibold.text-gray-900 Aperçu de la fusion
+  p.mt-1.text-sm.text-gray-500
+    | Résultat une fois les séjours sources rapatriés sur le survivant.
+
+  / --- Carte du séjour survivant après fusion --------------------------------
+  .mt-4.rounded-lg.border.border-gray-200.bg-white.p-4(style="border-left-width: 4px; border-left-color: hsl(#{target_hue}, 65%, 45%);")
+    .flex.items-center.flex-wrap.gap-2
+      span.font-semibold.text-gray-900 Séjour ##{target.id}
+      span.inline-flex.items-center.rounded-full.bg-indigo-50.px-2.py-0.5.text-xs.font-medium.text-indigo-700 survivant
+      span.text-gray-700 = preview.customer_name
+    .mt-1.text-sm.text-gray-500
+      - if preview.arrival_date.present? || preview.departure_date.present?
+        = "#{preview.arrival_date ? l(preview.arrival_date, format: :long) : '?'} → #{preview.departure_date ? l(preview.departure_date, format: :long) : '?'}"
+      - else
+        | —
+
+    / Composition complète groupée par type, avec provenance.
+    .mt-4.space-y-3
+      - ordered_types.each do |type|
+        - items = grouped[type]
+        - next if items.blank?
+        div
+          .text-xs.font-semibold.uppercase.tracking-wide.text-gray-400 = merge_type_label(type)
+          ul.mt-1.space-y-1
+            - items.each do |item|
+              li.flex.items-center.justify-between.gap-2.text-sm
+                .min-w-0.flex-1.text-gray-700
+                  = item.label
+                  - unless item.from_target
+                    span.ml-1.text-xs.text-gray-400 depuis ##{item.origin_stay_id}
+                span.text-gray-600 = humanized_money_with_symbol(Money.new(item.amount_cents))
+
+    / Totaux recalculés.
+    .mt-4.border-t.border-gray-100.pt-3.space-y-1.text-sm
+      .flex.items-center.justify-between
+        span.text-gray-500 Nouveau total
+        span.font-semibold.text-gray-900 = humanized_money_with_symbol(Money.new(preview.total_cents))
+      .flex.items-center.justify-between
+        span.text-gray-500 Déjà payé
+        span.text-gray-700 = humanized_money_with_symbol(Money.new(preview.paid_cents))
+      .flex.items-center.justify-between
+        span.text-gray-500 Nouveau solde
+        span.font-semibold.text-gray-900 = humanized_money_with_symbol(Money.new(preview.balance_cents))
+
+  / --- Séjours sources (archivés) --------------------------------------------
+  - if preview.sources.any?
+    .mt-4
+      .text-xs.font-semibold.uppercase.tracking-wide.text-gray-400 Séjours archivés
+      ul.mt-1.space-y-1
+        - preview.sources.each do |source|
+          - source_hue = stay_hue(source.id)
+          li.flex.items-center.gap-2.text-sm.text-gray-600
+            span.inline-block.h-3.w-3.rounded-full.flex-shrink-0(style="background-color: hsl(#{source_hue}, 65%, 45%);")
+            span ##{source.id} (#{source.customer_name}) → archivé
+
+  / --- Avertissements contextuels --------------------------------------------
+  - if preview.warnings.any?
+    .mt-4.space-y-2
+      - preview.warnings.each do |warning|
+        .rounded-md.border.border-amber-200.bg-amber-50.px-4.py-2.text-sm.text-amber-800
+          = warning.message
+
+  / --- Actions ---------------------------------------------------------------
+  .mt-6.flex.items-center.justify-between.gap-3
+    button.text-sm.font-medium.text-gray-600.hover:text-gray-800(type="button" data-action="stay-merge#backToSetup")
+      | ← Modifier la cible
+    .flex.items-center.gap-3
+      button.text-sm.font-medium.text-gray-600.hover:text-gray-800(type="button" data-action="stay-merge#closeDialog")
+        | Annuler
+      = button_to "Confirmer la fusion", merge_stays_path, params: { target_id: target.id, stay_ids: all_ids }, method: :post, form: { data: { action: "submit->stay-merge#commit" } }, class: "inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"

--- a/app/views/stays/_merge_setup.html.slim
+++ b/app/views/stays/_merge_setup.html.slim
@@ -1,0 +1,40 @@
+/ Étape A de la fusion (epic #81, Phase 2) — désignation du séjour survivant.
+/ Rendu PAR LE SERVEUR (aucune donnée reconstruite en JS) et injecté dans le
+/ <dialog> par le contrôleur Stimulus stay-merge. Cartes radio riches, avec
+/ présélection intelligente motivée (badge « suggéré »).
+- different_customers = stays.map(&:customer_id).uniq.size > 1
+
+.px-6.py-5(data-merge-step="setup")
+  h3.text-lg.font-semibold.text-gray-900
+    | Fusionner #{stays.size} séjours
+  p.mt-1.text-sm.text-gray-500
+    | Choisis le séjour survivant : sa fiche client est conservée, tout le reste y est rapatrié.
+
+  - if different_customers
+    .mt-4.rounded-md.border.border-amber-200.bg-amber-50.px-4.py-3.text-sm.text-amber-800
+      | Clients différents : le client du séjour survivant sera conservé, les autres seront écartés.
+
+  .mt-4.space-y-3
+    - stays.each do |stay|
+      - hue = stay_hue(stay.id)
+      - decorated = stay.decorate
+      label.flex.items-start.gap-3.rounded-lg.border.border-gray-200.bg-white.p-4.cursor-pointer.hover:border-indigo-300.transition-colors(style="border-left-width: 4px; border-left-color: hsl(#{hue}, 65%, 45%);")
+        input.mt-1.h-4.w-4.text-indigo-600(type="radio" name="target_id" value=stay.id checked=(stay.id == target&.id) data-action="stay-merge#targetChanged")
+        .min-w-0.flex-1
+          .flex.items-center.flex-wrap.gap-2
+            span.font-semibold.text-gray-900 ##{stay.id}
+            span.text-gray-700 = stay_short_label(stay)
+            - if stay.id == suggested_id
+              span.inline-flex.items-center.rounded-full.bg-indigo-50.px-2.py-0.5.text-xs.font-medium.text-indigo-700(title="Présélection : #{merge_suggestion_reason(suggested_reason)}")
+                | suggéré · #{merge_suggestion_reason(suggested_reason)}
+          .mt-0.5.text-sm.text-gray-500 = decorated.date_range
+          .mt-1.text-sm.text-gray-600 = stay_composition_summary(stay)
+          .mt-1.flex.items-center.flex-wrap.gap-x-3.gap-y-1.text-sm
+            span.font-medium.text-gray-900 = humanized_money_with_symbol(stay.total_amount)
+            span.text-gray-500 = stay_payments_summary(stay)
+
+  .mt-6.flex.items-center.justify-end.gap-3
+    button.text-sm.font-medium.text-gray-600.hover:text-gray-800(type="button" data-action="stay-merge#closeDialog")
+      | Annuler
+    button.inline-flex.items-center.rounded-md.bg-indigo-600.px-4.py-2.text-sm.font-medium.text-white.shadow-sm.hover:bg-indigo-700(type="button" data-action="stay-merge#showPreview")
+      | Voir l'aperçu →

--- a/app/views/stays/_merge_setup.html.slim
+++ b/app/views/stays/_merge_setup.html.slim
@@ -25,9 +25,9 @@
             span.font-semibold.text-gray-900 ##{stay.id}
             span.text-gray-700 = stay_short_label(stay)
             - if stay.id == suggested_id
-              span.inline-flex.items-center.rounded-full.bg-indigo-50.px-2.py-0.5.text-xs.font-medium.text-indigo-700(title="Présélection : #{merge_suggestion_reason(suggested_reason)}")
+              span.inline-flex.items-center.rounded-full.bg-indigo-50.px-2.text-xs.font-medium.text-indigo-700(class="py-0.5" title="Présélection : #{merge_suggestion_reason(suggested_reason)}")
                 | suggéré · #{merge_suggestion_reason(suggested_reason)}
-          .mt-0.5.text-sm.text-gray-500 = decorated.date_range
+          .text-sm.text-gray-500(class="mt-0.5") = decorated.date_range
           .mt-1.text-sm.text-gray-600 = stay_composition_summary(stay)
           .mt-1.flex.items-center.flex-wrap.gap-x-3.gap-y-1.text-sm
             span.font-medium.text-gray-900 = humanized_money_with_symbol(stay.total_amount)

--- a/app/views/stays/_merge_setup.html.slim
+++ b/app/views/stays/_merge_setup.html.slim
@@ -19,7 +19,7 @@
       - hue = stay_hue(stay.id)
       - decorated = stay.decorate
       label.flex.items-start.gap-3.rounded-lg.border.border-gray-200.bg-white.p-4.cursor-pointer.hover:border-indigo-300.transition-colors(style="border-left-width: 4px; border-left-color: hsl(#{hue}, 65%, 45%);")
-        input.mt-1.h-4.w-4.text-indigo-600(type="radio" name="target_id" value=stay.id checked=(stay.id == target&.id) data-action="stay-merge#targetChanged")
+        input.mt-1.h-4.w-4.text-indigo-600(type="radio" name="target_id" value=stay.id checked=(stay.id == target&.id))
         .min-w-0.flex-1
           .flex.items-center.flex-wrap.gap-2
             span.font-semibold.text-gray-900 ##{stay.id}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,14 @@ Rails.application.routes.draw do
       # Devis live du form de composition (issue #73) : recalcule le panneau
       # « Devis (B2C) » en Turbo Stream à chaque changement, via PricingModel.
       post :quote
+      # Fusion de séjours depuis le calendrier (epic #81, Phase 2). Trois étapes
+      # rendues PAR LE SERVEUR (fragments HTML, aucune vérité recalculée en JS) :
+      #   - merge_setup   : étape A — désignation du séjour survivant (cartes radio) ;
+      #   - merge_preview : étape B — aperçu dry-run (Stays::MergePreview) ;
+      #   - merge         : commit — Stays::MergeService, puis redirection + flash.
+      post :merge_setup
+      post :merge_preview
+      post :merge
     end
     member do
       # Action rapide depuis la modale du calendrier (issue #76) : bascule

--- a/spec/models/experience_booking_paper_trail_spec.rb
+++ b/spec/models/experience_booking_paper_trail_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+# Audit (epic #81) : ExperienceBooking est rapatrié par la fusion de séjours ;
+# il lui faut un historique PaperTrail comme aux autres modèles migrés.
+RSpec.describe ExperienceBooking, type: :model do
+  let(:customer) { Customer.create!(email: "eb@example.com", customer_type: "individual") }
+  let(:stay) { Stay.create!(customer: customer, source: "manual", status: "confirmed", arrival_date: Date.today + 5, departure_date: Date.today + 7) }
+  let(:other_stay) { Stay.create!(customer: customer, source: "manual", status: "confirmed", arrival_date: Date.today + 10, departure_date: Date.today + 12) }
+  let(:porteur) { Human.create!(name: "Porteur", email: "porteur-eb@example.com") }
+  let(:experience) { Experience.create!(name: "Balade", human: porteur, fixed_price_cents: 4_000, price_cents: 1_500) }
+  let(:availability) { ExperienceAvailability.create!(experience: experience, available_on: Date.today + 6, starts_at: "10:00") }
+
+  it "est versionné par PaperTrail" do
+    expect(described_class).to respond_to(:paper_trail)
+    eb = ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "confirmed")
+    expect(eb.versions).to be_present # au moins la version de création
+  end
+
+  it "trace un changement de stay_id (rattachement à un autre séjour, cas fusion)" do
+    eb = ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "confirmed")
+    expect { eb.update!(stay_id: other_stay.id) }.to change { eb.versions.count }.by(1)
+    expect(eb.versions.last.object_changes).to include("stay_id")
+  end
+end

--- a/spec/requests/calendar_stay_modal_spec.rb
+++ b/spec/requests/calendar_stay_modal_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe "Calendrier — modale séjour depuis les blocs (epic #66, Phase 
       get "/"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('data-controller="stay-details"')
+      # Le wrapper porte désormais stay-details ET stay-merge (epic #81, Phase 2).
+      expect(response.body).to match(/data-controller="[^"]*\bstay-details\b[^"]*"/)
       expect(response.body).to include('data-stay-details-target="dialog"')
       expect(response.body).to include('data-stay-details-target="content"')
     end

--- a/spec/requests/stays_merge_spec.rb
+++ b/spec/requests/stays_merge_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+# UI serveur de la fusion de séjours (epic #81, Phase 2). Trois fragments rendus
+# côté serveur — désignation (merge_setup), aperçu dry-run (merge_preview),
+# commit (merge) — protégés Devise et bornés par des garde-fous (≥ 2 séjours).
+RSpec.describe "Stays merge (epic #81)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { User.create!(email: "staff-merge@les4sources.be", password: "password123") }
+  let(:c_target) { Customer.create!(email: "target@example.com", customer_type: "individual", first_name: "Cible") }
+  let(:c_source) { Customer.create!(email: "source@example.com", customer_type: "individual", first_name: "Source") }
+  let(:lodging) { Lodging.create!(name: "La Hulotte", price_night_cents: 10_000) }
+
+  def build_stay(customer:, arrival:, departure:, lodging_cents:, paid_cents: nil)
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: arrival, departure_date: departure)
+    booking = Booking.create!(firstname: customer.first_name, lodging: lodging, from_date: arrival,
+                              to_date: departure, adults: 2, status: "confirmed",
+                              booking_type: "lodging", price_cents: lodging_cents)
+    stay.stay_items.create!(bookable: booking)
+    Payment.create!(stay: stay, amount_cents: paid_cents, status: "paid", payment_method: "card") if paid_cents
+    stay.recompute_aggregates!
+    stay.set_payment_status
+    stay
+  end
+
+  let!(:target) { build_stay(customer: c_target, arrival: Date.new(2026, 9, 12), departure: Date.new(2026, 9, 15), lodging_cents: 30_000, paid_cents: 10_000) }
+  let!(:source) { build_stay(customer: c_source, arrival: Date.new(2026, 9, 16), departure: Date.new(2026, 9, 18), lodging_cents: 20_000) }
+
+  before { sign_in admin }
+
+  describe "POST /stays/merge_setup" do
+    it "rend l'étape A avec une carte radio par séjour et présélectionne le porteur de paiements" do
+      post merge_setup_stays_path, params: { stay_ids: [target.id, source.id] }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('name="target_id"')
+      expect(response.body).to include("Fusionner 2 séjours")
+      expect(response.body).to include("suggéré")
+      # La cible porte des paiements → présélectionnée (radio checked). L'attribut
+      # `checked` est sérialisé avant `value` dans la balise input.
+      expect(response.body).to match(/<input checked[^>]*value="#{target.id}"/)
+    end
+
+    it "affiche l'encart « clients différents » quand les clients diffèrent" do
+      post merge_setup_stays_path, params: { stay_ids: [target.id, source.id] }
+      expect(response.body).to include("Clients différents")
+    end
+
+    it "refuse moins de deux séjours (422)" do
+      post merge_setup_stays_path, params: { stay_ids: [target.id] }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("au moins deux séjours")
+    end
+  end
+
+  describe "POST /stays/merge_preview" do
+    it "rend l'étape B avec l'aperçu dry-run (total, payé, solde)" do
+      post merge_preview_stays_path, params: { target_id: target.id, stay_ids: [target.id, source.id] }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Aperçu de la fusion")
+      expect(response.body).to include("Nouveau total")
+      expect(response.body).to include("Séjour ##{target.id}")
+      expect(response.body).to include("archivé")
+    end
+
+    it "refuse moins de deux séjours (422)" do
+      post merge_preview_stays_path, params: { target_id: target.id, stay_ids: [target.id] }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "POST /stays/merge" do
+    it "exécute la fusion, archive la source et redirige avec un flash détaillé (JSON)" do
+      post merge_stays_path, params: { target_id: target.id, stay_ids: [target.id, source.id] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["redirect"]).to include("stay_merge_done=1")
+
+      expect(Stay.find_by(id: source.id)).to be_nil                    # soft-deleted
+      expect(target.reload.stay_items.count).to eq(2)
+      expect(flash[:notice]).to include("fusionné").and include("##{target.id}")
+    end
+
+    it "refuse une cible figurant parmi les sources et re-rend l'aperçu avec l'erreur (422)" do
+      # target_id absent des stay_ids résolus → cible = min id ; on force le cas
+      # dégénéré d'un seul séjour pour déclencher le garde-fou serveur.
+      post merge_stays_path, params: { target_id: target.id, stay_ids: [target.id] }, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "authentification" do
+    it "exige une session admin (Devise)" do
+      sign_out admin
+      post merge_setup_stays_path, params: { stay_ids: [target.id, source.id] }
+      expect(response).to have_http_status(:found) # redirigé vers login
+    end
+  end
+end

--- a/spec/services/stays/merge_preview_spec.rb
+++ b/spec/services/stays/merge_preview_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+# Aperçu dry-run de la fusion (epic #81, Phase 2). Le test le plus important du
+# lot est la COHÉRENCE : sur un même jeu de données, l'aperçu annoncé DOIT être
+# rigoureusement égal au résultat réel de Stays::MergeService (garantie
+# anti-divergence JS/serveur).
+RSpec.describe Stays::MergePreview, type: :service do
+  let(:c_target) { Customer.create!(email: "target@example.com", customer_type: "individual", first_name: "Cible") }
+  let(:c_source) { Customer.create!(email: "source@example.com", customer_type: "individual", first_name: "Source") }
+  let(:lodging)  { Lodging.create!(name: "La Hulotte", price_night_cents: 10_000) }
+
+  def build_stay(customer:, arrival:, departure:, lodging_cents:, paid_cents: nil, pending_cents: nil, meal_cents: nil)
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: arrival, departure_date: departure)
+    booking = Booking.create!(firstname: customer.first_name, lodging: lodging, from_date: arrival,
+                              to_date: departure, adults: 2, status: "confirmed",
+                              booking_type: "lodging", price_cents: lodging_cents)
+    stay.stay_items.create!(bookable: booking)
+    MealOrder.create!(stay: stay, kind: "buffet", date: arrival, people: 4, price_cents: meal_cents) if meal_cents
+    Payment.create!(stay: stay, amount_cents: paid_cents, status: "paid", payment_method: "card") if paid_cents
+    Payment.create!(stay: stay, amount_cents: pending_cents, status: "pending", payment_method: "card") if pending_cents
+    stay.recompute_aggregates!
+    stay.set_payment_status
+    stay
+  end
+
+  let(:target) { build_stay(customer: c_target, arrival: Date.new(2026, 9, 12), departure: Date.new(2026, 9, 15), lodging_cents: 30_000, paid_cents: 10_000) }
+  let(:source) { build_stay(customer: c_source, arrival: Date.new(2026, 9, 16), departure: Date.new(2026, 9, 18), lodging_cents: 20_000, paid_cents: 5_000, meal_cents: 8_000) }
+
+  subject(:preview) { described_class.new(target: target, sources: [source]).call }
+
+  describe "projection" do
+    it "conserve le client de la cible" do
+      expect(preview.customer_name).to eq(c_target.name)
+    end
+
+    it "projette les dates en union" do
+      expect(preview.arrival_date).to eq(Date.new(2026, 9, 12))
+      expect(preview.departure_date).to eq(Date.new(2026, 9, 18))
+    end
+
+    it "projette le nouveau total, le déjà payé et le solde" do
+      expect(preview.total_cents).to eq(30_000 + 20_000 + 8_000)
+      expect(preview.paid_cents).to eq(15_000)
+      expect(preview.balance_cents).to eq(58_000 - 15_000)
+    end
+
+    it "liste la composition groupée avec provenance" do
+      types = preview.composition.map(&:type)
+      expect(types).to include(:lodging, :meal)
+      source_line = preview.composition.find { |i| i.origin_stay_id == source.id }
+      expect(source_line.from_target).to be(false)
+    end
+
+    it "liste les séjours sources archivés" do
+      expect(preview.sources.map(&:id)).to eq([source.id])
+      expect(preview.sources.first.customer_name).to eq(c_source.name)
+    end
+  end
+
+  describe "avertissements" do
+    it "signale les clients différents" do
+      expect(preview.warnings.map(&:kind)).to include(:different_customers)
+    end
+
+    it "signale un paiement en attente sur une source" do
+      source_with_pending = build_stay(customer: c_source, arrival: Date.new(2026, 10, 1), departure: Date.new(2026, 10, 2), lodging_cents: 10_000, pending_cents: 3_000)
+      pv = described_class.new(target: target, sources: [source_with_pending]).call
+      expect(pv.warnings.map(&:kind)).to include(:pending_payment)
+    end
+
+    it "signale des dates identiques (possible doublon)" do
+      twin = build_stay(customer: c_target, arrival: target.arrival_date, departure: target.departure_date, lodging_cents: 12_000)
+      pv = described_class.new(target: target, sources: [twin]).call
+      expect(pv.warnings.map(&:kind)).to include(:identical_dates)
+    end
+
+    it "n'émet aucun avertissement quand tout est net (même client, dates disjointes)" do
+      same_client_source = build_stay(customer: c_target, arrival: Date.new(2026, 11, 1), departure: Date.new(2026, 11, 3), lodging_cents: 10_000)
+      pv = described_class.new(target: target, sources: [same_client_source]).call
+      expect(pv.warnings).to be_empty
+    end
+  end
+
+  # --- LA garantie anti-divergence ------------------------------------------
+  describe "cohérence preview == fusion réelle (garantie anti-divergence)" do
+    it "annonce exactement le total / payé / solde / dates que la fusion produit" do
+      snapshot = described_class.new(target: target, sources: [source]).call
+
+      service = Stays::MergeService.new(target: target, sources: [source])
+      expect(service.run).to be_truthy
+      target.reload
+
+      aggregate_failures do
+        expect(target.total_amount_cents).to eq(snapshot.total_cents)
+        expect(target.amount_paid_cents).to eq(snapshot.paid_cents)
+        expect(target.amount_due_cents).to eq(snapshot.balance_cents)
+        expect(target.arrival_date).to eq(snapshot.arrival_date)
+        expect(target.departure_date).to eq(snapshot.departure_date)
+      end
+    end
+
+    it "tient aussi avec plusieurs sources et compositions hétérogènes" do
+      s2 = build_stay(customer: c_source, arrival: Date.new(2026, 9, 20), departure: Date.new(2026, 9, 25), lodging_cents: 40_000, paid_cents: 12_000, meal_cents: 6_000)
+      snapshot = described_class.new(target: target, sources: [source, s2]).call
+
+      expect(Stays::MergeService.new(target: target, sources: [source, s2]).run).to be_truthy
+      target.reload
+
+      aggregate_failures do
+        expect(target.total_amount_cents).to eq(snapshot.total_cents)
+        expect(target.amount_paid_cents).to eq(snapshot.paid_cents)
+        expect(target.amount_due_cents).to eq(snapshot.balance_cents)
+        expect(target.arrival_date).to eq(snapshot.arrival_date)
+        expect(target.departure_date).to eq(snapshot.departure_date)
+      end
+    end
+  end
+end

--- a/spec/services/stays/merge_service_spec.rb
+++ b/spec/services/stays/merge_service_spec.rb
@@ -177,6 +177,26 @@ RSpec.describe Stays::MergeService, type: :service do
     end
   end
 
+  describe "cache d'association préchargé (régression)" do
+    # Le contrôleur charge les séjours avec includes(stay_items: :bookable) :
+    # sans le reload d'absorb!, la cascade dependent: :destroy du soft-delete
+    # relisait le cache et supprimait les items pourtant déjà migrés.
+    it "ne re-supprime pas les items migrés quand stay_items est préchargé" do
+      customer = make_customer("preload@example.com")
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer)
+      attach(target, make_booking)
+      attach(source, make_space_booking)
+
+      preloaded = Stay.where(id: [target.id, source.id]).includes(stay_items: :bookable).to_a
+      preloaded_target = preloaded.find { |s| s.id == target.id }
+      preloaded_source = preloaded.find { |s| s.id == source.id }
+
+      expect(described_class.new(target: preloaded_target, sources: [preloaded_source]).run).to be_truthy
+      expect(target.reload.stay_items.count).to eq(2)
+    end
+  end
+
   describe "intégrité transactionnelle" do
     it "ne modifie rien si une étape échoue en cours de route" do
       customer = make_customer("tx@example.com")

--- a/spec/services/stays/merge_service_spec.rb
+++ b/spec/services/stays/merge_service_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+# Fusion de séjours (epic #81, Phase 2). Rapatrie toute la composition d'un ou
+# plusieurs séjours SOURCES sur la CIBLE (survivant), soft-delete les sources,
+# recalcule total / dates (union) / statut de paiement.
+RSpec.describe Stays::MergeService, type: :service do
+  let(:c_target) { Customer.create!(email: "target@example.com", customer_type: "individual", first_name: "Cible") }
+  let(:c_source) { Customer.create!(email: "source@example.com", customer_type: "individual", first_name: "Source") }
+  let(:lodging)  { Lodging.create!(name: "La Hulotte", price_night_cents: 10_000) }
+
+  # Séjour cible : hébergement (300 €) + un paiement encaissé (100 €).
+  let(:target) do
+    stay = Stay.create!(customer: c_target, source: "manual", status: "confirmed",
+                        arrival_date: Date.new(2026, 9, 12), departure_date: Date.new(2026, 9, 15))
+    booking = Booking.create!(firstname: "Cible", lodging: lodging, from_date: Date.new(2026, 9, 12),
+                              to_date: Date.new(2026, 9, 15), adults: 2, status: "confirmed",
+                              booking_type: "lodging", price_cents: 30_000)
+    stay.stay_items.create!(bookable: booking)
+    Payment.create!(stay: stay, amount_cents: 10_000, status: "paid", payment_method: "card")
+    stay.recompute_aggregates!
+    stay
+  end
+
+  # Séjour source : hébergement (200 €) + repas (80 €) + activité, dates plus tardives.
+  let(:porteur)     { Human.create!(name: "Porteur", email: "porteur@example.com") }
+  let(:experience)  { Experience.create!(name: "Balade ânes", human: porteur, fixed_price_cents: 4_000, price_cents: 1_500) }
+  let(:availability) { ExperienceAvailability.create!(experience: experience, available_on: Date.new(2026, 9, 17), starts_at: "10:00") }
+  let(:source) do
+    stay = Stay.create!(customer: c_source, source: "manual", status: "confirmed",
+                        arrival_date: Date.new(2026, 9, 16), departure_date: Date.new(2026, 9, 18))
+    booking = Booking.create!(firstname: "Source", lodging: lodging, from_date: Date.new(2026, 9, 16),
+                              to_date: Date.new(2026, 9, 18), adults: 2, status: "confirmed",
+                              booking_type: "lodging", price_cents: 20_000)
+    stay.stay_items.create!(bookable: booking)
+    MealOrder.create!(stay: stay, kind: "buffet", date: Date.new(2026, 9, 17), people: 4, price_cents: 8_000)
+    ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "confirmed")
+    Payment.create!(stay: stay, amount_cents: 5_000, status: "paid", payment_method: "card")
+    stay.recompute_aggregates!
+    stay
+  end
+
+  describe "#run (fusion réussie)" do
+    subject(:service) { described_class.new(target: target, sources: [source]) }
+
+    it "rapatrie tous les StayItem de la source sur la cible" do
+      source_item_ids = source.stay_items.pluck(:id)
+      expect { service.run }.to change { target.stay_items.reload.count }.from(1).to(2)
+      expect(StayItem.where(id: source_item_ids).pluck(:stay_id).uniq).to eq([target.id])
+    end
+
+    it "rapatrie les repas et les activités sur la cible" do
+      service.run
+      expect(target.meal_orders.reload.count).to eq(1)
+      expect(target.experience_bookings.reload.count).to eq(1)
+    end
+
+    it "ré-ancre les paiements de la source (payments.stay_id) sur la cible" do
+      service.run
+      expect(Payment.where(stay_id: source.id)).to be_empty
+      expect(target.payments.paid.sum(:amount_cents)).to eq(15_000) # 100 € + 50 €
+    end
+
+    it "conserve le client de la cible" do
+      expect { service.run }.not_to(change { target.reload.customer_id })
+      expect(target.customer_id).to eq(c_target.id)
+    end
+
+    it "recalcule le total (union de toute la composition)" do
+      service.run
+      # 300 (cible) + 200 + 80 (source repas) = 580 €. Activité : 4000 + 2*1500 = 70 €.
+      expect(target.reload.total_amount_cents).to eq(30_000 + 20_000 + 8_000 + 7_000)
+    end
+
+    it "recalcule les dates en UNION (min arrivée / max départ)" do
+      service.run
+      expect(target.reload.arrival_date).to eq(Date.new(2026, 9, 12))
+      expect(target.departure_date).to eq(Date.new(2026, 9, 18))
+    end
+
+    it "recalcule le statut de paiement d'après l'encaissé rapatrié" do
+      service.run
+      expect(target.reload.payment_status).to eq("partially_paid")
+    end
+
+    it "soft-delete la source vidée et expose merged_count" do
+      expect(service.run).to be_truthy
+      expect(service.merged_count).to eq(1)
+      expect(Stay.find_by(id: source.id)).to be_nil                       # hors default scope
+      expect(Stay.unscoped.find(source.id).deleted_at).to be_present
+    end
+
+    it "trace le changement de séjour des éléments migrés (PaperTrail)" do
+      item = source.stay_items.first
+      eb = source.experience_bookings.first
+      service.run
+      expect(item.reload.versions.last.object_changes).to include("stay_id")
+      expect(eb.reload.versions.last.object_changes).to include("stay_id")
+    end
+  end
+
+  describe "fusion de plusieurs sources" do
+    let(:c_third) { Customer.create!(email: "third@example.com", customer_type: "individual") }
+    let(:third) do
+      Stay.create!(customer: c_third, source: "manual", status: "confirmed",
+                   arrival_date: Date.new(2026, 9, 20), departure_date: Date.new(2026, 9, 22)).tap do |stay|
+        b = Booking.create!(firstname: "Third", lodging: lodging, from_date: Date.new(2026, 9, 20),
+                            to_date: Date.new(2026, 9, 22), adults: 1, status: "confirmed",
+                            booking_type: "lodging", price_cents: 15_000)
+        stay.stay_items.create!(bookable: b)
+        stay.recompute_aggregates!
+      end
+    end
+
+    it "rapatrie les deux sources et les archive" do
+      service = described_class.new(target: target, sources: [source, third])
+      expect(service.run).to be_truthy
+      expect(service.merged_count).to eq(2)
+      expect(target.stay_items.reload.count).to eq(3)
+      expect(target.departure_date).to eq(Date.new(2026, 9, 22))
+    end
+  end
+
+  describe "garde-fous" do
+    it "refuse une cible nil" do
+      service = described_class.new(target: nil, sources: [source])
+      expect(service.run).to be(false)
+      expect(service.error_message).to be_present
+    end
+
+    it "refuse une fusion sans source (moins de deux séjours)" do
+      service = described_class.new(target: target, sources: [])
+      expect(service.run).to be(false)
+      expect(service.error_message).to be_present
+    end
+
+    it "refuse que la cible figure parmi les sources" do
+      service = described_class.new(target: target, sources: [target])
+      expect(service.run).to be(false)
+      expect(service.error_message).to be_present
+    end
+  end
+end

--- a/spec/services/stays/merge_service_spec.rb
+++ b/spec/services/stays/merge_service_spec.rb
@@ -1,0 +1,203 @@
+require "rails_helper"
+
+# Fusion de séjours (epic #81, Phase 2). Calqué sur le spec de
+# Customers::MergeService : on construit deux Stay saisis séparément (ancien
+# Booking + ancien SpaceBooking d'un même séjour client), on fusionne, et on
+# vérifie que la cible absorbe toutes les occupations tandis que les sources
+# vidées sont soft-deletées.
+RSpec.describe Stays::MergeService, type: :service do
+  def make_customer(email, **attrs)
+    Customer.create!({ email: email, customer_type: "individual" }.merge(attrs))
+  end
+
+  def make_stay(customer:, **attrs)
+    Stay.create!({
+      customer: customer,
+      source: "manual",
+      status: "confirmed",
+      arrival_date: Date.new(2026, 8, 1),
+      departure_date: Date.new(2026, 8, 3),
+      total_amount_cents: 0
+    }.merge(attrs))
+  end
+
+  def make_booking(**attrs)
+    Booking.create!({
+      firstname: "Zoé", lastname: "Durand", email: "booking@example.com",
+      from_date: Date.new(2026, 8, 1), to_date: Date.new(2026, 8, 3),
+      adults: 2, status: "confirmed", price_cents: 30_000
+    }.merge(attrs))
+  end
+
+  def make_space_booking(**attrs)
+    SpaceBooking.create!({
+      firstname: "Zoé", lastname: "Durand", email: "space@example.com",
+      from_date: Date.new(2026, 8, 4), to_date: Date.new(2026, 8, 6),
+      status: "confirmed", price_cents: 20_000
+    }.merge(attrs))
+  end
+
+  def attach(stay, bookable)
+    StayItem.create!(stay: stay, bookable: bookable)
+  end
+
+  let(:experience) { Experience.create!(name: "Atelier pain", fixed_price_cents: 5_000, price_cents: 1_500) }
+  let(:availability) do
+    ExperienceAvailability.create!(experience: experience, available_on: Date.new(2026, 8, 5), starts_at: "10:00")
+  end
+
+  describe "fusion Booking + SpaceBooking (2 séjours → 1)" do
+    let(:customer) { make_customer("client@example.com") }
+    let(:target) { make_stay(customer: customer) }
+    let(:source) { make_stay(customer: customer, arrival_date: Date.new(2026, 8, 4), departure_date: Date.new(2026, 8, 6)) }
+
+    let(:booking) { make_booking }
+    let(:space_booking) { make_space_booking }
+
+    before do
+      attach(target, booking)
+      attach(source, space_booking)
+      Payment.create!(stay: target, amount_cents: 10_000, status: "paid", payment_method: "card")
+      Payment.create!(stay: source, amount_cents: 5_000, status: "paid", payment_method: "transfer")
+    end
+
+    it "porte les 2 occupations, recalcule dates/total, regroupe les paiements et soft-delete la source" do
+      service = described_class.new(target: target, sources: [source])
+      expect(service.run).to be_truthy
+
+      # Les 2 occupations vivent désormais sur la cible.
+      expect(target.reload.bookables).to contain_exactly(booking, space_booking)
+
+      # Dates = union (min arrivée / max départ) de toutes les occupations.
+      expect(target.arrival_date).to eq(Date.new(2026, 8, 1))
+      expect(target.departure_date).to eq(Date.new(2026, 8, 6))
+
+      # Total recalculé sans double-compte = 30 000 + 20 000.
+      expect(target.total_amount_cents).to eq(50_000)
+
+      # Paiements regroupés sur la cible = 10 000 + 5 000 encaissés.
+      expect(target.amount_paid_cents).to eq(15_000)
+      # Solde exigible = total − encaissé = 50 000 − 15 000.
+      expect(target.balance_due_cents).to eq(35_000)
+      expect(target.payment_status).to eq("partially_paid")
+
+      # Source vidée puis soft-deletée.
+      expect(Stay.find_by(id: source.id)).to be_nil
+      expect(Stay.unscoped.find(source.id).deleted_at).to be_present
+    end
+
+    it "trace le changement de stay_id des occupations via PaperTrail" do
+      described_class.new(target: target, sources: [source]).run
+
+      moved_item = StayItem.find_by(bookable: space_booking)
+      expect(moved_item.stay_id).to eq(target.id)
+      expect(moved_item.versions.last.object_changes).to include("stay_id")
+
+      moved_payment = Payment.find_by(amount_cents: 5_000)
+      expect(moved_payment.stay_id).to eq(target.id)
+      expect(moved_payment.versions.last.object_changes).to include("stay_id")
+    end
+  end
+
+  describe "clients différents" do
+    it "conserve le client de la cible (la cible gagne)" do
+      target_customer = make_customer("cible@example.com")
+      source_customer = make_customer("source@example.com")
+      target = make_stay(customer: target_customer)
+      source = make_stay(customer: source_customer)
+      attach(target, make_booking)
+      attach(source, make_space_booking)
+
+      described_class.new(target: target, sources: [source]).run
+
+      expect(target.reload.customer_id).to eq(target_customer.id)
+      # L'occupation migrée suit la cible (donc son client).
+      expect(StayItem.find_by(bookable_type: "SpaceBooking").stay.customer_id).to eq(target_customer.id)
+    end
+  end
+
+  describe "migration des éléments non calendaires" do
+    it "déplace MealOrder et ExperienceBooking vers la cible" do
+      customer = make_customer("repas@example.com")
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer)
+      attach(target, make_booking)
+
+      meal = MealOrder.create!(stay: source, kind: "buffet", date: Date.new(2026, 8, 5), people: 4, price_cents: 4_000)
+      exp_booking = ExperienceBooking.create!(experience_availability: availability, stay: source, participants: 2, status: "confirmed")
+
+      expect(described_class.new(target: target, sources: [source]).run).to be_truthy
+
+      expect(meal.reload.stay_id).to eq(target.id)
+      expect(exp_booking.reload.stay_id).to eq(target.id)
+      expect(target.reload.meal_orders).to include(meal)
+      expect(target.experience_bookings).to include(exp_booking)
+    end
+  end
+
+  describe "garde-fous" do
+    let(:customer) { make_customer("guard@example.com") }
+
+    it "refuse une fusion sans source (1 seul séjour)" do
+      target = make_stay(customer: customer)
+      service = described_class.new(target: target, sources: [])
+      expect(service.run).to be(false)
+      expect(service.error_message).to be_present
+    end
+
+    it "refuse si la cible figure parmi les sources" do
+      target = make_stay(customer: customer)
+      service = described_class.new(target: target, sources: [target])
+      expect(service.run).to be(false)
+      expect(service.error_message).to be_present
+    end
+
+    it "refuse une source déjà soft-deletée (idempotence : pas de corruption)" do
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer)
+      attach(source, make_space_booking)
+      source.soft_delete!(validate: false)
+
+      service = described_class.new(target: target, sources: [Stay.unscoped.find(source.id)])
+      expect(service.run).to be(false)
+      expect(service.error_message).to be_present
+      # L'occupation de la source n'a pas migré vers la cible (elle reste sur la
+      # source — soft-deletée en cascade avec elle, donc lue en unscoped).
+      expect(StayItem.unscoped.find_by(bookable_type: "SpaceBooking").stay_id).to eq(source.id)
+    end
+
+    it "refuse une cible déjà soft-deletée" do
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer)
+      target.soft_delete!(validate: false)
+
+      service = described_class.new(target: Stay.unscoped.find(target.id), sources: [source])
+      expect(service.run).to be(false)
+      expect(service.error_message).to be_present
+    end
+  end
+
+  describe "intégrité transactionnelle" do
+    it "ne modifie rien si une étape échoue en cours de route" do
+      customer = make_customer("tx@example.com")
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer)
+      attach(target, make_booking)
+      space_booking = make_space_booking
+      attach(source, space_booking)
+      Payment.create!(stay: source, amount_cents: 5_000, status: "paid", payment_method: "card")
+
+      # Simule une exception au recalcul final : tout doit être annulé (tout-ou-rien).
+      allow(target).to receive(:recompute_aggregates!).and_raise(ActiveRecord::StatementInvalid.new("boom"))
+
+      service = described_class.new(target: target, sources: [source])
+      expect(service.run).to be(false)
+
+      # Rien n'a bougé : occupation, paiement et source intacts.
+      expect(StayItem.find_by(bookable: space_booking).stay_id).to eq(source.id)
+      expect(Payment.find_by(amount_cents: 5_000).stay_id).to eq(source.id)
+      expect(source.reload.deleted_at).to be_nil
+      expect(target.reload.stay_items.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Epic #81 — Phase 2 : Fusion de séjours depuis le calendrier

PR **empilée sur #90** (Phase 1 — orphelins). L'outil que tu utiliseras pour assainir l'historique jusqu'à 2023 : sélection multiple de séjours sur le calendrier → désignation du survivant → aperçu serveur → fusion.

### UX (spec frontend-design, vérifiée navigateur de bout en bout)
- **Mode fusion** togglé depuis le calendrier : un clic sur un bloc allume **tout le séjour** de sa teinte (ring + badge ✓ sur chaque bloc), les non-sélectionnés s'estompent, la modale séjour est neutralisée tant que le mode est actif — et **zéro interférence** mode éteint.
- **Sélection persistante entre les mois** (sessionStorage horodaté, périmé après 1 h) : fusionner fin septembre avec début octobre marche malgré le rechargement simple_calendar.
- **Bottom bar** : chips colorées (#id · client · dates, retirables), compteur, bouton actif dès 2 séjours (libellé explicite sinon).
- **Dialog natif 2 étapes, tout rendu par le serveur** : (A) cartes radio riches avec présélection motivée « suggéré » (paiements > composition > ancienneté) et encart « clients différents » ; (B) **aperçu dry-run** — dates union, composition avec provenance « depuis #id », nouveau total / déjà payé / nouveau solde, avertissements ambre contextuels (clients différents, paiement en attente, doublon probable), « → archivé » par source.
- **Commit** : redirection au mois du survivant, flash détaillé, la grille reteinte confirme visuellement ; erreurs de garde-fous rendues **dans** le dialog (422).

### Backend
- **`Stays::MergeService`** (pattern `Customers::MergeService`) : transaction tout-ou-rien, **verrou pessimiste `FOR UPDATE`** (ordre d'id stable) + re-vérification sous verrou, migration de TOUTES les occupations (`StayItem` tous bookables, `MealOrder`, `ExperienceBooking`) et des `Payment` par leur **ancre réelle** (`payments.stay_id` — pas l'union dérivée `Stay#payments`), client de la cible conservé, sources soft-deletées, `recompute_aggregates!` + `set_payment_status` (échec → rollback). Garde-fous : <2 séjours, cible ∈ sources, doublons, séjour déjà supprimé, `target_id` hors sélection → 422.
- **`Stays::MergePreview`** (dry-run, zéro mutation) avec **test de cohérence anti-divergence** : sur un même jeu de données, preview calculé PUIS fusion réellement exécutée → total/payé/solde/dates identiques (mono et multi-sources).
- **`has_paper_trail` ajouté à `ExperienceBooking`** (seul modèle migré sans audit) — la fusion est intégralement tracée.

### Bugs réels attrapés par le processus
1. **Cascade soft-delete vs cache d'association** : avec `stay_items` préchargés (le `includes` du contrôleur), la cascade `dependent: :destroy` du soft-delete relisait le cache et **supprimait les items déjà migrés**. Corrigé (`source.reload`) + spec de régression. *(Attrapé par le test de cohérence — il a payé dès son premier jour.)*
2. **Slim scinde les classes fractionnaires** (`.gap-1.5` → `gap-1` + `5`) et **texte blanc sur fond blanc** sur le toggle actif (`bg-white` non retiré) — attrapés par la passe navigateur.

### Vérifications
- **RSpec : 664 examples, 0 failures** (+31 vs Phase 1 : service, preview, cohérence, requests, PaperTrail, régression cache).
- **Revue Forge : SHIP AVEC RÉSERVES → les 6 findings corrigés** (verrou concurrent, set_payment_status, target strict, double-clic, TTL sessionStorage, action morte). Passe croisée GPT-5.4 indisponible (quota codex) — revue directe complète livrée à la place.
- **Navigateur (agent-browser) : 11/11 PASS** sur le parcours complet avec fusion réelle des séjours de test #2+#3 (clients différents), puis contre-passe **5/5 PASS** sur les correctifs visuels. Zéro erreur console, zéro 4xx/5xx. Captures dans la PR review au besoin.

### ❓ Question produit pour la review
Après fusion, les blocs calendrier de l'ex-source affichent toujours le **nom porté par le Booking** (« Bruno ») alors que le séjour appartient désormais au client de la cible (« Aurélie ») — la teinte dit #2, le texte dit Bruno. Trois options : (a) laisser tel quel (le nom d'occupant historique reste vrai), (b) afficher le client du séjour sur les blocs quand un Stay existe, (c) renommer le booking à la fusion. Je recommande (b) — cohérent avec la logique stay-first — mais c'est un changement d'affichage global du calendrier, donc à trancher.
