### PR TITLE
Epic #81 Phase 4 — OTA absorbé dans le séjour (bascule plateforme↔canal + preuves occupation/veto)

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -37,11 +37,13 @@ class StaysController < BaseController
   def create
     @draft  = build_draft
     builder = Reservations::Builder.new(
-      draft:             @draft,
-      admin:             true,
-      status:            requested_status,
-      source:            "manual",
-      skip_availability: force_availability?
+      draft:                @draft,
+      admin:                true,
+      status:               requested_status,
+      source:               requested_source || "manual",
+      platform:             requested_platform,
+      price_override_cents: requested_price_override_cents,
+      skip_availability:    force_availability?
     )
 
     if builder.run
@@ -65,11 +67,14 @@ class StaysController < BaseController
   def update
     @draft  = build_draft
     updater = Stays::AdminUpdater.new(
-      stay:              @stay,
-      draft:             @draft,
-      status:            requested_status,
-      skip_availability: force_availability?,
-      user:              current_user
+      stay:                 @stay,
+      draft:                @draft,
+      status:               requested_status,
+      source:               requested_source,
+      platform:             requested_platform,
+      price_override_cents: requested_price_override_cents,
+      skip_availability:    force_availability?,
+      user:                 current_user
     )
 
     if updater.run
@@ -479,6 +484,31 @@ class StaysController < BaseController
 
   def requested_status
     stay_params[:status]
+  end
+
+  # Canal d'attribution du séjour (epic #81, Phase 3). Validé contre `SOURCES`
+  # (le service borne / préserve ensuite). nil si absent ou forgé — l'appelant
+  # décide du repli (create → "manual" ; update → source d'origine préservée).
+  def requested_source
+    src = stay_params[:source]
+    Stay::SOURCES.include?(src) ? src : nil
+  end
+
+  # Attribution OTA à propager au Booking d'occupation (Airbnb/Booking.com/web).
+  def requested_platform
+    stay_params[:platform].presence
+  end
+
+  # Prix imposé (€ saisis) → cents. Vide = nil (pas d'override → devis B2C).
+  # Tolère la virgule décimale (locale FR) et un éventuel symbole/espaces.
+  def requested_price_override_cents
+    raw = stay_params[:price_override].to_s.strip
+    return nil if raw.blank?
+    normalized = raw.tr(",", ".").delete("^0-9.-")
+    return nil if normalized.blank?
+    (BigDecimal(normalized) * 100).round
+  rescue ArgumentError
+    nil
   end
 
   def force_availability?

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -506,7 +506,10 @@ class StaysController < BaseController
     return nil if raw.blank?
     normalized = raw.tr(",", ".").delete("^0-9.-")
     return nil if normalized.blank?
-    (BigDecimal(normalized) * 100).round
+    cents = (BigDecimal(normalized) * 100).round
+    # Négatif = saisie invalide, jamais un prix (le `min: 0` du champ n'est
+    # qu'un garde-fou client). 0 € reste un override valide.
+    cents.negative? ? nil : cents
   rescue ArgumentError
     nil
   end

--- a/app/frontend/controllers/stay_form_controller.js
+++ b/app/frontend/controllers/stay_form_controller.js
@@ -10,8 +10,10 @@ import { Controller } from "@hotwired/stimulus"
 //     input[type=radio name="stay[customer_mode]"] (data-action="change->stay-form#toggleCustomer")
 //     div(data-stay-form-target="existingPanel")
 //     div(data-stay-form-target="newPanel")
+//     select[name="stay[platform]"] (data-stay-form-target="platform" data-action="change->stay-form#syncChannelFromPlatform")
+//     select[name="stay[source]"]   (data-stay-form-target="source")
 export default class extends Controller {
-  static targets = ["existingPanel", "newPanel"]
+  static targets = ["existingPanel", "newPanel", "platform", "source"]
 
   connect() {
     this.toggleCustomer()
@@ -28,5 +30,33 @@ export default class extends Controller {
   togglePanel(panel, active) {
     if (!panel) return
     panel.classList.toggle("hidden", !active)
+  }
+
+  // Cohérence plateforme ↔ canal (epic #81, Phase 4). Choisir une plateforme OTA
+  // (Airbnb / Booking.com) bascule automatiquement le canal sur « OTA ». Repasser
+  // en « Réservation directe » (web) NE force le retour à « Saisie manuelle » QUE
+  // si le canal était justement « ota » — on ne réécrit jamais un autre canal
+  // (reservation / tally_legacy conservés en édition).
+  syncChannelFromPlatform() {
+    if (!this.hasPlatformTarget || !this.hasSourceTarget) return
+
+    const isOta =
+      this.platformTarget.value === "airbnb" ||
+      this.platformTarget.value === "bookingdotcom"
+
+    if (isOta) {
+      this.setSourceIfPossible("ota")
+    } else if (this.sourceTarget.value === "ota") {
+      this.setSourceIfPossible("manual")
+    }
+  }
+
+  // Positionne le <select> canal sur `value` uniquement si l'option existe (les
+  // options sont bornées côté serveur à manual/ota + la source d'origine). No-op
+  // si la valeur est déjà en place — évite tout événement superflu.
+  setSourceIfPossible(value) {
+    const hasOption = Array.from(this.sourceTarget.options).some((o) => o.value === value)
+    if (!hasOption || this.sourceTarget.value === value) return
+    this.sourceTarget.value = value
   }
 }

--- a/app/helpers/stays_helper.rb
+++ b/app/helpers/stays_helper.rb
@@ -1,0 +1,15 @@
+# Helpers de présentation des séjours (epic #81, Phase 3).
+module StaysHelper
+  # Libellés français des canaux d'attribution (`Stay::SOURCES`). Partagés entre
+  # le form séjour, l'index « Séjours récents » et son filtre.
+  SOURCE_LABELS = {
+    "manual"       => "Saisie manuelle",
+    "ota"          => "OTA (Airbnb / Booking.com)",
+    "reservation"  => "Réservation en ligne",
+    "tally_legacy" => "Import Tally (legacy)"
+  }.freeze
+
+  def stay_source_label(value)
+    SOURCE_LABELS[value.to_s] || value.to_s
+  end
+end

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -8,6 +8,7 @@
 #  departure_date     :date
 #  status             :string
 #  total_amount_cents :integer          default(0), not null
+#  price_override_cents :integer
 #  notes              :text
 #  legacy_origin      :string
 #  deleted_at         :datetime
@@ -19,6 +20,14 @@ class Stay < ApplicationRecord
   # d'import/dédup de la migration legacy). Tout Stay créé via /reservation
   # porte la valeur par défaut "reservation".
   SOURCES = %w[reservation tally_legacy ota manual].freeze
+
+  # Canaux d'attribution qu'un admin peut POSER depuis le CRUD Séjour (epic #81,
+  # Phase 3). `reservation` (funnel public natif) et `tally_legacy` (import) sont
+  # automatiques — jamais choisis à la main. On borne donc le `<select>` du form
+  # à la saisie manuelle et à l'OTA (parité avec le canal Booking direct). Le
+  # modèle, lui, continue d'accepter toute valeur de `SOURCES` (édition d'un
+  # séjour issu d'un canal automatique : sa source d'origine est préservée).
+  ADMIN_SELECTABLE_SOURCES = %w[manual ota].freeze
 
   # Statut de paiement du séjour (epic #26, Phase 1). Le séjour devient l'ancre
   # de paiement ; Booking garde le sien tant que la colonne existe.
@@ -41,6 +50,8 @@ class Stay < ApplicationRecord
   has_soft_deletion default_scope: true
 
   monetize :total_amount_cents
+  # Prix libre / override du séjour (epic #81, Phase 3) : nullable — vide = devis.
+  monetize :price_override_cents, allow_nil: true
 
   before_create :generate_activity_token
   before_create :generate_token
@@ -179,6 +190,14 @@ class Stay < ApplicationRecord
     payment_status == "paid"
   end
 
+  # Le séjour porte-t-il un prix imposé (epic #81, Phase 3) ? Quand oui, le total
+  # est FIXÉ par l'admin et court-circuite le devis B2C forfaitaire ; l'exigible
+  # (`payable_amount_cents` / `balance_due_cents`) en découle automatiquement,
+  # car il se dérive de `total_amount_cents`.
+  def price_overridden?
+    price_override_cents.present?
+  end
+
   private
 
   def generate_activity_token
@@ -213,9 +232,16 @@ class Stay < ApplicationRecord
     # Le total agrège : bookables (hébergement/espaces/camping/van via StayItem)
     # + activités ACTIVES + repas (epic #66, Phase 3 — has_many direct, non
     # calendrier). Les repas soft-deleted sont exclus par le default_scope.
-    amount = items.sum { |b| b.try(:price_cents).to_i } +
-             experience_bookings.active.sum(&:price_cents) +
-             meal_orders.sum(:price_cents).to_i
+    # Prix imposé (epic #81, Phase 3) : s'il est présent, il FIXE le total et
+    # court-circuite le devis calculé depuis la composition. Les DATES, elles,
+    # restent toujours dérivées des bookables (l'override ne borne que le montant).
+    amount = if price_overridden?
+      price_override_cents
+    else
+      items.sum { |b| b.try(:price_cents).to_i } +
+        experience_bookings.active.sum(&:price_cents) +
+        meal_orders.sum(:price_cents).to_i
+    end
     # Séjour SANS hébergement (epic #66, Phase 2) : les dates viennent des
     # SpaceBooking (Booking ET SpaceBooking exposent from_date/to_date), donc un
     # séjour « espaces seuls » reste daté. On ne réécrit les dates QUE si au moins

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -57,6 +57,9 @@ class Stay < ApplicationRecord
   before_create :generate_token
 
   validates :source, inclusion: { in: SOURCES, message: "Canal d'attribution invalide" }
+  # Défense en profondeur : le contrôleur rejette déjà le négatif, mais aucun
+  # chemin (import, console, futur canal) ne doit pouvoir imposer un prix < 0.
+  validates :price_override_cents, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :payment_status, inclusion: { in: PAYMENT_STATUSES, message: "Statut de paiement invalide" }
   validates :token, uniqueness: true, allow_nil: true
 
@@ -148,7 +151,13 @@ class Stay < ApplicationRecord
 
   # Assiette EXIGIBLE = hébergement/espaces + activités CONFIRMED
   #                   = total prévu − activités pending.
+  # SOUS PRIX IMPOSÉ (epic #81, Phase 3) : l'admin a fixé un montant ferme — il
+  # est exigible tel quel, sans déduire les activités pending (sinon un override
+  # inférieur au montant des activités en attente rendait le solde négatif et
+  # faisait disparaître le bouton « Payer le solde »).
   def payable_amount_cents
+    return total_amount_cents.to_i if price_overridden?
+
     total_amount_cents.to_i - experiences_pending_amount_cents
   end
 

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -49,14 +49,20 @@ module Reservations
     #                             fait foi) mais l'indisponibilité n'échoue plus —
     #                             elle est exposée via `availability_warning`
     #                             (surbooking / saisie a posteriori autorisés).
+    # `price_override_cents` / `platform` (epic #81, Phase 3) : prix libre imposé
+    # et attribution OTA — RÉSERVÉS au canal admin. Ignorés hors `admin: true`,
+    # même sur param forgé (le funnel public ne les expose jamais).
     def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE,
-                   admin: false, status: nil, source: nil, skip_availability: false)
+                   admin: false, status: nil, source: nil, skip_availability: false,
+                   price_override_cents: nil, platform: nil)
       @draft = draft
       @deposit_rate = deposit_rate
       @admin = admin
       @requested_status = status
       @requested_source = source
       @skip_availability = skip_availability
+      @requested_price_override_cents = price_override_cents
+      @requested_platform = platform
       @report_errors = true
     end
 
@@ -104,6 +110,10 @@ module Reservations
           arrival_date: draft.arrival_date,
           departure_date: draft.departure_date,
           total_amount_cents: quote.total_excluding_experiences_cents,
+          # Prix imposé (epic #81, Phase 3) : persisté d'entrée. `total_amount_cents`
+          # est réaligné juste après (voir plus bas) pour que le total reflète
+          # l'override dès la création, sans attendre un recompute.
+          price_override_cents: admin_price_override,
           notes: internal_notes
         )
         @stay.stay_items.create!(bookable: @booking) if @booking
@@ -126,7 +136,11 @@ module Reservations
         # MÊME nature que ceux du rail email, donc soumis à la validation porteur.
         # On réintègre leur montant au total prévu (mais JAMAIS à l'acompte).
         experiences_total = create_experience_bookings!(@stay)
-        if experiences_total.positive?
+        # Total du séjour : le prix imposé (epic #81) PRIME sur le devis. Sinon,
+        # comportement historique — devis hors activités + activités créées.
+        if admin_price_override.present?
+          @stay.update!(total_amount_cents: admin_price_override)
+        elsif experiences_total.positive?
           @stay.update!(total_amount_cents: quote.total_excluding_experiences_cents + experiences_total)
         end
         # Le paiement est rattaché au Stay dans tous les cas ; le booking n'est
@@ -326,7 +340,7 @@ module Reservations
         children: draft.children.to_i,
         status: stay_status,
         payment_status: "pending",
-        platform: "web",
+        platform: booking_platform,
         lodging_id: draft.lodging_id,
         # Prix de l'occupation d'hébergement = hébergement PUR (`lodging_only_cents`),
         # dans TOUS les canaux (issue #79) : camping / van / repas sont extraits sur
@@ -385,6 +399,20 @@ module Reservations
 
     def stay_source
       @requested_source.presence || "reservation"
+    end
+
+    # Prix imposé effectif : seulement en mode admin (jamais côté public, même sur
+    # param forgé). nil = pas d'override → devis appliqué.
+    def admin_price_override
+      return nil unless @admin
+      @requested_price_override_cents.presence
+    end
+
+    # Attribution OTA du Booking d'occupation (epic #81, Phase 3). Réservée à
+    # l'admin ; le funnel public reste "web" (réservation directe native).
+    def booking_platform
+      return "web" unless @admin
+      @requested_platform.presence || "web"
     end
 
     # Multi-chiens hors flow auto (Q2) : on consigne pour traitement manuel.

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -29,12 +29,20 @@ module Stays
 
     attr_reader :stay, :availability_warning, :space_warning
 
-    def initialize(stay:, draft:, status: nil, skip_availability: false, user: nil)
+    # `price_override_cents` / `platform` / `source` (epic #81, Phase 3) : prix
+    # imposé, attribution OTA du Booking et canal du Stay. `price_override_cents`
+    # est appliqué TEL QUEL — nil le RETIRE (retour au devis B2C). Ce service est
+    # le canal admin exclusif : aucun garde-fou public à prévoir ici.
+    def initialize(stay:, draft:, status: nil, skip_availability: false, user: nil,
+                   price_override_cents: nil, platform: nil, source: nil)
       @stay = stay
       @draft = draft
       @requested_status = status
       @skip_availability = skip_availability
       @user = user
+      @requested_price_override_cents = price_override_cents
+      @requested_platform = platform
+      @requested_source = source
       @report_errors = true
     end
 
@@ -53,7 +61,15 @@ module Stays
     def run!
       validate!
       ActiveRecord::Base.transaction do
-        @stay.update!(customer: upsert_customer!, status: stay_status)
+        # `price_override_cents` est posé AVANT le recompute final : ce dernier
+        # honore l'override (total = override) tout en gardant les dates dérivées
+        # de la composition. nil retire l'override → le recompute reprend le devis.
+        @stay.update!(
+          customer:             upsert_customer!,
+          status:               stay_status,
+          source:               stay_source,
+          price_override_cents: @requested_price_override_cents.presence
+        )
         reconcile_lodging!
         reconcile_spaces!
         reconcile_camping!
@@ -188,6 +204,8 @@ module Stays
 
       if booking
         # NB : ni `status` ni `email` ici — voir l'en-tête de classe (anti-email).
+        # `platform` (attribution OTA, epic #81) est en revanche propagé : son
+        # changement ne déclenche AUCUN email (cf. `notify_customer_on_update`).
         booking.update!(
           lodging_id:        @draft.lodging_id,
           from_date:         @draft.arrival_date,
@@ -198,6 +216,7 @@ module Stays
           firstname:         @draft.first_name,
           lastname:          @draft.last_name,
           phone:             @draft.phone,
+          platform:          booking_platform(booking.platform),
           price_cents:       price,
           shown_price_cents: price
         )
@@ -214,7 +233,7 @@ module Stays
           children:          @draft.children.to_i,
           status:            stay_status,
           payment_status:    "pending",
-          platform:          "web",
+          platform:          booking_platform,
           lodging_id:        @draft.lodging_id,
           price_cents:       price,
           shown_price_cents: price
@@ -375,6 +394,19 @@ module Stays
 
     def stay_status
       Stay::STATUSES_ADMIN_CREATABLE.include?(@requested_status) ? @requested_status : @stay.status
+    end
+
+    # Canal du Stay : on ne change la source QUE si l'admin en fournit une valide
+    # (`SOURCES`). Sinon on préserve celle d'origine — ne jamais écraser en
+    # silence l'attribution d'un séjour issu d'un canal automatique.
+    def stay_source
+      Stay::SOURCES.include?(@requested_source) ? @requested_source : @stay.source
+    end
+
+    # Attribution OTA à propager au Booking. Priorité au choix admin ; à défaut,
+    # on préserve la valeur courante (`current`) plutôt que de la réinitialiser.
+    def booking_platform(current = nil)
+      @requested_platform.presence || current || "web"
     end
 
     def raise_invalid(message)

--- a/app/services/stays/merge_preview.rb
+++ b/app/services/stays/merge_preview.rb
@@ -55,7 +55,13 @@ module Stays
 
     # --- Total : mirror de `recompute_aggregates!` sur l'ensemble fusionné ----
     # bookables (hébergement/espaces/camping/van) + activités ACTIVES + repas.
+    # Prix imposé (epic #81, Phase 3) : décision figée — à la fusion, si la CIBLE
+    # porte un override il est CONSERVÉ (recompute de la cible fusionnée le
+    # honore) ; les overrides des SOURCES sont ignorés (leur montant réel a déjà
+    # été absorbé dans les items migrés). On projette donc EXACTEMENT cela.
     def projected_total_cents
+      return target.price_override_cents if target.price_overridden?
+
       all_stays.sum { |stay| computed_total_cents(stay) }
     end
 
@@ -144,6 +150,19 @@ module Stays
           kind: :pending_payment,
           message: "Le séjour ##{source.id} porte un paiement en attente — vérifier avant de fusionner."
         )
+      end
+
+      # Prix imposé impliqué (epic #81, Phase 3) : l'admin DOIT savoir qu'un
+      # override est en jeu — la cible conserve le sien, ceux des sources tombent.
+      overridden = all_stays.select(&:price_overridden?)
+      if overridden.any?
+        message = if target.price_overridden?
+          "Prix imposé sur la cible (##{target.id}) : il sera CONSERVÉ comme total du séjour fusionné."
+        else
+          ids = overridden.map { |s| "##{s.id}" }.join(", ")
+          "Prix imposé sur une source (#{ids}) : il sera IGNORÉ (le total sera recalculé depuis la composition fusionnée)."
+        end
+        warnings << Warning.new(kind: :price_override, message: message)
       end
 
       dupes = all_stays

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -4,6 +4,16 @@
 - current_status = (@stay.status.presence || "pending")
 - selected_experiences = {}
 - Array(@draft&.experiences).each { |e| selected_experiences[e[:availability_id].to_i] = e[:participants] }
+/ Attribution + prix imposé (epic #81, Phase 3). Source portée par le Stay,
+/ plateforme portée par le Booking d'occupation (quand il y en a un).
+- current_source = (@stay&.source.presence || "manual")
+- source_labels = { "manual" => "Saisie manuelle", "ota" => "OTA (Airbnb / Booking.com)", "reservation" => "Réservation en ligne", "tally_legacy" => "Import Tally (legacy)" }
+- source_values = (Stay::ADMIN_SELECTABLE_SOURCES + [current_source]).uniq
+- source_options = source_values.map { |v| [source_labels[v] || v, v] }
+- lodging_booking = @stay&.persisted? ? @stay.stay_items.where(bookable_type: "Booking").first&.bookable : nil
+- current_platform = (lodging_booking&.platform.presence || "web")
+- platform_options = [["Réservation directe (aucune)", "web"], ["Airbnb", "airbnb"], ["Booking.com", "bookingdotcom"]]
+- override_prefill = params.dig(:stay, :price_override).presence || (@stay&.price_override_cents.present? ? format("%g", @stay.price_override_cents / 100.0) : nil)
 
 = form_with url: url, method: method, data: { controller: "stay-form stay-quote stay-availability", "stay-quote-url-value": quote_stays_path, "stay-availability-url-value": availability_stays_path, action: "change->stay-quote#check input->stay-quote#check" } do
   .space-y-8
@@ -134,6 +144,18 @@
               = hidden_field_tag "stay[experiences][#{index}][availability_id]", availability.id
               = number_field_tag "stay[experiences][#{index}][participants]", selected_experiences[availability.id].to_i, min: 0, class: "w-20 rounded-md border-gray-300 shadow-sm sm:text-sm"
 
+    / --- Attribution (source + plateforme) ----------------------------------
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Attribution
+      p.text-sm.text-gray-500 D'où vient ce séjour ? La plateforme n'est enregistrée que si le séjour comporte un hébergement.
+      .grid.grid-cols-2.gap-4
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Canal (source)
+          = select_tag "stay[source]", options_for_select(source_options, current_source), class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Plateforme
+          = select_tag "stay[platform]", options_for_select(platform_options, current_platform), class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+
     / --- Statut + force dispo -----------------------------------------------
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
       h2.text-base.font-semibold.text-gray-900 Statut & disponibilité
@@ -146,6 +168,17 @@
 
     / --- Devis (live — issue #73) -------------------------------------------
     = render "stays/quote_panel"
+
+    / --- Prix imposé (override — epic #81, Phase 3) --------------------------
+    / Le devis B2C ci-dessus reste la référence par défaut. Saisir un montant ici
+    / IMPOSE le total du séjour et court-circuite le devis ; laisser vide applique
+    / le devis. Le solde exigible se recalcule automatiquement depuis ce total.
+    section.bg-gray-50.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-2
+      h2.text-base.font-semibold.text-gray-900 Prix
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Prix total imposé (€)
+        = number_field_tag "stay[price_override]", override_prefill, step: "0.01", min: 0, placeholder: "—", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        p.text-xs.text-gray-500 Laisser vide pour appliquer le devis B2C. Un montant remplace le total du devis.
 
     .flex.justify-end.gap-3
       = link_to "Annuler", recent_stays_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -156,10 +156,11 @@
       .grid.grid-cols-2.gap-4
         .space-y-1
           label.block.text-sm.font-medium.text-gray-700 Canal (source)
-          = select_tag "stay[source]", options_for_select(source_options, current_source), class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+          = select_tag "stay[source]", options_for_select(source_options, current_source), data: { "stay-form-target": "source" }, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
         .space-y-1
           label.block.text-sm.font-medium.text-gray-700 Plateforme
-          = select_tag "stay[platform]", options_for_select(platform_options, current_platform), class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+          / Choisir une plateforme OTA bascule le canal sur « OTA » (stay-form#syncChannelFromPlatform).
+          = select_tag "stay[platform]", options_for_select(platform_options, current_platform), data: { "stay-form-target": "platform", action: "change->stay-form#syncChannelFromPlatform" }, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
     / --- Statut + force dispo -----------------------------------------------
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -13,6 +13,10 @@
 - lodging_booking = @stay&.persisted? ? @stay.stay_items.where(bookable_type: "Booking").first&.bookable : nil
 - current_platform = (lodging_booking&.platform.presence || "web")
 - platform_options = [["Réservation directe (aucune)", "web"], ["Airbnb", "airbnb"], ["Booking.com", "bookingdotcom"]]
+/ Même garde-fou que `source` : une valeur historique hors options (ex. "direct",
+/ posée par le form Booking) doit apparaître sélectionnée, sinon le navigateur
+/ retombe sur "web" et l'édition réécrit la plateforme en silence.
+- platform_options += [[current_platform, current_platform]] unless platform_options.any? { |_l, v| v == current_platform }
 - override_prefill = params.dig(:stay, :price_override).presence || (@stay&.price_override_cents.present? ? format("%g", @stay.price_override_cents / 100.0) : nil)
 
 = form_with url: url, method: method, data: { controller: "stay-form stay-quote stay-availability", "stay-quote-url-value": quote_stays_path, "stay-availability-url-value": availability_stays_path, action: "change->stay-quote#check input->stay-quote#check" } do

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -6,10 +6,11 @@
 - Array(@draft&.experiences).each { |e| selected_experiences[e[:availability_id].to_i] = e[:participants] }
 / Attribution + prix imposé (epic #81, Phase 3). Source portée par le Stay,
 / plateforme portée par le Booking d'occupation (quand il y en a un).
-- current_source = (@stay&.source.presence || "manual")
-- source_labels = { "manual" => "Saisie manuelle", "ota" => "OTA (Airbnb / Booking.com)", "reservation" => "Réservation en ligne", "tally_legacy" => "Import Tally (legacy)" }
+/ Séjour NEUF : canal "manual" (saisie admin) — le défaut DB "reservation"
+/ (funnel public) ne doit pas fuir dans le form. En édition : source réelle.
+- current_source = @stay&.persisted? ? (@stay.source.presence || "manual") : "manual"
 - source_values = (Stay::ADMIN_SELECTABLE_SOURCES + [current_source]).uniq
-- source_options = source_values.map { |v| [source_labels[v] || v, v] }
+- source_options = source_values.map { |v| [stay_source_label(v), v] }
 - lodging_booking = @stay&.persisted? ? @stay.stay_items.where(bookable_type: "Booking").first&.bookable : nil
 - current_platform = (lodging_booking&.platform.presence || "web")
 - platform_options = [["Réservation directe (aucune)", "web"], ["Airbnb", "airbnb"], ["Booking.com", "bookingdotcom"]]
@@ -180,8 +181,8 @@
     section.bg-gray-50.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-2
       h2.text-base.font-semibold.text-gray-900 Prix
       .space-y-1
-        label.block.text-sm.font-medium.text-gray-700 Prix total imposé (€)
-        = number_field_tag "stay[price_override]", override_prefill, step: "0.01", min: 0, placeholder: "—", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        label.block.text-sm.font-medium.text-gray-700 for="stay_price_override" Prix total imposé (€)
+        = number_field_tag "stay[price_override]", override_prefill, id: "stay_price_override", step: "0.01", min: 0, placeholder: "—", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
         p.text-xs.text-gray-500 Laisser vide pour appliquer le devis B2C. Un montant remplace le total du devis.
 
     .flex.justify-end.gap-3

--- a/app/views/stays/recent.html.slim
+++ b/app/views/stays/recent.html.slim
@@ -9,7 +9,7 @@
   / Filtre par source (AC-T2-23).
   = form_with url: recent_stays_path, method: :get, class: "mb-4 flex items-center gap-2" do
     label.text-sm.text-gray-600 Canal :
-    = select_tag :source, options_for_select([["Tous", ""]] + @sources.map { |s| [s, s] }, @source), onchange: "this.form.requestSubmit()", class: "rounded border-gray-300 text-sm"
+    = select_tag :source, options_for_select([["Tous", ""]] + @sources.map { |s| [stay_source_label(s), s] }, @source), onchange: "this.form.requestSubmit()", class: "rounded border-gray-300 text-sm"
 
   .overflow-hidden.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg
     table.min-w-full.divide-y.divide-gray-300
@@ -19,6 +19,7 @@
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Dates
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Canal
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Statut
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Total
           th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Créé le
           th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Actions
       tbody.divide-y.divide-gray-200.bg-white
@@ -31,11 +32,15 @@
                 = stay.contact_line
             td.px-4.py-2.text-sm = stay.date_range
             td.px-4.py-2.text-sm
-              span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.py-0.5.text-xs.font-medium.text-gray-700 = stay.source
+              span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.text-xs.font-medium.text-gray-700(class="py-0.5") = stay_source_label(stay.source)
             td.px-4.py-2.text-sm = stay.status_badge
+            td.px-4.py-2.text-sm.text-right.whitespace-nowrap
+              span.font-medium.text-gray-900 = humanized_money_with_symbol(stay.total_amount)
+              - if stay.price_overridden?
+                span.ml-1.text-xs.text-amber-700(title="Prix total imposé par l'admin (devis B2C court-circuité)") imposé
             td.px-4.py-2.text-sm.text-gray-500 = l(stay.created_at.to_date, format: :long)
             td.px-4.py-2.text-sm.text-right
               = link_to "Éditer", edit_stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 hover:underline"
         - if @stays.empty?
           tr
-            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="6" Aucun séjour pour ce canal.
+            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="7" Aucun séjour pour ce canal.

--- a/db/migrate/20260719130000_add_price_override_cents_to_stays.rb
+++ b/db/migrate/20260719130000_add_price_override_cents_to_stays.rb
@@ -1,0 +1,8 @@
+# Prix libre / override du séjour (epic #81, Phase 3). Colonne additive nullable :
+# quand elle est renseignée, elle IMPOSE le total du séjour et court-circuite le
+# devis B2C forfaitaire. Vide (NULL) = comportement historique (devis appliqué).
+class AddPriceOverrideCentsToStays < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stays, :price_override_cents, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_19_120000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_19_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -645,6 +645,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_19_120000) do
     t.string "token"
     t.string "payment_status", default: "pending", null: false
     t.datetime "balance_reminder_sent_at"
+    t.integer "price_override_cents"
     t.index ["activity_selection_token"], name: "index_stays_on_activity_selection_token"
     t.index ["customer_id"], name: "index_stays_on_customer_id"
     t.index ["legacy_origin"], name: "index_stays_on_legacy_origin_unique_live", unique: true, where: "((legacy_origin IS NOT NULL) AND (deleted_at IS NULL))"

--- a/spec/models/stay_spec.rb
+++ b/spec/models/stay_spec.rb
@@ -337,5 +337,37 @@ RSpec.describe Stay, type: :model do
       stay.set_payment_status
       expect(stay.reload.payment_status).to eq("paid")
     end
+
+    # Décision figée (epic #81, Phase 3, revue Forge F3) : un prix IMPOSÉ est
+    # ferme — exigible tel quel, sans déduction des activités pending (sinon un
+    # override inférieur au montant pending rendait le solde négatif et faisait
+    # disparaître le bouton « Payer le solde »).
+    it "sous prix imposé, l'exigible est l'override entier (pending non déduite)" do
+      stay.update!(price_override_cents: 30_000)
+      stay.recompute_aggregates!
+      expect(stay.payable_amount_cents).to eq(30_000)
+      expect(stay.balance_due_cents).to eq(30_000)
+      expect(stay).to be_payable_now
+    end
+
+    it "sous prix imposé inférieur aux activités pending, le solde reste exigible (jamais négatif par déduction)" do
+      stay.update!(price_override_cents: 5_000) # < 6 500 de pending
+      stay.recompute_aggregates!
+      expect(stay.payable_amount_cents).to eq(5_000)
+      expect(stay).to be_payable_now
+    end
+  end
+
+  describe "validation du prix imposé (epic #81, Phase 3)" do
+    it "refuse un override négatif (défense en profondeur, tout canal)" do
+      stay = Stay.new(customer: customer, source: "manual", price_override_cents: -100)
+      expect(stay).not_to be_valid
+      expect(stay.errors[:price_override_cents]).to be_present
+    end
+
+    it "accepte 0 € (override valide) et nil (pas d'override)" do
+      expect(Stay.new(customer: customer, source: "manual", price_override_cents: 0)).to be_valid
+      expect(Stay.new(customer: customer, source: "manual", price_override_cents: nil)).to be_valid
+    end
   end
 end

--- a/spec/models/stay_spec.rb
+++ b/spec/models/stay_spec.rb
@@ -77,6 +77,41 @@ RSpec.describe Stay, type: :model do
     end
   end
 
+  describe "#recompute_aggregates! avec prix imposé (epic #81, Phase 3)" do
+    it "impose le total = override tout en gardant les dates de la composition" do
+      stay = Stay.create!(customer: customer, price_override_cents: 99_900)
+      stay.stay_items.create!(bookable: booking(from: Date.new(2026, 7, 5), to: Date.new(2026, 7, 8), price_cents: 30_000))
+
+      stay.recompute_aggregates!
+
+      expect(stay.total_amount_cents).to eq(99_900)         # override, pas 30 000
+      expect(stay.arrival_date).to eq(Date.new(2026, 7, 5)) # dates toujours dérivées des items
+      expect(stay.departure_date).to eq(Date.new(2026, 7, 8))
+    end
+
+    it "reprend le total de la composition quand l'override est retiré" do
+      stay = Stay.create!(customer: customer, price_override_cents: 99_900)
+      stay.stay_items.create!(bookable: booking(from: Date.new(2026, 7, 5), to: Date.new(2026, 7, 8), price_cents: 30_000))
+      stay.recompute_aggregates!
+      expect(stay.total_amount_cents).to eq(99_900)
+
+      stay.update!(price_override_cents: nil)
+      stay.recompute_aggregates!
+      expect(stay.total_amount_cents).to eq(30_000)
+    end
+
+    it "fait suivre l'exigible et le solde depuis le total imposé" do
+      stay = Stay.create!(customer: customer, price_override_cents: 50_000)
+      b = booking(from: Date.new(2026, 7, 5), to: Date.new(2026, 7, 8), price_cents: 30_000)
+      stay.stay_items.create!(bookable: b)
+      Payment.create!(booking: b, stay: stay, amount_cents: 20_000, status: "paid", payment_method: "card")
+      stay.recompute_aggregates!
+
+      expect(stay.payable_amount_cents).to eq(50_000) # = total imposé (aucune activité pending)
+      expect(stay.balance_due_cents).to eq(30_000)    # 50 000 imposés − 20 000 encaissés
+    end
+  end
+
   describe "scopes" do
     it "separates current/future stays from past ones" do
       future = Stay.create!(customer: customer, arrival_date: Date.today + 5, departure_date: Date.today + 10)

--- a/spec/requests/stays_admin_crud_spec.rb
+++ b/spec/requests/stays_admin_crud_spec.rb
@@ -222,6 +222,29 @@ RSpec.describe "Stays — CRUD admin (epic #66)", type: :request do
       expect(stay.reload.price_override_cents).to be_nil
       expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents) # devis repris
     end
+
+    it "ignore un override négatif (revue Forge F2) : traité comme une saisie vide" do
+      post stays_path, params: base_params(price_override: "-50")
+      stay = Stay.order(:created_at).last
+      expect(stay.price_override_cents).to be_nil
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents)
+    end
+
+    # Revue Forge F1 : le form Booking direct historique écrit platform="direct",
+    # hors des 3 options du select séjour. Sans garde-fou, l'édition retombait
+    # sur "web" et réécrivait la plateforme en silence.
+    it "préserve une plateforme historique hors options (ex. \"direct\") à l'édition" do
+      stay = create_admin_stay
+      booking = stay.stay_items.where(bookable_type: "Booking").first.bookable
+      booking.update!(platform: "direct")
+
+      get edit_stay_path(stay)
+      expect(response.body).to match(/<option selected[^>]*value="direct"|<option[^>]*value="direct"[^>]*selected/)
+
+      # Resoumettre le form avec la valeur affichée ne mute pas la plateforme.
+      patch stay_path(stay), params: update_params(stay, platform: "direct")
+      expect(booking.reload.platform).to eq("direct")
+    end
   end
 
   describe "DELETE /stays/:id (destroy)" do

--- a/spec/requests/stays_admin_crud_spec.rb
+++ b/spec/requests/stays_admin_crud_spec.rb
@@ -182,6 +182,48 @@ RSpec.describe "Stays — CRUD admin (epic #66)", type: :request do
     end
   end
 
+  describe "prix imposé & attribution (epic #81, Phase 3)" do
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: lodging.id, status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "POST impose le total via price_override et enregistre source + plateforme" do
+      post stays_path, params: base_params(price_override: "999", source: "ota", platform: "airbnb")
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay = Stay.order(:created_at).last
+      expect(stay.price_override_cents).to eq(99_900)
+      expect(stay.total_amount_cents).to eq(99_900)          # override, pas 74 500
+      expect(stay.source).to eq("ota")
+      booking = stay.stay_items.where(bookable_type: "Booking").first.bookable
+      expect(booking.platform).to eq("airbnb")
+    end
+
+    it "POST sans price_override applique le devis B2C" do
+      post stays_path, params: base_params
+      expect(Stay.order(:created_at).last.total_amount_cents).to eq(hulotte_two_nights_cents)
+    end
+
+    it "PATCH pose puis retire l'override (retour au devis)" do
+      stay = create_admin_stay
+
+      patch stay_path(stay), params: update_params(stay, price_override: "500")
+      expect(stay.reload.price_override_cents).to eq(50_000)
+      expect(stay.total_amount_cents).to eq(50_000)
+
+      patch stay_path(stay), params: update_params(stay, price_override: "")
+      expect(stay.reload.price_override_cents).to be_nil
+      expect(stay.total_amount_cents).to eq(hulotte_two_nights_cents) # devis repris
+    end
+  end
+
   describe "DELETE /stays/:id (destroy)" do
     it "soft-supprime le séjour (jamais de hard destroy)" do
       stay = create_admin_stay

--- a/spec/requests/stays_ota_spec.rb
+++ b/spec/requests/stays_ota_spec.rb
@@ -1,0 +1,150 @@
+require "rails_helper"
+
+# Epic #81, Phase 4 — Absorber l'OTA (Airbnb / Booking.com) dans le séjour.
+#
+# Un séjour OTA se crée avec une plateforme (Airbnb / Booking.com) et un PRIX
+# LIBRE (le montant de la plateforme, saisi via `price_override`). Il occupe le
+# calendrier et pose le veto de disponibilité EXACTEMENT comme un séjour B2C :
+# c'est `Reservations::Builder` (mode admin) qui crée les `Reservation` de
+# chambres jour par jour (fix epic #66, Phase 6). On le PROUVE ici de bout en
+# bout — création, Reservation, veto Grand-Duc, rendu calendrier, prefill edit.
+RSpec.describe "Stays — canal OTA (epic #81, Phase 4)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-ota@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  # La Hulotte est au barème B2C (Pricing::Catalog) ET porte une chambre : c'est
+  # la chambre qui reçoit les `Reservation` jour par jour — source de vérité du
+  # veto (`Lodging#available_between?`) et du rendu calendrier par ressource.
+  let!(:lodging) { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:room)    { lodging.rooms.create!(name: "Chambre Hulotte", level: 1) }
+  let(:arrival)   { Date.today.next_occurring(:friday) }
+  let(:departure) { arrival + 2 } # 2 nuits → 2 Reservation attendues
+
+  # Teinte séjour attendue au calendrier — même formule que CalendarHelper.
+  def hue_for(stay_id)
+    ((stay_id * CalendarHelper::GOLDEN_ANGLE) % 360).round
+  end
+
+  def ota_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Olga", last_name: "Airbnb", email: "olga@example.com", phone: "0470999888" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "confirmed",
+        source: "ota", platform: "airbnb", price_override: "640"
+      }.merge(overrides)
+    }
+  end
+
+  def last_booking
+    Stay.order(:created_at).last.stay_items.where(bookable_type: "Booking").first.bookable
+  end
+
+  describe "création d'un séjour OTA complet (AC1 / AC4)" do
+    it "enregistre source ota, plateforme persistée et total = prix imposé" do
+      expect {
+        post stays_path, params: ota_params
+      }.to change(Stay, :count).by(1)
+       .and change(Booking, :count).by(1)
+       .and change(Customer, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      stay = Stay.order(:created_at).last
+      expect(stay.source).to eq("ota")
+      expect(stay.status).to eq("confirmed")
+      expect(stay.price_override_cents).to eq(64_000)
+      expect(stay.total_amount_cents).to eq(64_000)          # prix imposé, pas le devis B2C (74 500)
+      expect(last_booking.platform).to eq("airbnb")
+      # Canal admin : aucun paiement (donc aucun Stripe) à la création.
+      expect(stay.payments).to be_empty
+    end
+
+    it "absorbe aussi Booking.com comme plateforme" do
+      post stays_path, params: ota_params(platform: "bookingdotcom")
+      expect(last_booking.platform).to eq("bookingdotcom")
+    end
+  end
+
+  describe "occupation calendrier & veto de disponibilité (AC3)" do
+    it "crée les Reservation de chambres jour par jour sur la fenêtre" do
+      post stays_path, params: ota_params
+
+      booking = last_booking
+      # 2 nuits [arrivée, départ) → une Reservation par nuit sur la chambre.
+      expect(booking.reservations.count).to eq(2)
+      expect(booking.reservations.pluck(:date)).to match_array([arrival, arrival + 1])
+      expect(booking.reservations.pluck(:room_id).uniq).to eq([room.id])
+    end
+
+    it "pose le veto : l'hébergement n'est plus disponible sur la fenêtre" do
+      post stays_path, params: ota_params
+
+      # Même sémantique que le veto du Builder (`available_between?(arrivée, départ)`).
+      expect(lodging.reload.available_between?(arrival, departure)).to be(false)
+      expect(lodging.available_on?(arrival)).to be(false)
+    end
+
+    it "refuse un 2e séjour sur le même hébergement / mêmes dates sans forçage" do
+      post stays_path, params: ota_params # 1er séjour OTA confirmé → pose le veto
+
+      expect {
+        post stays_path, params: ota_params(
+          source: "manual", platform: "web",
+          new_customer: { first_name: "Bob", last_name: "Direct", email: "bob@example.com", phone: "0470000000" }
+        )
+      }.not_to change(Stay, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("plus disponibles")
+    end
+
+    it "autorise le 2e séjour en forçant la disponibilité (surbooking)" do
+      post stays_path, params: ota_params
+
+      expect {
+        post stays_path, params: ota_params(
+          force_availability: "1",
+          new_customer: { first_name: "Bob", last_name: "Direct", email: "bob@example.com", phone: "0470000000" }
+        )
+      }.to change(Stay, :count).by(1)
+
+      expect(response).to redirect_to(recent_stays_path)
+      expect(flash[:alert]).to include("forçant la disponibilité")
+    end
+
+    it "apparaît au calendrier, groupé et teinté par séjour (data-stay-id)" do
+      post stays_path, params: ota_params
+      stay    = Stay.order(:created_at).last
+      booking = last_booking
+
+      get "/"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("data-stay-id=\"#{stay.id}\"")
+      # 2 nuits → 2 entrées jour chambre (la représentation qui porte le veto).
+      expect(response.body.scan("data-booking-day-entry=\"#{booking.id}\"").size).to eq(2)
+      expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
+    end
+  end
+
+  describe "édition d'un séjour OTA — prefill (AC4)" do
+    it "présélectionne la plateforme, le canal OTA et préremplit le prix imposé" do
+      post stays_path, params: ota_params
+      stay = Stay.order(:created_at).last
+
+      get edit_stay_path(stay)
+
+      expect(response).to have_http_status(:ok)
+      # Plateforme Airbnb présélectionnée dans le <select>.
+      expect(response.body).to match(/<option selected[^>]*value="airbnb"|<option[^>]*value="airbnb"[^>]*selected/)
+      # Canal OTA présélectionné.
+      expect(response.body).to match(/<option selected[^>]*value="ota"|<option[^>]*value="ota"[^>]*selected/)
+      # Prix imposé prérempli (640 €).
+      expect(response.body).to include('value="640"')
+    end
+  end
+end

--- a/spec/services/reservations/builder_spec.rb
+++ b/spec/services/reservations/builder_spec.rb
@@ -224,4 +224,52 @@ RSpec.describe Reservations::Builder do
       expect(builder.stay.experience_bookings).to be_empty
     end
   end
+
+  # ------------------------------------------------------------------------
+  # Epic #81, Phase 3 — Prix libre / override + attribution (source/platform),
+  # RÉSERVÉS au canal admin. Le funnel public les ignore, même sur param forgé.
+  # ------------------------------------------------------------------------
+  describe "prix imposé & attribution admin (epic #81, Phase 3)" do
+    it "impose le total du séjour quand un override admin est fourni" do
+      builder = described_class.new(draft: draft, admin: true, price_override_cents: 99_900)
+      expect(builder.run).to be(true)
+
+      expect(builder.stay.price_override_cents).to eq(99_900)
+      expect(builder.stay.total_amount_cents).to eq(99_900) # pas 74 500 (devis B2C)
+    end
+
+    it "applique le devis B2C quand aucun override n'est fourni (admin)" do
+      builder = described_class.new(draft: draft, admin: true)
+      expect(builder.run).to be(true)
+
+      expect(builder.stay.price_override_cents).to be_nil
+      expect(builder.stay.total_amount_cents).to eq(74_500)
+    end
+
+    it "IGNORE un override forgé côté public (admin: false)" do
+      builder = described_class.new(draft: draft, price_override_cents: 1)
+      expect(builder.run).to be(true)
+
+      expect(builder.stay.price_override_cents).to be_nil     # jamais persisté hors admin
+      expect(builder.stay.total_amount_cents).to eq(74_500)   # devis appliqué, override ignoré
+    end
+
+    it "propage la plateforme OTA au Booking d'occupation (admin)" do
+      builder = described_class.new(draft: draft, admin: true, platform: "airbnb")
+      expect(builder.run).to be(true)
+      expect(builder.booking.platform).to eq("airbnb")
+    end
+
+    it "garde platform=web côté public même sur param de plateforme forgé" do
+      builder = described_class.new(draft: draft, platform: "airbnb")
+      expect(builder.run).to be(true)
+      expect(builder.booking.platform).to eq("web")
+    end
+
+    it "propage la source d'attribution du Stay (admin)" do
+      builder = described_class.new(draft: draft, admin: true, source: "ota")
+      expect(builder.run).to be(true)
+      expect(builder.stay.source).to eq("ota")
+    end
+  end
 end

--- a/spec/services/stays/merge_preview_spec.rb
+++ b/spec/services/stays/merge_preview_spec.rb
@@ -82,6 +82,38 @@ RSpec.describe Stays::MergePreview, type: :service do
     end
   end
 
+  # --- Prix imposé (epic #81, Phase 3) --------------------------------------
+  describe "prix imposé" do
+    it "projette le total imposé de la cible et signale l'override" do
+      target.update!(price_override_cents: 88_000)
+      pv = described_class.new(target: target, sources: [source]).call
+
+      expect(pv.total_cents).to eq(88_000) # override cible, pas la somme des items
+      expect(pv.warnings.map(&:kind)).to include(:price_override)
+    end
+
+    it "signale aussi l'override d'une source (qui sera ignoré à la fusion)" do
+      source.update!(price_override_cents: 12_345)
+      pv = described_class.new(target: target, sources: [source]).call
+
+      expect(pv.warnings.map(&:kind)).to include(:price_override)
+    end
+
+    it "reste rigoureusement cohérent avec la fusion réelle quand la cible porte un override" do
+      target.update!(price_override_cents: 88_000)
+      snapshot = described_class.new(target: target, sources: [source]).call
+
+      expect(Stays::MergeService.new(target: target, sources: [source]).run).to be_truthy
+      target.reload
+
+      aggregate_failures do
+        expect(target.total_amount_cents).to eq(snapshot.total_cents)
+        expect(target.amount_paid_cents).to eq(snapshot.paid_cents)
+        expect(target.amount_due_cents).to eq(snapshot.balance_cents)
+      end
+    end
+  end
+
   # --- LA garantie anti-divergence ------------------------------------------
   describe "cohérence preview == fusion réelle (garantie anti-divergence)" do
     it "annonce exactement le total / payé / solde / dates que la fusion produit" do

--- a/spec/services/stays/merge_service_spec.rb
+++ b/spec/services/stays/merge_service_spec.rb
@@ -99,6 +99,34 @@ RSpec.describe Stays::MergeService, type: :service do
     end
   end
 
+  # Décision figée (epic #81, Phase 3) : à la fusion, l'override de la CIBLE est
+  # CONSERVÉ (le recompute de la cible fusionnée l'honore) ; les overrides des
+  # SOURCES tombent (leur montant réel a déjà été absorbé dans les items migrés).
+  describe "prix imposé (epic #81, Phase 3)" do
+    let(:customer) { make_customer("override@example.com") }
+
+    it "conserve l'override de la CIBLE comme total du séjour fusionné" do
+      target = make_stay(customer: customer, price_override_cents: 88_000)
+      source = make_stay(customer: customer, arrival_date: Date.new(2026, 8, 4), departure_date: Date.new(2026, 8, 6))
+      attach(target, make_booking(price_cents: 30_000))
+      attach(source, make_space_booking(price_cents: 20_000))
+
+      expect(described_class.new(target: target, sources: [source]).run).to be_truthy
+      expect(target.reload.total_amount_cents).to eq(88_000) # override conservé, pas 50 000
+    end
+
+    it "ignore l'override d'une SOURCE (montant réel déjà absorbé dans les items)" do
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer, price_override_cents: 99_999,
+                         arrival_date: Date.new(2026, 8, 4), departure_date: Date.new(2026, 8, 6))
+      attach(target, make_booking(price_cents: 30_000))
+      attach(source, make_space_booking(price_cents: 20_000))
+
+      expect(described_class.new(target: target, sources: [source]).run).to be_truthy
+      expect(target.reload.total_amount_cents).to eq(50_000) # somme des items, override source ignoré
+    end
+  end
+
   describe "clients différents" do
     it "conserve le client de la cible (la cible gagne)" do
       target_customer = make_customer("cible@example.com")


### PR DESCRIPTION
## Epic #81 — Phase 4 : OTA absorbé dans le séjour

PR **empilée sur #92** (Phase 3). Phase volontairement compacte : la Phase 3 avait déjà posé platform/source/prix libre — restaient la cohérence UX et les **preuves**.

### Contenu
- **Bascule automatique plateforme ↔ canal** (`stay_form_controller.js`) : choisir Airbnb/Booking.com force le canal « OTA » ; revenir en « Réservation directe » ne rend « Saisie manuelle » QUE si le canal était ota (jamais de réécriture de `reservation`/`tally_legacy` en édition). No-op si l'option n'existe pas.
- **8 specs de preuve** (`stays_ota_spec.rb`) : séjour OTA complet (platform + prix libre → total = override, 0 paiement) ; les `Reservation` de chambres existent jour par jour ; `available_between?` = false sur la fenêtre ; **2e séjour refusé sans forçage (veto), accepté avec** ; rendu calendrier (`data-stay-id`, blocs, teinte hsl) ; prefill édition.

### Analyse de parité avec le canal OTA direct (`Bookings::CreateService`)
| Capacité | Séjour |
|---|---|
| platform (airbnb/bookingdotcom) | ✅ Phase 3 |
| prix libre (« montant convenu ») | ✅ `price_override_cents` |
| barème par tier | ✅ **non nécessaire** : le tier n'existe que dans le form *public* ; le form admin Booking est déjà en prix libre (défauts `neutre` vestigiaux). Aucun sélecteur de tier ajouté. |

Aucune colonne commission/notes OTA sur `Booking` (schéma vérifié) → aucun trou. Seule dette pré-existante notée : `platform=\"direct\"` écrit par le form Booking vs `from_web?` qui teste `web` (le garde-fou Phase 3 préserve déjà `direct` à l'édition).

### Vérifications
- **RSpec : 695 examples, 0 failures** (+8).
- **Navigateur : 6/6 PASS** (bascule dans les deux sens, canal manuel préservé, pas de réécriture au chargement en édition, devis live + dispo intacts, zéro erreur console).