### PR TITLE
Epic #81 Phase 6 — Facturation espace enrichie dans le séjour

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -104,6 +104,18 @@ class StaysController < BaseController
       return render json: { checkable: false }
     end
 
+    # Mode chambres seules (epic #81, Phase 5) : la dispo porte sur les chambres
+    # cochées, pas sur tout le gîte. Sans chambre cochée, rien à vérifier.
+    if params[:booking_type].to_s == "rooms"
+      room_ids = Array(params[:room_ids]).reject(&:blank?)
+      return render json: { checkable: false } if room_ids.empty?
+      return render json: {
+        checkable: true,
+        available: lodging.rooms_available_between?(room_ids, from, to),
+        lodging:   lodging.name
+      }
+    end
+
     render json: {
       checkable: true,
       available: lodging.available_between?(from, to),
@@ -295,6 +307,8 @@ class StaysController < BaseController
     contact = customer_contact(p)
     Reservations::Draft.new(
       lodging_id:     p[:lodging_id],
+      booking_type:   p[:booking_type],
+      room_ids:       room_ids_param(p),
       arrival_date:   p[:arrival_date],
       departure_date: p[:departure_date],
       adults:         p[:adults],
@@ -311,6 +325,12 @@ class StaysController < BaseController
       vans:           van_entries(p),
       meals:          meal_entries(p)
     )
+  end
+
+  # Chambres cochées (mode chambres seules, epic #81, Phase 5). Tableau de la
+  # forme stay[room_ids][] ; on ne garde que des entiers exploitables.
+  def room_ids_param(p)
+    Array(p[:room_ids]).map { |id| id.to_i }.reject(&:zero?)
   end
 
   # Nombre de nuits déduit des dates du formulaire (pour tarifer camping/van).
@@ -363,8 +383,14 @@ class StaysController < BaseController
   # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
   def draft_from_stay(stay)
     booking = stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    # Chambres seules (epic #81, Phase 5) : rétablit le mode + les chambres cochées
+    # depuis les Reservation persistées (pas de drapeau stocké, cf.
+    # Booking#rooms_only_occupation?).
+    rooms_mode = booking&.rooms_only_occupation?
     Reservations::Draft.new(
       lodging_id:     booking&.lodging_id,
+      booking_type:   rooms_mode ? "rooms" : "lodging",
+      room_ids:       rooms_mode ? booking.reservations.map(&:room_id).uniq : [],
       arrival_date:   stay.arrival_date,
       departure_date: stay.departure_date,
       adults:         booking&.adults,

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -289,6 +289,9 @@ class StaysController < BaseController
                                                        .upcoming
                                                        .includes(:experience)
     @statuses = Stay::STATUSES_ADMIN_CREATABLE
+    # Événements sélectionnables pour la facturation espace (epic #81, Phase 6),
+    # décorés pour l'affichage « nom (dates) » — même source que le form direct.
+    @events = EventDecorator.decorate_collection(Event.order(starts_at: :desc))
     @quote  ||= safe_quote(@draft)
   end
 
@@ -323,7 +326,12 @@ class StaysController < BaseController
       halls:          space_entries(p),
       campings:       camping_entries(p),
       vans:           van_entries(p),
-      meals:          meal_entries(p)
+      meals:          meal_entries(p),
+      # Facturation espace (epic #81, Phase 6) : le sous-hash brut transite tel
+      # quel ; le Draft normalise (presence → nil) et la persistance convertit les
+      # montants via les setters `monetize`. Absent du form → `space_billing` nil,
+      # les valeurs existantes survivent à la réédition.
+      space_billing:  p[:space_billing]
     )
   end
 
@@ -406,8 +414,33 @@ class StaysController < BaseController
       halls:          halls_from_stay(stay),
       campings:       campings_from_stay(stay),
       vans:           vans_from_stay(stay),
-      meals:          meals_from_stay(stay)
+      meals:          meals_from_stay(stay),
+      space_billing:  space_billing_from_stay(stay)
     )
+  end
+
+  # Facturation espace (epic #81, Phase 6) : reconstitue le sous-hash de
+  # facturation depuis le SpaceBooking du séjour, pour préremplir le form edit.
+  # nil si le séjour n'a pas d'espace. Les montants repassent en € (chaîne `%g`
+  # pour éviter les décimales parasites) — miroir du form direct `_payment`.
+  def space_billing_from_stay(stay)
+    sb = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+    return nil if sb.nil?
+
+    {
+      advance_amount: euro_prefill(sb.advance_amount_cents),
+      deposit_amount: euro_prefill(sb.deposit_amount_cents),
+      payment_method: sb.payment_method,
+      event_id:       sb.event_id,
+      arrival_time:   sb.arrival_time,
+      departure_time: sb.departure_time
+    }
+  end
+
+  # Cents → chaîne € prête pour un number_field (nil si absent, "50" pas "50.0").
+  def euro_prefill(cents)
+    return nil if cents.nil?
+    format("%g", cents / 100.0)
   end
 
   # Reconstruit l'entrée camping {kind, people, nights} depuis le CampingBooking

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -383,10 +383,10 @@ class StaysController < BaseController
   # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
   def draft_from_stay(stay)
     booking = stay.stay_items.where(bookable_type: "Booking").first&.bookable
-    # Chambres seules (epic #81, Phase 5) : rétablit le mode + les chambres cochées
-    # depuis les Reservation persistées (pas de drapeau stocké, cf.
-    # Booking#rooms_only_occupation?).
-    rooms_mode = booking&.rooms_only_occupation?
+    # Chambres seules (epic #81, Phase 5) : rétablit le mode + les chambres
+    # cochées. La colonne `booking_type` fait foi ; dérivation des Reservation
+    # en secours pour le legacy (cf. Booking#rooms_mode?).
+    rooms_mode = booking&.rooms_mode?
     Reservations::Draft.new(
       lodging_id:     booking&.lodging_id,
       booking_type:   rooms_mode ? "rooms" : "lodging",

--- a/app/frontend/controllers/stay_availability_controller.js
+++ b/app/frontend/controllers/stay_availability_controller.js
@@ -43,6 +43,15 @@ export default class extends Controller {
       departure_date: departure,
     })
 
+    // Mode chambres seules (epic #81, Phase 5) : la dispo porte sur les chambres
+    // cochées. Sans chambre cochée, l'endpoint répond checkable:false → on masque.
+    const bookingType =
+      this.element.querySelector('input[name="stay[booking_type]"]:checked')?.value || "lodging"
+    if (bookingType === "rooms") {
+      params.set("booking_type", "rooms")
+      this.checkedRoomIds().forEach((id) => params.append("room_ids[]", id))
+    }
+
     try {
       const response = await fetch(`${this.urlValue}?${params}`, {
         headers: { Accept: "application/json" },
@@ -66,6 +75,13 @@ export default class extends Controller {
 
   fieldValue(name) {
     return this.element.querySelector(`[name="${name}"]`)?.value?.trim() || ""
+  }
+
+  // Chambres cochées ET VISIBLES (les groupes masqués sont décochés par stay-form).
+  checkedRoomIds() {
+    return Array.from(
+      this.element.querySelectorAll('input[name="stay[room_ids][]"]:checked')
+    ).map((cb) => cb.value)
   }
 
   render(available, message) {

--- a/app/frontend/controllers/stay_form_controller.js
+++ b/app/frontend/controllers/stay_form_controller.js
@@ -13,10 +13,43 @@ import { Controller } from "@hotwired/stimulus"
 //     select[name="stay[platform]"] (data-stay-form-target="platform" data-action="change->stay-form#syncChannelFromPlatform")
 //     select[name="stay[source]"]   (data-stay-form-target="source")
 export default class extends Controller {
-  static targets = ["existingPanel", "newPanel", "platform", "source"]
+  static targets = ["existingPanel", "newPanel", "platform", "source", "roomsPanel", "roomsGroup"]
 
   connect() {
     this.toggleCustomer()
+    this.toggleBookingMode()
+  }
+
+  // Mode d'occupation (epic #81, Phase 5) : gîte entier / chambres seules. En mode
+  // chambres, on révèle le panneau des chambres (et le bon groupe de gîte) ; sinon
+  // on le masque. Idempotent — rappelé au connect pour restaurer l'état à l'édition.
+  toggleBookingMode() {
+    const rooms = this.bookingMode() === "rooms"
+    if (this.hasRoomsPanelTarget) this.roomsPanelTarget.classList.toggle("hidden", !rooms)
+    this.syncRoomVisibility()
+  }
+
+  // N'affiche que le groupe de chambres du gîte sélectionné, et seulement en mode
+  // chambres. Décoche les chambres des gîtes masqués pour ne pas soumettre des
+  // chambres d'un autre gîte (le serveur les filtrerait de toute façon).
+  syncRoomVisibility() {
+    if (!this.hasRoomsGroupTarget) return
+    const rooms = this.bookingMode() === "rooms"
+    const lodgingId = this.element.querySelector('[name="stay[lodging_id]"]')?.value || ""
+
+    this.roomsGroupTargets.forEach((group) => {
+      const match = rooms && group.dataset.lodgingId === lodgingId
+      group.classList.toggle("hidden", !match)
+      if (!match) {
+        group.querySelectorAll('input[type="checkbox"]').forEach((cb) => (cb.checked = false))
+      }
+    })
+  }
+
+  bookingMode() {
+    return (
+      this.element.querySelector('input[name="stay[booking_type]"]:checked')?.value || "lodging"
+    )
   }
 
   toggleCustomer() {

--- a/app/frontend/controllers/stay_form_controller.js
+++ b/app/frontend/controllers/stay_form_controller.js
@@ -13,11 +13,33 @@ import { Controller } from "@hotwired/stimulus"
 //     select[name="stay[platform]"] (data-stay-form-target="platform" data-action="change->stay-form#syncChannelFromPlatform")
 //     select[name="stay[source]"]   (data-stay-form-target="source")
 export default class extends Controller {
-  static targets = ["existingPanel", "newPanel", "platform", "source", "roomsPanel", "roomsGroup"]
+  static targets = [
+    "existingPanel",
+    "newPanel",
+    "platform",
+    "source",
+    "roomsPanel",
+    "roomsGroup",
+    "spaceBillingPanel",
+  ]
 
   connect() {
     this.toggleCustomer()
     this.toggleBookingMode()
+    this.toggleSpaceBilling()
+  }
+
+  // Facturation espace (epic #81, Phase 6) : le sous-panneau n'apparaît que si au
+  // moins une ligne d'espace porte un type sélectionné. Idempotent — rappelé au
+  // connect pour restaurer l'état à l'édition (espace déjà présent → panneau
+  // ouvert). Les champs restent dans le DOM même masqués : le serveur lit
+  // `space_billing` normalement, et un panneau replié resoumet ses valeurs.
+  toggleSpaceBilling() {
+    if (!this.hasSpaceBillingPanelTarget) return
+    const anyKindSelected = Array.from(
+      this.element.querySelectorAll('select[name^="stay[halls]"][name$="[kind]"]'),
+    ).some((select) => select.value.trim() !== "")
+    this.spaceBillingPanelTarget.classList.toggle("hidden", !anyKindSelected)
   }
 
   // Mode d'occupation (epic #81, Phase 5) : gîte entier / chambres seules. En mode

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -151,6 +151,20 @@ class Booking < ApplicationRecord
     rooms.where.not(level: -1).any?
   end
 
+  # Occupation « chambres seules » (epic #81, Phase 5) : le Booking ne réserve
+  # qu'un SOUS-ENSEMBLE des chambres de son gîte (et non le gîte entier). Dérivé
+  # des Reservation comparées à l'ensemble des chambres du gîte — aucun drapeau
+  # persisté (le `booking_type` est un attr_accessor non stocké). Sert au
+  # préremplissage du form d'édition Séjour pour rétablir le bon mode.
+  def rooms_only_occupation?
+    return false if lodging.blank?
+    reserved = reservations.map(&:room_id).uniq.compact
+    return false if reserved.empty?
+
+    lodging_room_ids = lodging.rooms.pluck(:id).uniq
+    (reserved - lodging_room_ids).empty? && reserved.sort != lodging_room_ids.sort
+  end
+
   def from_airbnb?
     platform == "airbnb"
   end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -77,7 +77,10 @@ class Booking < ApplicationRecord
 
   attr_accessor :invoice_wanted
   attr_accessor :room_ids
-  attr_accessor :booking_type # lodging || rooms
+  # `booking_type` (lodging || rooms) est désormais une COLONNE (epic #81,
+  # Phase 5) : le mode d'occupation est persisté à la création, la dérivation
+  # depuis les Reservation (`rooms_only_occupation?`) ne sert plus que de
+  # secours pour le legacy (colonne nil).
   attr_accessor :tier_lodgings
   attr_accessor :tier_rooms
   attr_accessor :terms_approval
@@ -163,6 +166,15 @@ class Booking < ApplicationRecord
 
     lodging_room_ids = lodging.rooms.pluck(:id).uniq
     (reserved - lodging_room_ids).empty? && reserved.sort != lodging_room_ids.sort
+  end
+
+  # Mode d'occupation effectif : la colonne persistée fait foi (fiable même si
+  # l'ensemble des chambres du gîte évolue après coup — revue Forge F2) ; pour le
+  # legacy (colonne nil), on retombe sur la dérivation depuis les Reservation.
+  def rooms_mode?
+    return booking_type == "rooms" if booking_type.present?
+
+    rooms_only_occupation?
   end
 
   def from_airbnb?

--- a/app/models/lodging.rb
+++ b/app/models/lodging.rb
@@ -89,6 +89,27 @@ class Lodging < ApplicationRecord
     self_available_between?(date, date)
   end
 
+  # Disponibilité d'un SOUS-ENSEMBLE de chambres de ce gîte (epic #81, Phase 5 —
+  # chambres seules). Mêmes sémantiques de dates (inclusives) et d'indisponibilité
+  # que `self_available_between?`, mais bornées aux chambres passées plutôt qu'à
+  # l'ensemble du gîte. Comme l'occupation est portée par les Reservation de
+  # chambres, ceci suffit à rendre le veto symétrique : réserver une chambre prise
+  # (confirmée) sur ces dates la rend indisponible, qu'elle ait été prise par un
+  # gîte entier ou par une autre réservation chambres seules. Les room_ids sont
+  # bornés aux chambres de CE gîte (anti-injection cross-gîte). Sans room_ids
+  # exploitables, on retombe sur la dispo du gîte entier.
+  def rooms_available_between?(room_ids, from_date, to_date)
+    ids = Array(room_ids).map(&:to_i).reject(&:zero?).uniq
+    return self_available_between?(from_date, to_date) if ids.empty?
+
+    scoped = rooms.where(id: ids).pluck(:id)
+    return true if scoped.empty?
+
+    Reservation.includes(:booking)
+               .where(date: from_date..to_date, room: scoped, booking: { status: "confirmed" })
+               .none? && unavailabilities.where(date: from_date..to_date).none?
+  end
+
   # The set of lodgings whose occupancy entangles with this one (self + its
   # components if composite, self + its composites if component).
   def entangled_lodgings_including_self

--- a/app/models/lodging.rb
+++ b/app/models/lodging.rb
@@ -102,8 +102,11 @@ class Lodging < ApplicationRecord
     ids = Array(room_ids).map(&:to_i).reject(&:zero?).uniq
     return self_available_between?(from_date, to_date) if ids.empty?
 
+    # room_ids fournis mais AUCUN n'appartient à ce gîte : réponse conservatrice
+    # (revue Forge F1) — « indisponible » plutôt que d'avaliser une occupation
+    # fantôme (Booking sans aucune Reservation, invisible du calendrier).
     scoped = rooms.where(id: ids).pluck(:id)
-    return true if scoped.empty?
+    return false if scoped.empty?
 
     Reservation.includes(:booking)
                .where(date: from_date..to_date, room: scoped, booking: { status: "confirmed" })

--- a/app/services/concerns/space_composition.rb
+++ b/app/services/concerns/space_composition.rb
@@ -117,10 +117,29 @@ module SpaceComposition
       price_cents:    price_cents
     )
     space_booking.generate_token
+    assign_space_billing(space_booking, draft)
     specs.each do |spec|
       space_booking.space_reservations.build(space: spec[:space], date: spec[:date], duration: spec[:duration])
     end
     space_booking
+  end
+
+  # Facturation ESPACE (epic #81, Phase 6) : recopie les attributs de facturation
+  # portés par le draft (`space_billing`) sur le SpaceBooking. No-op quand le draft
+  # ne porte PAS la facturation (`space_billing` nil) — les valeurs existantes
+  # SURVIVENT alors à une réédition qui ne les change pas. Les montants passent par
+  # les setters `monetize` (`advance_amount=` / `deposit_amount=`) : conversion
+  # €→cents IDENTIQUE au canal direct, et champ vide (nil) → cents nil, jamais 0.
+  def assign_space_billing(space_booking, draft)
+    billing = draft.space_billing
+    return if billing.nil?
+
+    space_booking.advance_amount = billing[:advance_amount]
+    space_booking.deposit_amount = billing[:deposit_amount]
+    space_booking.payment_method = billing[:payment_method]
+    space_booking.event_id       = billing[:event_id]
+    space_booking.arrival_time   = billing[:arrival_time]
+    space_booking.departure_time = billing[:departure_time]
   end
 
   # Réservable d'espace déjà rattaché au séjour (édition), ou nil.

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -127,6 +127,13 @@ class PricingModel
   # Supporte le multi-hébergement via lodging_night_ids (Array indexé par nuit).
   # Fallback sur lodging + nights si lodging_night_ids absent (backward compat).
   def lodging_lines
+    # Chambres seules (epic #81, Phase 5) : le barème B2C (`LODGING_RATES`) est un
+    # FORFAIT par gîte entier — il n'existe pas de tarif par chambre exploitable.
+    # En mode "rooms", on ne facture donc AUCUN forfait d'hébergement automatique ;
+    # le total du séjour vient du Prix total imposé (override, Phase 3). L'UI
+    # l'annonce explicitement dans le panneau devis.
+    return [] if read(:rooms_mode?)
+
     night_ids = Array(read(:lodging_night_ids)).map { |id| id.presence }
 
     if night_ids.any?(&:present?)

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -187,7 +187,13 @@ module Reservations
       raise_invalid("Veuillez indiquer si vous venez avec un animal (champ obligatoire).") if draft.dogs_count.nil?
       raise_invalid("Veuillez préciser votre prénom.") if draft.first_name.blank?
       raise_invalid("Veuillez préciser une adresse email valide.") unless Customer.exploitable_email?(draft.email)
-      if draft.lodging.present? && !draft.lodging.available_between?(draft.arrival_date, draft.departure_date)
+      # Mode chambres seules (epic #81, Phase 5) : au moins une chambre doit être
+      # cochée, sinon il n'y a rien à réserver (on ne retombe pas sur le gîte
+      # entier en silence).
+      if draft.lodging.present? && draft.rooms_mode? && draft.room_ids.blank?
+        raise_invalid("Veuillez sélectionner au moins une chambre pour une réservation de chambres seules.")
+      end
+      if draft.lodging.present? && !lodging_available?
         # Force-dispo admin (epic #66) : on n'échoue pas, on consigne un
         # avertissement que le contrôleur remonte à l'admin. Hors force, le
         # comportement historique tient (l'indisponibilité bloque la création).
@@ -201,6 +207,17 @@ module Reservations
       end
       check_space_availability!
       check_outdoor_capacity!
+    end
+
+    # Dispo de l'hébergement : sur les chambres cochées en mode "rooms" (epic #81,
+    # Phase 5), sur le gîte entier sinon. Source unique de vérité (veto Grand-Duc /
+    # chambres partagées inclus).
+    def lodging_available?
+      if draft.rooms_mode?
+        draft.lodging.rooms_available_between?(draft.room_ids, draft.arrival_date, draft.departure_date)
+      else
+        draft.lodging.available_between?(draft.arrival_date, draft.departure_date)
+      end
     end
 
     # Camping / van : capacité GLOBALE du domaine (epic #66, Phase 3). Vérifiée
@@ -349,11 +366,13 @@ module Reservations
         price_cents: lodging_price_cents(quote),
         shown_price_cents: lodging_price_cents(quote)
       )
-      # booking_type (epic #66, Phase 6) : attr_accessor NON persisté — il ne
-      # touche pas la ligne DB. Il est REQUIS par `get_rooms` du concern Bookable
-      # pour router vers `lodging.rooms` (sinon get_rooms renvoie nil et pose une
-      # erreur). L'occupation d'hébergement est toujours de type "lodging".
-      booking.booking_type = "lodging"
+      # booking_type (epic #66, Phase 6 ; chambres seules epic #81, Phase 5) :
+      # attr_accessor NON persisté. En mode "rooms" l'occupation ne vise qu'un
+      # sous-ensemble de chambres du gîte (cf. `reservation_rooms`) ; sinon le
+      # gîte entier. On CONSERVE `lodging_id` dans les deux modes (contrairement
+      # au canal Booking direct qui le retire) : le séjour garde ainsi la
+      # référence du gîte (préremplissage édition, devis, entanglement).
+      booking.booking_type = draft.rooms_mode? ? "rooms" : "lodging"
       booking.generate_token
       booking.save!
       booking
@@ -368,10 +387,23 @@ module Reservations
     # porte déjà des Reservation (rejeu de run! sur un booking déjà peuplé).
     def build_lodging_reservations!
       return if @booking.reservations.any?
-      rooms = get_rooms
+      rooms = reservation_rooms
       return if rooms.blank?
       build_reservations(rooms)
       @booking.save!
+    end
+
+    # Chambres à réserver pour l'occupation d'hébergement. En mode "rooms" (epic
+    # #81, Phase 5) : le SOUS-ENSEMBLE coché, borné aux chambres du gîte
+    # (anti-injection cross-gîte). Sinon : toutes les chambres du gîte (== ce que
+    # `get_rooms` renvoie en mode lodging — comportement historique inchangé).
+    def reservation_rooms
+      return Room.none if draft.lodging.blank?
+      if draft.rooms_mode?
+        draft.lodging.rooms.where(id: draft.room_ids)
+      else
+        draft.lodging.rooms
+      end
     end
 
     # Part de prix portée par le Booking d'hébergement : hébergement PUR dans tous

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -193,6 +193,13 @@ module Reservations
       if draft.lodging.present? && draft.rooms_mode? && draft.room_ids.blank?
         raise_invalid("Veuillez sélectionner au moins une chambre pour une réservation de chambres seules.")
       end
+      # Revue Forge F1 : room_ids fournis mais tous étrangers au gîte (params
+      # forgés) → sans ce garde-fou, Booking créé avec ZÉRO Reservation
+      # (occupation fantôme, invisible du calendrier, aucun veto).
+      if draft.lodging.present? && draft.rooms_mode? && draft.room_ids.present? &&
+         draft.lodging.rooms.where(id: draft.room_ids).none?
+        raise_invalid("Les chambres sélectionnées n'appartiennent pas à cet hébergement.")
+      end
       if draft.lodging.present? && !lodging_available?
         # Force-dispo admin (epic #66) : on n'échoue pas, on consigne un
         # avertissement que le contrôleur remonte à l'admin. Hors force, le

--- a/app/services/reservations/draft.rb
+++ b/app/services/reservations/draft.rb
@@ -19,6 +19,13 @@ module Reservations
                   # chambres cochées ; il n'a de sens qu'en mode "rooms".
                   :booking_type
 
+    # Facturation ESPACE (epic #81, Phase 6) : attributs portés par le
+    # `SpaceBooking` du séjour (acompte, caution, mode de paiement, événement,
+    # horaires). Vaut `nil` quand le form ne porte PAS la clé `space_billing` —
+    # signal « ne pas toucher » à la réédition ; un Hash (même à valeurs vides)
+    # signifie « appliquer tel quel » (champ vidé → nil, jamais 0 forcé).
+    attr_reader :space_billing
+
     # Backing stores pour campings/vans/hamacs (utilisés quand per_night_resources absent)
     attr_writer :campings, :vans, :hamacs
     attr_writer :room_ids
@@ -43,6 +50,7 @@ module Reservations
       @experiences       = symbolize_rows(attrs[:experiences])
       @booking_type      = attrs[:booking_type].presence
       @room_ids          = normalize_room_ids(attrs[:room_ids])
+      @space_billing     = normalize_space_billing(attrs[:space_billing])
       @first_name        = attrs[:first_name].presence
       @last_name         = attrs[:last_name].presence
       @email             = attrs[:email].presence
@@ -135,6 +143,7 @@ module Reservations
         experiences:        experiences,
         booking_type:       booking_type,
         room_ids:           room_ids,
+        space_billing:      space_billing,
         first_name:         first_name,
         last_name:          last_name,
         email:              email,
@@ -172,6 +181,25 @@ module Reservations
     # Chambres cochées → Integer dédupliqués, ordre stable, sans zéro/blanc.
     def normalize_room_ids(ids)
       Array(ids).map { |id| id.to_i }.reject(&:zero?).uniq
+    end
+
+    # Facturation espace → Hash normalisé à clés symboles, ou nil si la clé est
+    # absente (« ne pas toucher »). Chaque valeur est ramenée à nil quand elle est
+    # vide : les montants (`advance_amount`/`deposit_amount`) restent des chaînes €
+    # brutes, converties en cents par les setters `monetize` du SpaceBooking —
+    # même conversion EXACTE que le canal direct `SpaceBookings::CreateService`.
+    def normalize_space_billing(raw)
+      return nil if raw.nil?
+      raw = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h
+      raw = raw.symbolize_keys
+      {
+        advance_amount: raw[:advance_amount].presence,
+        deposit_amount: raw[:deposit_amount].presence,
+        payment_method: raw[:payment_method].presence,
+        event_id:       raw[:event_id].presence,
+        arrival_time:   raw[:arrival_time].presence,
+        departure_time: raw[:departure_time].presence
+      }
     end
 
     def parse_per_night_resources(pnr)

--- a/app/services/reservations/draft.rb
+++ b/app/services/reservations/draft.rb
@@ -12,10 +12,16 @@ module Reservations
                   :halls, :space_slots, :meals, :pizza_parties,
                   :experiences,
                   :first_name, :last_name, :email, :phone, :group_name,
-                  :adults, :children
+                  :adults, :children,
+                  # Chambres seules (epic #81, Phase 5) : mode d'occupation de
+                  # l'hébergement — "lodging" (gîte entier, défaut) ou "rooms"
+                  # (sous-ensemble de chambres du gîte). `room_ids` porte les
+                  # chambres cochées ; il n'a de sens qu'en mode "rooms".
+                  :booking_type
 
     # Backing stores pour campings/vans/hamacs (utilisés quand per_night_resources absent)
     attr_writer :campings, :vans, :hamacs
+    attr_writer :room_ids
 
     def initialize(attrs = {})
       attrs = (attrs || {}).symbolize_keys
@@ -35,6 +41,8 @@ module Reservations
       @pizza_parties     = symbolize_rows(attrs[:pizza_parties])
       @hamacs            = symbolize_rows(attrs[:hamacs])
       @experiences       = symbolize_rows(attrs[:experiences])
+      @booking_type      = attrs[:booking_type].presence
+      @room_ids          = normalize_room_ids(attrs[:room_ids])
       @first_name        = attrs[:first_name].presence
       @last_name         = attrs[:last_name].presence
       @email             = attrs[:email].presence
@@ -52,6 +60,21 @@ module Reservations
     def nights
       return 0 if arrival_date.blank? || departure_date.blank?
       (departure_date - arrival_date).to_i.clamp(0, 10_000)
+    end
+
+    # --- Chambres seules (epic #81, Phase 5) ------------------------------
+
+    # Ids des chambres cochées (Integer, dédupliqués). Vide hors mode "rooms".
+    def room_ids
+      Array(@room_ids)
+    end
+
+    # L'occupation vise-t-elle un SOUS-ENSEMBLE de chambres (et non le gîte
+    # entier) ? Piloté par le seul `booking_type` — l'UI le fixe explicitement.
+    # `room_ids` peut être vide (rien de coché) : c'est alors une saisie
+    # incomplète, tranchée par la validation du Builder/Updater, pas ici.
+    def rooms_mode?
+      booking_type.to_s == "rooms"
     end
 
     # Quand per_night_resources présent, on calcule depuis les comptes per-nuit.
@@ -110,6 +133,8 @@ module Reservations
         pizza_parties:      pizza_parties,
         hamacs:             hamacs,
         experiences:        experiences,
+        booking_type:       booking_type,
+        room_ids:           room_ids,
         first_name:         first_name,
         last_name:          last_name,
         email:              email,
@@ -142,6 +167,11 @@ module Reservations
 
     def symbolize_rows(rows)
       Array(rows).map { |row| row.respond_to?(:symbolize_keys) ? row.symbolize_keys : row }
+    end
+
+    # Chambres cochées → Integer dédupliqués, ordre stable, sans zéro/blanc.
+    def normalize_room_ids(ids)
+      Array(ids).map { |id| id.to_i }.reject(&:zero?).uniq
     end
 
     def parse_per_night_resources(pnr)

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -103,6 +103,10 @@ module Stays
       unless Customer.exploitable_email?(@draft.email)
         raise_invalid("Veuillez préciser une adresse email valide pour le client.")
       end
+      # Chambres seules (epic #81, Phase 5) : au moins une chambre cochée.
+      if @draft.lodging.present? && @draft.rooms_mode? && @draft.room_ids.blank?
+        raise_invalid("Veuillez sélectionner au moins une chambre pour une réservation de chambres seules.")
+      end
       check_availability!
       check_space_availability!
       check_outdoor_capacity!
@@ -134,7 +138,7 @@ module Stays
 
     def check_availability!
       return if @draft.lodging.blank?
-      return if @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
+      return if lodging_available?
 
       if @skip_availability
         @availability_warning =
@@ -143,6 +147,31 @@ module Stays
       else
         raise_invalid("Ces dates ne sont plus disponibles pour cet hébergement.")
       end
+    end
+
+    # Dispo de l'hébergement à l'édition. Mode gîte entier : `available_between?`
+    # (comportement historique inchangé). Mode chambres seules (epic #81, Phase 5) :
+    # dispo des chambres cochées, en EXCLUANT la propre occupation du séjour édité
+    # (sinon un séjour confirmé se bloquerait lui-même à chaque réenregistrement).
+    def lodging_available?
+      if @draft.rooms_mode?
+        rooms_available_excluding_self?
+      else
+        @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
+      end
+    end
+
+    def rooms_available_excluding_self?
+      ids = @draft.lodging.rooms.where(id: @draft.room_ids).pluck(:id)
+      return true if ids.empty?
+
+      scope = Reservation.joins(:booking)
+                         .where(date: @draft.arrival_date..@draft.departure_date,
+                                room_id: ids, bookings: { status: "confirmed" })
+      own = existing_lodging_booking
+      scope = scope.where.not(bookings: { id: own.id }) if own
+      scope.none? &&
+        @draft.lodging.unavailabilities.where(date: @draft.arrival_date..@draft.departure_date).none?
     end
 
     # Dispo espaces capacity-aware (`Space#available_on?`), même logique de force
@@ -241,6 +270,37 @@ module Stays
         booking.generate_token
         booking.save!
         @stay.stay_items.create!(bookable: booking)
+      end
+
+      # Reconstruction PROPRE des Reservation de chambres (epic #81, Phase 5). Le
+      # changement d'hébergement, de dates OU de chambres cochées doit se refléter
+      # dans les Reservation qui portent l'occupation (calendrier + veto de dispo).
+      # On les rebâtit intégralement pour rester la source de vérité : gîte entier
+      # → toutes les chambres du gîte ; chambres seules → le sous-ensemble coché.
+      rebuild_reservations!(booking)
+    end
+
+    # Rebâtit les Reservation {room, date} de l'occupation depuis le draft courant.
+    # Idempotent : détruit d'abord l'existant, puis reconstruit sur [arrivée, départ).
+    def rebuild_reservations!(booking)
+      booking.reservations.destroy_all
+      rooms = reservation_rooms
+      return if rooms.blank?
+      rooms.each do |room|
+        (booking.from_date..(booking.to_date - 1.day)).each do |date|
+          booking.reservations.create!(room: room, date: date)
+        end
+      end
+    end
+
+    # Chambres de l'occupation : sous-ensemble coché (mode rooms, borné au gîte) ou
+    # toutes les chambres du gîte (mode lodging). Miroir de `Reservations::Builder`.
+    def reservation_rooms
+      return Room.none if @draft.lodging.blank?
+      if @draft.rooms_mode?
+        @draft.lodging.rooms.where(id: @draft.room_ids)
+      else
+        @draft.lodging.rooms
       end
     end
 

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -107,6 +107,12 @@ module Stays
       if @draft.lodging.present? && @draft.rooms_mode? && @draft.room_ids.blank?
         raise_invalid("Veuillez sélectionner au moins une chambre pour une réservation de chambres seules.")
       end
+      # Revue Forge F1 : chambres toutes étrangères au gîte = params forgés,
+      # jamais une saisie UI — refus explicite plutôt qu'occupation fantôme.
+      if @draft.lodging.present? && @draft.rooms_mode? && @draft.room_ids.present? &&
+         @draft.lodging.rooms.where(id: @draft.room_ids).none?
+        raise_invalid("Les chambres sélectionnées n'appartiennent pas à cet hébergement.")
+      end
       check_availability!
       check_space_availability!
       check_outdoor_capacity!
@@ -153,23 +159,32 @@ module Stays
     # (comportement historique inchangé). Mode chambres seules (epic #81, Phase 5) :
     # dispo des chambres cochées, en EXCLUANT la propre occupation du séjour édité
     # (sinon un séjour confirmé se bloquerait lui-même à chaque réenregistrement).
+    # Dispo en édition, mode gîte entier comme chambres seules : on vérifie les
+    # Reservation confirmées sur les chambres visées en EXCLUANT TOUS les
+    # Booking du séjour édité (revue Forge F4 : `.first` seul laissait un
+    # éventuel second Booking auto-bloquer le séjour ; et le mode gîte entier
+    # ne s'excluait pas du tout — un séjour confirmé se bloquait lui-même).
     def lodging_available?
       if @draft.rooms_mode?
-        rooms_available_excluding_self?
+        ids = @draft.lodging.rooms.where(id: @draft.room_ids).pluck(:id)
+        # Chambres toutes hors gîte : déjà refusé en validation ; réponse
+        # conservatrice si on arrive ici par un autre chemin.
+        return false if ids.empty?
       else
-        @draft.lodging.available_between?(@draft.arrival_date, @draft.departure_date)
+        ids = @draft.lodging.rooms.pluck(:id)
+        # Gîte sans chambre modélisée : aucune Reservation possible — seule une
+        # indisponibilité posée à la main compte (comportement historique).
+        if ids.empty?
+          return @draft.lodging.unavailabilities
+                       .where(date: @draft.arrival_date..@draft.departure_date).none?
+        end
       end
-    end
-
-    def rooms_available_excluding_self?
-      ids = @draft.lodging.rooms.where(id: @draft.room_ids).pluck(:id)
-      return true if ids.empty?
 
       scope = Reservation.joins(:booking)
                          .where(date: @draft.arrival_date..@draft.departure_date,
                                 room_id: ids, bookings: { status: "confirmed" })
-      own = existing_lodging_booking
-      scope = scope.where.not(bookings: { id: own.id }) if own
+      own_ids = @stay.stay_items.where(bookable_type: "Booking").pluck(:bookable_id)
+      scope = scope.where.not(bookings: { id: own_ids }) if own_ids.any?
       scope.none? &&
         @draft.lodging.unavailabilities.where(date: @draft.arrival_date..@draft.departure_date).none?
     end

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -345,7 +345,7 @@ module Stays
 
       if space_booking
         space_booking.space_reservations.destroy_all
-        space_booking.update!(
+        space_booking.assign_attributes(
           firstname:   @draft.first_name,
           lastname:    @draft.last_name,
           phone:       @draft.phone,
@@ -354,6 +354,11 @@ module Stays
           to_date:     @draft.departure_date || dates.max,
           price_cents: price
         )
+        # Facturation espace (epic #81, Phase 6) : appliquée seulement si le draft
+        # la porte ; sinon les valeurs existantes survivent. N'affecte ni le
+        # `status` ni l'`email` → aucun email déclenché (cf. en-tête de classe).
+        assign_space_billing(space_booking, @draft)
+        space_booking.save!
         specs.each do |spec|
           space_booking.space_reservations.create!(space: spec[:space], date: spec[:date], duration: spec[:duration])
         end

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -79,11 +79,39 @@
         = text_field_tag "stay[group_name]", @draft&.group_name, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
     / --- Hébergement --------------------------------------------------------
+    / Mode d'occupation (epic #81, Phase 5) : gîte entier (défaut) ou chambres
+    / seules. En mode chambres, on coche les chambres du gîte choisi (pré-rendues
+    / par gîte, affichées/masquées par Stimulus — pas d'endpoint : plus robuste).
+    - current_booking_type = (@draft&.rooms_mode? ? "rooms" : "lodging")
+    - selected_room_ids = Array(@draft&.room_ids).map(&:to_i)
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
       h2.text-base.font-semibold.text-gray-900 Hébergement
+      .flex.gap-4.text-sm
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[booking_type]" value="lodging" checked=(current_booking_type == "lodging") data-action="change->stay-form#toggleBookingMode change->stay-availability#check"
+          | Gîte entier
+        label.flex.items-center.gap-2
+          input type="radio" name="stay[booking_type]" value="rooms" checked=(current_booking_type == "rooms") data-action="change->stay-form#toggleBookingMode change->stay-availability#check"
+          | Chambres seules
       .space-y-1
         label.block.text-sm.font-medium.text-gray-700 Hébergement
-        = select_tag "stay[lodging_id]", options_for_select(@lodgings.map { |l| [l.form_label, l.id] }, @draft&.lodging_id), include_blank: "— Choisir un hébergement —", data: { action: "change->stay-availability#check" }, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        = select_tag "stay[lodging_id]", options_for_select(@lodgings.map { |l| [l.form_label, l.id] }, @draft&.lodging_id), include_blank: "— Choisir un hébergement —", data: { action: "change->stay-availability#check change->stay-form#syncRoomVisibility" }, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      / Chambres du gîte (mode chambres seules). Un groupe par gîte, masqué par
+      / défaut ; Stimulus n'affiche que le groupe du gîte sélectionné, en mode rooms.
+      .space-y-2.hidden(data-stay-form-target="roomsPanel")
+        p.text-sm.text-gray-500 Cochez les chambres à réserver. Pas de devis automatique pour des chambres seules — utilisez le Prix total imposé plus bas.
+        - @lodgings.each do |lodging|
+          .space-y-1.hidden(data-stay-form-target="roomsGroup" data-lodging-id=lodging.id)
+            - rooms = lodging.rooms.order(:level)
+            - if rooms.any?
+              ul.space-y-1
+                - rooms.each do |room|
+                  li
+                    label.flex.items-center.gap-2.text-sm.text-gray-700
+                      input type="checkbox" name="stay[room_ids][]" value=room.id checked=(selected_room_ids.include?(room.id)) data-action="change->stay-availability#check" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      = room.name_with_level.presence || room.name
+            - else
+              p.text-sm.text-gray-400 Aucune chambre déclarée pour cet hébergement.
       / Indicateur de disponibilité en temps réel (issue #77). Informe sans bloquer :
       / la checkbox « Forcer la disponibilité » plus bas reste la seule décision.
       .hidden.text-sm.font-medium.rounded-md.px-3.py-2(data-stay-availability-target="indicator")

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -121,15 +121,47 @@
     - period_options = [["Journée", "journee"], ["Soirée", "soiree"], ["Journée + soirée", "journee_et_soiree"]]
     - existing_halls = Array(@draft&.halls).map { |h| h.respond_to?(:symbolize_keys) ? h.symbolize_keys : h }
     - space_rows = existing_halls + Array.new([3 - existing_halls.size, 1].max) { {} }
+    / Facturation espace (epic #81, Phase 6). Sous-panneau masqué tant qu'aucune
+    / ligne d'espace n'est renseignée ; révélé par stay-form#toggleSpaceBilling.
+    - space_billing = @draft&.space_billing || {}
+    - payment_method_options = [["En liquide à son arrivée", "cash"], ["Par virement bancaire", "bank_transfer"], ["Versement automatique Airbnb", "airbnb"], ["Versement automatique Booking.com", "bookingdotcom"]]
+    - event_options = Array(@events).map { |e| [e.name_with_date, e.id] }
+    - space_billing_open = existing_halls.any? { |h| h[:kind].present? }
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
       h2.text-base.font-semibold.text-gray-900 Espaces
       p.text-sm.text-gray-500 Ajoutez une salle ou la cuisine pro (date + période). Un séjour peut être composé d'espaces seuls, sans hébergement.
       ul.divide-y.divide-gray-100
         - space_rows.each_with_index do |row, index|
           li.py-2.grid.grid-cols-3.gap-2
-            = select_tag "stay[halls][#{index}][kind]", options_for_select(space_kind_options, row[:kind]), include_blank: "— Espace —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = select_tag "stay[halls][#{index}][kind]", options_for_select(space_kind_options, row[:kind]), include_blank: "— Espace —", data: { action: "change->stay-form#toggleSpaceBilling" }, class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
             = date_field_tag "stay[halls][#{index}][date]", row[:date], class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
             = select_tag "stay[halls][#{index}][period]", options_for_select(period_options, row[:period]), include_blank: "— Période —", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+
+      / Facturation espaces — n'apparaît que si ≥1 ligne d'espace est renseignée.
+      / Tous les champs sont optionnels (acompte/caution en €, converties comme le
+      / canal direct ; mode de paiement, événement, horaires d'arrivée/départ).
+      div class=("space-y-4 rounded-md bg-gray-50 p-4 ring-1 ring-black ring-opacity-5" + (space_billing_open ? "" : " hidden")) data-stay-form-target="spaceBillingPanel"
+        h3.text-sm.font-semibold.text-gray-900 Facturation espaces
+        .grid.grid-cols-2.gap-4
+          .space-y-1
+            label.block.text-sm.font-medium.text-gray-700 for="stay_space_billing_advance_amount" Acompte (€)
+            = number_field_tag "stay[space_billing][advance_amount]", space_billing[:advance_amount], id: "stay_space_billing_advance_amount", step: "0.01", min: 0, placeholder: "—", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+          .space-y-1
+            label.block.text-sm.font-medium.text-gray-700 for="stay_space_billing_deposit_amount" Caution (€) ♻️
+            = number_field_tag "stay[space_billing][deposit_amount]", space_billing[:deposit_amount], id: "stay_space_billing_deposit_amount", step: "0.01", min: 0, placeholder: "—", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 for="stay_space_billing_payment_method" Mode de paiement
+          = select_tag "stay[space_billing][payment_method]", options_for_select(payment_method_options, space_billing[:payment_method]), id: "stay_space_billing_payment_method", include_blank: "— Mode de paiement —", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 for="stay_space_billing_event_id" Événement
+          = select_tag "stay[space_billing][event_id]", options_for_select(event_options, space_billing[:event_id]), id: "stay_space_billing_event_id", include_blank: "— Aucun événement —", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+        .grid.grid-cols-2.gap-4
+          .space-y-1
+            label.block.text-sm.font-medium.text-gray-700 for="stay_space_billing_arrival_time" Heure d'arrivée
+            = text_field_tag "stay[space_billing][arrival_time]", space_billing[:arrival_time], id: "stay_space_billing_arrival_time", placeholder: "ex. 14:00", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+          .space-y-1
+            label.block.text-sm.font-medium.text-gray-700 for="stay_space_billing_departure_time" Heure de départ
+            = text_field_tag "stay[space_billing][departure_time]", space_billing[:departure_time], id: "stay_space_billing_departure_time", placeholder: "ex. 11:00", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
     / --- Camping (tente) ----------------------------------------------------
     - camping_people = Array(@draft&.campings).sum { |c| (c.respond_to?(:symbolize_keys) ? c.symbolize_keys : c)[:people].to_i }

--- a/app/views/stays/_quote_panel.html.slim
+++ b/app/views/stays/_quote_panel.html.slim
@@ -5,6 +5,10 @@
   - if @quote
     section.bg-gray-50.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-2
       h2.text-base.font-semibold.text-gray-900 Devis (B2C)
+      / Chambres seules (epic #81, Phase 5) : pas de barème par chambre — le total
+      / vient du Prix total imposé. On l'annonce clairement dans le panneau.
+      - if @draft&.rooms_mode?
+        p.text-sm.font-medium.text-amber-700 Pas de devis automatique pour des chambres seules — utilisez le Prix total imposé.
       ul.text-sm.text-gray-700.space-y-1
         - @quote.breakdown.each do |line|
           li.flex.justify-between

--- a/db/migrate/20260719190000_add_booking_type_to_bookings.rb
+++ b/db/migrate/20260719190000_add_booking_type_to_bookings.rb
@@ -1,0 +1,11 @@
+# Persiste le mode d'occupation (epic #81, Phase 5 — revue Forge F2). Jusqu'ici
+# `booking_type` était un attr_accessor éphémère : le mode « chambres seules »
+# était re-DÉRIVÉ des Reservation à chaque édition, et dérivait faux si
+# l'ensemble des chambres du gîte changeait après coup (chambre ajoutée →
+# résa gîte entier relue comme chambres seules). Colonne nullable : le legacy
+# reste dérivé, tout nouveau Booking porte son mode.
+class AddBookingTypeToBookings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bookings, :booking_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_19_130000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_19_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -138,6 +138,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_19_130000) do
     t.boolean "option_pizza_party"
     t.datetime "deleted_at", precision: nil
     t.boolean "wifi", default: false
+    t.string "booking_type"
     t.index ["lodging_id"], name: "index_bookings_on_lodging_id"
   end
 

--- a/spec/models/booking_rooms_occupation_spec.rb
+++ b/spec/models/booking_rooms_occupation_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+# Epic #81, Phase 5 — `Booking#rooms_only_occupation?` dérive le mode d'occupation
+# (gîte entier vs chambres seules) des Reservation comparées à l'ensemble des
+# chambres du gîte, sans drapeau persisté. Sert au préremplissage du form édition.
+RSpec.describe Booking, "#rooms_only_occupation? (epic #81, Phase 5)", type: :model do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging.rooms << Room.create!(name: "Chambre 2", level: 1)
+    lodging.rooms << Room.create!(name: "Chambre 3", level: 1)
+    lodging
+  end
+
+  let(:from) { Date.new(2026, 8, 1) }
+  let(:to)   { Date.new(2026, 8, 3) }
+
+  def booking_reserving(rooms)
+    booking = Booking.create!(firstname: "Occ", from_date: from, to_date: to, adults: 1, status: "confirmed", lodging: hulotte)
+    rooms.each { |room| (from...to).each { |date| Reservation.create!(booking: booking, room: room, date: date) } }
+    booking
+  end
+
+  it "est faux pour une occupation de gîte ENTIER (toutes les chambres réservées)" do
+    booking = booking_reserving(hulotte.rooms.to_a)
+    expect(booking.rooms_only_occupation?).to be(false)
+  end
+
+  it "est vrai pour un SOUS-ENSEMBLE de chambres" do
+    booking = booking_reserving(hulotte.rooms.first(2))
+    expect(booking.rooms_only_occupation?).to be(true)
+  end
+
+  it "est faux sans aucune réservation de chambre" do
+    booking = Booking.create!(firstname: "Occ", from_date: from, to_date: to, adults: 1, status: "confirmed", lodging: hulotte)
+    expect(booking.rooms_only_occupation?).to be(false)
+  end
+
+  it "est faux sans hébergement rattaché" do
+    booking = Booking.create!(firstname: "Occ", from_date: from, to_date: to, adults: 1, status: "confirmed")
+    expect(booking.rooms_only_occupation?).to be(false)
+  end
+end

--- a/spec/models/lodging_rooms_availability_spec.rb
+++ b/spec/models/lodging_rooms_availability_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+# Epic #81, Phase 5 — dispo « chambres seules » (`Lodging#rooms_available_between?`).
+# Réserver un SOUS-ENSEMBLE de chambres se vérifie sur CES chambres, pas sur tout
+# le gîte, tout en gardant l'entanglement Grand-Duc (chambres partagées) cohérent.
+RSpec.describe Lodging, "#rooms_available_between? (epic #81, Phase 5)", type: :model do
+  let(:grand_duc) { Lodging.create!(name: "Le Grand-Duc", price_night_cents: 12_000) }
+  let(:hulotte)   { Lodging.create!(name: "La Hulotte", price_night_cents: 10_000) }
+  let(:cheveche)  { Lodging.create!(name: "La Chevêche", price_night_cents: 8_000) }
+
+  let(:hulotte_1) { Room.create!(name: "Hulotte 1", level: 1) }
+  let(:hulotte_2) { Room.create!(name: "Hulotte 2", level: 1) }
+  let(:cheveche_1) { Room.create!(name: "Chevêche 1", level: 1) }
+
+  let(:from) { Date.new(2026, 8, 1) }
+  let(:to)   { Date.new(2026, 8, 3) }
+
+  before do
+    LodgingComposition.create!(composite_lodging: grand_duc, component_lodging: hulotte)
+    LodgingComposition.create!(composite_lodging: grand_duc, component_lodging: cheveche)
+    hulotte.rooms << hulotte_1
+    hulotte.rooms << hulotte_2
+    cheveche.rooms << cheveche_1
+    # Le composite possède l'union des chambres des composants.
+    grand_duc.rooms << hulotte_1
+    grand_duc.rooms << hulotte_2
+    grand_duc.rooms << cheveche_1
+  end
+
+  # Réserve (confirmé) une chambre précise sur la fenêtre.
+  def reserve_room(room, from:, to:)
+    booking = Booking.create!(firstname: "Occ", from_date: from, to_date: to, adults: 1, status: "confirmed", lodging: hulotte)
+    (from...to).each { |date| Reservation.create!(booking: booking, room: room, date: date) }
+    booking
+  end
+
+  it "reste dispo quand aucune des chambres visées n'est prise" do
+    expect(hulotte.rooms_available_between?([hulotte_1.id, hulotte_2.id], from, to)).to be(true)
+  end
+
+  it "devient indispo dès qu'UNE chambre visée est prise (confirmée)" do
+    reserve_room(hulotte_1, from: from, to: to)
+    expect(hulotte.rooms_available_between?([hulotte_1.id], from, to)).to be(false)
+    # …mais l'autre chambre du même gîte reste libre (granularité chambre).
+    expect(hulotte.rooms_available_between?([hulotte_2.id], from, to)).to be(true)
+  end
+
+  it "borne les room_ids aux chambres du gîte (anti-injection cross-gîte)" do
+    # La chambre de la Chevêche n'appartient pas à La Hulotte → ignorée.
+    reserve_room(cheveche_1, from: from, to: to) # confirmé sur la chambre Chevêche
+    expect(hulotte.rooms_available_between?([cheveche_1.id], from, to)).to be(true)
+  end
+
+  it "retombe sur la dispo du gîte entier sans room_ids exploitables" do
+    reserve_room(hulotte_1, from: from, to: to)
+    expect(hulotte.rooms_available_between?([], from, to)).to be(false)
+  end
+
+  it "respecte une indisponibilité posée sur le gîte" do
+    Unavailability.create!(lodging: hulotte, date: from)
+    expect(hulotte.rooms_available_between?([hulotte_2.id], from, to)).to be(false)
+  end
+
+  describe "entanglement Grand-Duc (chambres partagées)" do
+    it "réserver une chambre de la Hulotte bloque le composite mais pas la Chevêche" do
+      reserve_room(hulotte_1, from: from, to: to)
+      # Le composite partage la chambre Hulotte → indisponible en gîte entier.
+      expect(grand_duc.available_between?(from, to)).to be(false)
+      # La Chevêche ne partage pas cette chambre → toujours dispo.
+      expect(cheveche.available_between?(from, to)).to be(true)
+      # …et ses propres chambres restent réservables en mode chambres.
+      expect(cheveche.rooms_available_between?([cheveche_1.id], from, to)).to be(true)
+    end
+  end
+end

--- a/spec/models/lodging_rooms_availability_spec.rb
+++ b/spec/models/lodging_rooms_availability_spec.rb
@@ -46,9 +46,11 @@ RSpec.describe Lodging, "#rooms_available_between? (epic #81, Phase 5)", type: :
   end
 
   it "borne les room_ids aux chambres du gîte (anti-injection cross-gîte)" do
-    # La chambre de la Chevêche n'appartient pas à La Hulotte → ignorée.
+    # La chambre de la Chevêche n'appartient pas à La Hulotte : réponse
+    # CONSERVATRICE (revue Forge F1) — « indisponible » plutôt que d'avaliser
+    # une occupation fantôme (Booking sans aucune Reservation).
     reserve_room(cheveche_1, from: from, to: to) # confirmé sur la chambre Chevêche
-    expect(hulotte.rooms_available_between?([cheveche_1.id], from, to)).to be(true)
+    expect(hulotte.rooms_available_between?([cheveche_1.id], from, to)).to be(false)
   end
 
   it "retombe sur la dispo du gîte entier sans room_ids exploitables" do

--- a/spec/requests/stays_admin_spaces_billing_spec.rb
+++ b/spec/requests/stays_admin_spaces_billing_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+# Epic #81, Phase 6 — Facturation ESPACE enrichie dans le séjour. Le canal direct
+# `SpaceBookings::CreateService` porte des attributs de facturation (acompte,
+# caution, mode de paiement, événement, horaires) que le séjour ignorait. On les
+# fait transiter par le `Reservations::Draft` (`space_billing`) et persister sur
+# le `SpaceBooking` — à la création ET à l'édition, sans jamais déclencher d'email.
+#
+# Invariant de survie : une réédition qui NE PORTE PAS la facturation (clé
+# `space_billing` absente) conserve les valeurs existantes ; une réédition qui la
+# porte l'applique telle quelle (champ vide → nil, jamais 0 forcé).
+RSpec.describe "Stays — facturation espaces (epic #81, Phase 6)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-space-billing@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:lodging)      { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+  let(:arrival)       { Date.today + 30 }
+  let(:departure)     { Date.today + 32 }
+
+  let!(:event) do
+    category = EventCategory.create!(name: "Fête", color: "blue")
+    Event.create!(
+      name: "Mariage Martin", event_category: category,
+      starts_at: arrival.to_time, ends_at: departure.to_time,
+      starts_at_date: arrival, ends_at_date: departure
+    )
+  end
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: lodging.id, status: "pending"
+      }.merge(overrides)
+    }
+  end
+
+  def hall_param(kind: "grande_salle", date: nil, period: "journee")
+    { "0" => { kind: kind, date: (date || arrival).iso8601, period: period } }
+  end
+
+  def full_billing(overrides = {})
+    {
+      advance_amount: "50", deposit_amount: "200",
+      payment_method: "bank_transfer", event_id: event.id,
+      arrival_time: "14:00", departure_time: "11:00"
+    }.merge(overrides)
+  end
+
+  def space_booking_of(stay)
+    stay.stay_items.where(bookable_type: "SpaceBooking").first.bookable
+  end
+
+  # Crée un séjour hébergement + espace facturé, renvoie le Stay rechargé.
+  def create_billed_stay(billing: full_billing, halls: hall_param)
+    post stays_path, params: base_params(halls: halls, space_billing: billing)
+    Stay.order(:created_at).last
+  end
+
+  describe "GET /stays/new — sous-panneau facturation espaces" do
+    it "rend les champs de facturation espaces (masqués par défaut)" do
+      get new_stay_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Facturation espaces")
+      expect(response.body).to include('name="stay[space_billing][advance_amount]"')
+      expect(response.body).to include('name="stay[space_billing][deposit_amount]"')
+      expect(response.body).to include('name="stay[space_billing][payment_method]"')
+      expect(response.body).to include('name="stay[space_billing][event_id]"')
+      expect(response.body).to include('name="stay[space_billing][arrival_time]"')
+      expect(response.body).to include('name="stay[space_billing][departure_time]"')
+      # Reprend les valeurs de mode de paiement du form direct.
+      expect(response.body).to include('value="bank_transfer"')
+    end
+  end
+
+  describe "POST /stays — création avec espace facturé" do
+    it "persiste acompte, caution, mode, événement et horaires sur le SpaceBooking" do
+      stay = create_billed_stay
+      expect(response).to redirect_to(recent_stays_path)
+
+      sb = space_booking_of(stay)
+      expect(sb.advance_amount_cents).to eq(5_000)   # 50 € → cents, comme le canal direct
+      expect(sb.deposit_amount_cents).to eq(20_000)  # 200 €
+      expect(sb.payment_method).to eq("bank_transfer")
+      expect(sb.event_id).to eq(event.id)
+      expect(sb.arrival_time).to eq("14:00")
+      expect(sb.departure_time).to eq("11:00")
+      # Parité : aucun paiement Stripe, aucun email déclenché.
+      expect(stay.payments).to be_empty
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+
+    it "champ vide → nil (jamais 0 forcé) pour les montants, nil pour les autres" do
+      stay = create_billed_stay(billing: {
+        advance_amount: "", deposit_amount: "",
+        payment_method: "", event_id: "", arrival_time: "", departure_time: ""
+      })
+      sb = space_booking_of(stay)
+      expect(sb.advance_amount_cents).to be_nil
+      expect(sb.deposit_amount_cents).to be_nil
+      expect(sb.payment_method).to be_nil
+      expect(sb.event_id).to be_nil
+      expect(sb.arrival_time).to be_nil
+      expect(sb.departure_time).to be_nil
+    end
+  end
+
+  describe "GET /stays/:id/edit — préremplissage de la facturation" do
+    it "restitue les valeurs de facturation de l'espace existant" do
+      stay = create_billed_stay
+      get edit_stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('value="50"')                       # acompte €
+      expect(response.body).to include('value="200"')                      # caution €
+      expect(response.body).to include('value="14:00"')                    # heure d'arrivée
+      expect(response.body).to include('value="11:00"')                    # heure de départ
+      # Mode de paiement + événement présélectionnés.
+      expect(response.body).to match(/selected="selected" value="bank_transfer"/)
+      expect(response.body).to match(/selected="selected" value="#{event.id}"/)
+    end
+  end
+
+  describe "PATCH /stays/:id — édition de la facturation" do
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: lodging.id, status: "pending",
+          halls: hall_param
+        }.merge(overrides)
+      }
+    end
+
+    it "modifie l'acompte et le persiste" do
+      stay = create_billed_stay
+      patch stay_path(stay), params: update_params(stay, space_billing: full_billing(advance_amount: "80"))
+      expect(response).to redirect_to(recent_stays_path)
+
+      sb = space_booking_of(stay.reload)
+      expect(sb.advance_amount_cents).to eq(8_000)
+      # Le reste de la facturation n'est pas altéré par ce changement.
+      expect(sb.deposit_amount_cents).to eq(20_000)
+      expect(sb.payment_method).to eq("bank_transfer")
+    end
+
+    it "réédition SANS clé space_billing → valeurs de facturation conservées" do
+      stay = create_billed_stay
+      # Édition qui NE touche PAS la facturation (clé absente du form).
+      patch stay_path(stay), params: update_params(stay)
+      expect(response).to redirect_to(recent_stays_path)
+
+      sb = space_booking_of(stay.reload)
+      expect(sb.advance_amount_cents).to eq(5_000)
+      expect(sb.deposit_amount_cents).to eq(20_000)
+      expect(sb.payment_method).to eq("bank_transfer")
+      expect(sb.event_id).to eq(event.id)
+      expect(sb.arrival_time).to eq("14:00")
+      expect(sb.departure_time).to eq("11:00")
+    end
+
+    it "vider un champ à l'édition le remet à nil (pas 0 forcé)" do
+      stay = create_billed_stay
+      patch stay_path(stay), params: update_params(stay, space_billing: full_billing(advance_amount: ""))
+      expect(response).to redirect_to(recent_stays_path)
+
+      sb = space_booking_of(stay.reload)
+      expect(sb.advance_amount_cents).to be_nil
+      expect(sb.deposit_amount_cents).to eq(20_000) # les autres inchangés
+    end
+
+    it "édition de la facturation ne déclenche aucun email" do
+      stay = create_billed_stay
+      ActionMailer::Base.deliveries.clear
+      patch stay_path(stay), params: update_params(stay, space_billing: full_billing(deposit_amount: "300"))
+      expect(response).to redirect_to(recent_stays_path)
+      expect(ActionMailer::Base.deliveries).to be_empty
+      expect(space_booking_of(stay.reload).deposit_amount_cents).to eq(30_000)
+    end
+  end
+end

--- a/spec/requests/stays_rooms_spec.rb
+++ b/spec/requests/stays_rooms_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+# Epic #81, Phase 5 — CRUD Séjour admin en mode CHAMBRES SEULES + endpoint de
+# disponibilité par chambres. Parité avec le gîte entier, DANS le séjour.
+RSpec.describe "Stays — chambres seules (epic #81, Phase 5)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-rooms@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", summary: "gîte", price_night_cents: 48_500)
+    lodging.rooms << (@room_1 = Room.create!(name: "Chambre 1", level: 1))
+    lodging.rooms << (@room_2 = Room.create!(name: "Chambre 2", level: 1))
+    lodging.rooms << (@room_3 = Room.create!(name: "Chambre 3", level: 2))
+    lodging
+  end
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+
+  def base_params(overrides = {})
+    {
+      stay: {
+        customer_mode: "new",
+        new_customer: { first_name: "Alice", last_name: "Martin", email: "alice@example.com", phone: "0470111222" },
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        adults: 2, children: 0, dogs_count: 0,
+        lodging_id: hulotte.id, status: "confirmed"
+      }.merge(overrides)
+    }
+  end
+
+  def booking_of(stay)
+    stay.stay_items.where(bookable_type: "Booking").first.bookable
+  end
+
+  describe "GET /stays/new" do
+    it "affiche le mode chambres seules et les chambres du gîte" do
+      get new_stay_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('value="rooms"')
+      expect(response.body).to include("Chambres seules")
+      expect(response.body).to include('name="stay[room_ids][]"')
+      expect(response.body).to include("Chambre 1")
+    end
+  end
+
+  describe "POST /stays (création chambres seules)" do
+    it "crée un séjour chambres seules avec 2 chambres sur 3 et le prix imposé" do
+      post stays_path, params: base_params(
+        booking_type: "rooms",
+        room_ids: [@room_1.id, @room_2.id],
+        price_override: "150"
+      )
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay = Stay.order(:created_at).last
+      booking = booking_of(stay)
+      # booking_type est un attr_accessor non persisté → on vérifie le mode par les
+      # Reservation (source de vérité, cf. Booking#rooms_only_occupation?).
+      expect(booking.rooms_only_occupation?).to be(true)
+      expect(booking.reservations.map(&:room_id).uniq).to match_array([@room_1.id, @room_2.id])
+      expect(booking.reservations.count).to eq(4) # 2 chambres × 2 nuits
+      expect(stay.total_amount_cents).to eq(15_000) # override, pas de forfait gîte
+    end
+
+    it "refuse un séjour chambres seules sans chambre cochée" do
+      expect {
+        post stays_path, params: base_params(booking_type: "rooms", room_ids: [])
+      }.not_to change(Stay, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("au moins une chambre")
+    end
+
+    it "affiche le message « pas de devis automatique » via le devis live" do
+      post quote_stays_path, params: base_params(booking_type: "rooms", room_ids: [@room_1.id]), as: :turbo_stream
+      expect(response.body).to include("Pas de devis automatique pour des chambres seules")
+    end
+  end
+
+  describe "veto croisé (endpoint availability)" do
+    def get_availability(overrides = {})
+      get availability_stays_path, params: {
+        lodging_id: hulotte.id, arrival_date: arrival.iso8601, departure_date: departure.iso8601
+      }.merge(overrides)
+      JSON.parse(response.body)
+    end
+
+    it "chambre libre → available:true ; chambre prise → available:false (granulaire)" do
+      # Occupe la chambre 1 (confirmée) via un séjour chambres seules.
+      post stays_path, params: base_params(booking_type: "rooms", room_ids: [@room_1.id], price_override: "100")
+
+      taken = get_availability(booking_type: "rooms", "room_ids[]": [@room_1.id])
+      free  = get_availability(booking_type: "rooms", "room_ids[]": [@room_2.id])
+      expect(taken["available"]).to be(false)
+      expect(free["available"]).to be(true)
+    end
+
+    it "un gîte entier confirmé rend TOUTES ses chambres indisponibles" do
+      post stays_path, params: base_params(booking_type: "lodging")
+
+      body = get_availability(booking_type: "rooms", "room_ids[]": [@room_2.id])
+      expect(body["available"]).to be(false)
+    end
+
+    it "checkable:false en mode rooms sans chambre transmise" do
+      expect(get_availability(booking_type: "rooms")["checkable"]).to be(false)
+    end
+  end
+
+  describe "PATCH /stays/:id (édition chambres seules)" do
+    it "prérempli le mode chambres et change les chambres réservées" do
+      post stays_path, params: base_params(booking_type: "rooms", room_ids: [@room_1.id], price_override: "100")
+      stay = Stay.order(:created_at).last
+
+      # Le form d'édition restitue le mode chambres + la chambre cochée.
+      get edit_stay_path(stay)
+      expect(response.body).to include('value="rooms"')
+      # Slim ordonne les attributs alphabétiquement : checked="" … value="ID".
+      expect(response.body).to match(/<input checked[^>]*name="stay\[room_ids\]\[\]"[^>]*value="#{@room_1.id}"/)
+
+      patch stay_path(stay), params: {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: hulotte.id, status: "confirmed",
+          booking_type: "rooms", room_ids: [@room_2.id, @room_3.id], price_override: "100"
+        }
+      }
+      expect(response).to redirect_to(recent_stays_path)
+
+      booking = booking_of(stay.reload)
+      expect(booking.reservations.map(&:room_id).uniq).to match_array([@room_2.id, @room_3.id])
+    end
+  end
+end

--- a/spec/services/pricing_model_rooms_spec.rb
+++ b/spec/services/pricing_model_rooms_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+# Epic #81, Phase 5 — devis en mode « chambres seules ». Le barème B2C
+# (`LODGING_RATES`) est un forfait par gîte ENTIER : il n'existe pas de tarif
+# par chambre. En mode "rooms", PricingModel ne facture donc AUCUN forfait
+# d'hébergement — le total du séjour vient du Prix total imposé (override).
+RSpec.describe PricingModel, "mode chambres seules (epic #81, Phase 5)" do
+  let!(:hulotte) { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      lodging_id: hulotte.id,
+      arrival_date: "2026-08-01",
+      departure_date: "2026-08-03"
+    }.merge(overrides))
+  end
+
+  it "facture le forfait gîte entier en mode lodging (comportement historique)" do
+    quote = PricingModel.quote(draft(booking_type: "lodging"))
+    # La Hulotte = 485 € + 260 € = 745 € sur 2 nuits.
+    expect(quote.total_cents).to eq(74_500)
+  end
+
+  it "ne facture AUCUN forfait d'hébergement en mode rooms" do
+    quote = PricingModel.quote(draft(booking_type: "rooms", room_ids: [1]))
+    expect(quote.total_cents).to eq(0)
+    expect(quote.breakdown).to be_empty
+  end
+
+  it "continue de facturer les autres composantes en mode rooms (ex. chien)" do
+    quote = PricingModel.quote(draft(booking_type: "rooms", room_ids: [1], dogs_count: 1))
+    # Pas de forfait gîte, mais le supplément chien (50 €) reste dû.
+    expect(quote.total_cents).to eq(5_000)
+  end
+end

--- a/spec/services/reservations/builder_rooms_spec.rb
+++ b/spec/services/reservations/builder_rooms_spec.rb
@@ -124,4 +124,31 @@ RSpec.describe Reservations::Builder, "chambres seules (epic #81, Phase 5)" do
       expect(forced.availability_warning).to include("forçant la disponibilité")
     end
   end
+
+  describe "garde-fous de revue (Forge Phase 5)" do
+    it "refuse des room_ids tous étrangers au gîte — jamais d'occupation fantôme (F1)" do
+      foreign = Room.create!(name: "Chambre étrangère", level: 1)
+      builder = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [foreign.id]),
+        admin: true, status: "confirmed", source: "manual"
+      )
+      expect(builder.run).to be(false)
+      expect(builder.error_message).to include("n'appartiennent pas")
+      expect(Booking.count).to eq(0)
+    end
+
+    it "persiste booking_type sur le Booking créé (F2 — plus de dérivation fragile)" do
+      described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_1.id, @room_2.id]),
+        admin: true, status: "confirmed", source: "manual"
+      ).run!
+      expect(Booking.last.read_attribute(:booking_type)).to eq("rooms")
+
+      described_class.new(
+        draft: draft(email: "entier@example.com", arrival_date: (departure + 1).iso8601, departure_date: (departure + 3).iso8601),
+        admin: true, status: "confirmed", source: "manual"
+      ).run!
+      expect(Booking.last.read_attribute(:booking_type)).to eq("lodging")
+    end
+  end
 end

--- a/spec/services/reservations/builder_rooms_spec.rb
+++ b/spec/services/reservations/builder_rooms_spec.rb
@@ -1,0 +1,127 @@
+require "rails_helper"
+
+# Epic #81, Phase 5 — le Builder sait réserver des CHAMBRES SEULES dans un séjour
+# (parité avec le canal Booking direct, DANS le séjour). Mode "rooms" : on
+# construit les Reservation UNIQUEMENT pour les chambres cochées ; la dispo se
+# vérifie sur ces chambres ; le veto joue dans les deux sens.
+RSpec.describe Reservations::Builder, "chambres seules (epic #81, Phase 5)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << (@room_1 = Room.create!(name: "Chambre 1", level: 1))
+    lodging.rooms << (@room_2 = Room.create!(name: "Chambre 2", level: 1))
+    lodging.rooms << (@room_3 = Room.create!(name: "Chambre 3", level: 1))
+    lodging
+  end
+
+  let(:arrival)   { Date.today + 30 } # 2 nuits : [arrival, arrival+2)
+  let(:departure) { Date.today + 32 }
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      lodging_id: hulotte.id,
+      arrival_date: arrival.iso8601,
+      departure_date: departure.iso8601,
+      dogs_count: 0,
+      first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  describe "création d'une occupation chambres seules" do
+    it "route booking_type=rooms et ne réserve QUE les chambres cochées" do
+      builder = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_1.id, @room_2.id]),
+        admin: true, status: "confirmed", source: "manual"
+      )
+      expect(builder.run!).to be(true)
+
+      booking = builder.booking
+      expect(booking.booking_type).to eq("rooms")
+      expect(booking.lodging_id).to eq(hulotte.id) # référence gîte conservée
+      # 2 chambres × 2 nuits = 4 Reservation, uniquement sur les chambres cochées.
+      expect(booking.reservations.count).to eq(4)
+      expect(booking.reservations.map(&:room_id).uniq).to match_array([@room_1.id, @room_2.id])
+      expect(booking.reservations.map(&:room_id)).not_to include(@room_3.id)
+    end
+
+    it "n'applique aucun forfait gîte au Booking (prix piloté par l'override)" do
+      builder = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_1.id]),
+        admin: true, status: "confirmed", source: "manual"
+      )
+      builder.run!
+      expect(builder.booking.price_cents).to eq(0)
+      expect(builder.stay.total_amount_cents).to eq(0)
+    end
+
+    it "honore le prix imposé en mode chambres" do
+      builder = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_1.id]),
+        admin: true, status: "confirmed", source: "manual",
+        price_override_cents: 12_000
+      )
+      builder.run!
+      expect(builder.stay.total_amount_cents).to eq(12_000)
+    end
+
+    it "borne les chambres au gîte (une chambre d'un autre gîte est ignorée)" do
+      other = Lodging.create!(name: "La Chevêche", price_night_cents: 27_500)
+      other.rooms << (foreign = Room.create!(name: "Chevêche 1", level: 1))
+
+      builder = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_1.id, foreign.id]),
+        admin: true, status: "confirmed", source: "manual"
+      )
+      builder.run!
+      expect(builder.booking.reservations.map(&:room_id).uniq).to eq([@room_1.id])
+    end
+
+    it "refuse une création chambres seules sans aucune chambre cochée" do
+      builder = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: []),
+        admin: true, status: "confirmed", source: "manual"
+      )
+      expect(builder.run).to be(false)
+      expect(builder.error_message).to include("au moins une chambre")
+    end
+  end
+
+  describe "veto croisé gîte entier ↔ chambre" do
+    it "une chambre confirmée rend le gîte ENTIER indisponible, l'autre chambre restant libre" do
+      described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_1.id]),
+        admin: true, status: "confirmed", source: "manual"
+      ).run!
+
+      # Le gîte entier ne peut plus être réservé (une de ses chambres est prise).
+      expect(hulotte.available_between?(arrival, departure)).to be(false)
+      # Mais une AUTRE chambre du gîte reste réservable.
+      expect(hulotte.rooms_available_between?([@room_2.id], arrival, departure)).to be(true)
+      expect(hulotte.rooms_available_between?([@room_1.id], arrival, departure)).to be(false)
+    end
+
+    it "un gîte entier confirmé bloque une nouvelle résa chambres seules (sans forçage)" do
+      # Occupation gîte entier confirmée.
+      described_class.new(draft: draft, admin: true, status: "confirmed", source: "manual").run!
+
+      # Tentative chambres seules sur une chambre du gîte → indispo → refus.
+      rooms_builder = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_2.id], email: "autre@example.com"),
+        admin: true, status: "confirmed", source: "manual"
+      )
+      expect(rooms_builder.run).to be(false)
+      expect(rooms_builder.error_message).to include("plus disponibles")
+    end
+
+    it "permet de forcer la dispo en mode chambres (surbooking) avec avertissement" do
+      described_class.new(draft: draft, admin: true, status: "confirmed", source: "manual").run!
+
+      forced = described_class.new(
+        draft: draft(booking_type: "rooms", room_ids: [@room_2.id], email: "autre@example.com"),
+        admin: true, status: "confirmed", source: "manual", skip_availability: true
+      )
+      expect(forced.run!).to be(true)
+      expect(forced.availability_warning).to include("forçant la disponibilité")
+    end
+  end
+end

--- a/spec/services/stays/admin_updater_rooms_spec.rb
+++ b/spec/services/stays/admin_updater_rooms_spec.rb
@@ -115,4 +115,29 @@ RSpec.describe Stays::AdminUpdater, "chambres seules (epic #81, Phase 5)" do
     expect(updater.run).to be(false)
     expect(updater.error_message).to include("plus disponibles")
   end
+
+  # Revue Forge Phase 5.
+  it "refuse des room_ids tous étrangers au gîte en édition (F1)" do
+    foreign = Room.create!(name: "Chambre étrangère", level: 1)
+    stay = create_rooms_stay
+    updater = described_class.new(
+      stay: stay,
+      draft: draft(booking_type: "rooms", room_ids: [foreign.id], price_override_cents: 12_000),
+      status: "confirmed", price_override_cents: 12_000
+    )
+    expect(updater.run).to be(false)
+    expect(updater.error_message).to include("n'appartiennent pas")
+  end
+
+  it "n'auto-bloque pas la réédition d'un séjour GÎTE ENTIER confirmé (F4 — exclusion de soi en mode lodging)" do
+    builder = Reservations::Builder.new(
+      draft: draft, admin: true, status: "confirmed", source: "manual"
+    )
+    builder.run!
+    stay = builder.stay
+
+    updater = described_class.new(stay: stay, draft: draft, status: "confirmed")
+    expect(updater.run).to be(true)
+    expect(updater.availability_warning).to be_nil
+  end
 end

--- a/spec/services/stays/admin_updater_rooms_spec.rb
+++ b/spec/services/stays/admin_updater_rooms_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+# Epic #81, Phase 5 — édition d'un séjour en mode chambres seules. L'updater
+# reconstruit proprement les Reservation quand les chambres (ou dates/hébergement)
+# changent, et ne bloque pas un séjour confirmé par sa propre occupation.
+RSpec.describe Stays::AdminUpdater, "chambres seules (epic #81, Phase 5)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << (@room_1 = Room.create!(name: "Chambre 1", level: 1))
+    lodging.rooms << (@room_2 = Room.create!(name: "Chambre 2", level: 1))
+    lodging.rooms << (@room_3 = Room.create!(name: "Chambre 3", level: 1))
+    lodging
+  end
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 32 }
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      lodging_id: hulotte.id,
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      adults: 2, dogs_count: 0,
+      first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  # Séjour chambres seules confirmé, sur 2 chambres, via le Builder.
+  def create_rooms_stay(room_ids: [@room_1.id, @room_2.id], price_override_cents: 12_000)
+    builder = Reservations::Builder.new(
+      draft: draft(booking_type: "rooms", room_ids: room_ids),
+      admin: true, status: "confirmed", source: "manual",
+      price_override_cents: price_override_cents
+    )
+    builder.run!
+    builder.stay
+  end
+
+  def booking_of(stay)
+    stay.stay_items.where(bookable_type: "Booking").first.bookable
+  end
+
+  it "reconstruit les Reservation quand les chambres cochées changent" do
+    stay = create_rooms_stay(room_ids: [@room_1.id, @room_2.id])
+
+    updater = described_class.new(
+      stay: stay,
+      draft: draft(booking_type: "rooms", room_ids: [@room_3.id], price_override_cents: 12_000),
+      status: "confirmed", price_override_cents: 12_000
+    )
+    expect(updater.run).to be(true)
+
+    booking = booking_of(stay.reload)
+    expect(booking.reservations.map(&:room_id).uniq).to eq([@room_3.id])
+    # 1 chambre × 2 nuits.
+    expect(booking.reservations.count).to eq(2)
+  end
+
+  it "convertit un séjour gîte entier en chambres seules" do
+    entire = Reservations::Builder.new(
+      draft: draft, admin: true, status: "confirmed", source: "manual"
+    ).tap(&:run!).stay
+    expect(booking_of(entire).reservations.map(&:room_id).uniq).to match_array(hulotte.rooms.pluck(:id))
+
+    updater = described_class.new(
+      stay: entire,
+      draft: draft(booking_type: "rooms", room_ids: [@room_1.id], price_override_cents: 9_000),
+      status: "confirmed", price_override_cents: 9_000
+    )
+    expect(updater.run).to be(true)
+
+    booking = booking_of(entire.reload)
+    expect(booking.reservations.map(&:room_id).uniq).to eq([@room_1.id])
+    expect(booking.rooms_only_occupation?).to be(true)
+  end
+
+  it "ne se bloque pas lui-même en réenregistrant un séjour chambres CONFIRMÉ inchangé" do
+    stay = create_rooms_stay(room_ids: [@room_1.id])
+
+    updater = described_class.new(
+      stay: stay,
+      draft: draft(booking_type: "rooms", room_ids: [@room_1.id], price_override_cents: 12_000),
+      status: "confirmed", price_override_cents: 12_000, skip_availability: false
+    )
+    expect(updater.run).to be(true)
+    # L'occupation reste intacte (pas d'auto-blocage → pas de perte de Reservation).
+    expect(booking_of(stay.reload).reservations.map(&:room_id).uniq).to eq([@room_1.id])
+  end
+
+  it "refuse le passage en chambres seules sans chambre cochée" do
+    stay = create_rooms_stay
+
+    updater = described_class.new(
+      stay: stay,
+      draft: draft(booking_type: "rooms", room_ids: []),
+      status: "confirmed"
+    )
+    expect(updater.run).to be(false)
+    expect(updater.error_message).to include("au moins une chambre")
+  end
+
+  it "bloque le passage sur une chambre déjà prise par un AUTRE séjour confirmé" do
+    # Un autre séjour confirmé occupe la chambre 3.
+    Reservations::Builder.new(
+      draft: draft(booking_type: "rooms", room_ids: [@room_3.id], email: "autre@example.com"),
+      admin: true, status: "confirmed", source: "manual", price_override_cents: 5_000
+    ).run!
+
+    stay = create_rooms_stay(room_ids: [@room_1.id])
+    updater = described_class.new(
+      stay: stay,
+      draft: draft(booking_type: "rooms", room_ids: [@room_3.id], price_override_cents: 12_000),
+      status: "confirmed", price_override_cents: 12_000
+    )
+    expect(updater.run).to be(false)
+    expect(updater.error_message).to include("plus disponibles")
+  end
+end


### PR DESCRIPTION
## Epic #81 — Phase 6 : facturation espace enrichie

PR **empilée sur #95** (Phase 5). Le séjour porte désormais la facturation des espaces — parité avec `SpaceBookings::CreateService` (prérequis de la dépréciation du canal direct en Phase 9).

### Contenu
- **Form séjour** : sous-panneau « Facturation espaces » (toggle Stimulus, affiché dès qu'une ligne d'espace est renseignée) — acompte, caution, mode de paiement (liquide/virement/Airbnb/Booking), événement (select `Event`), heures d'arrivée/départ. Tous optionnels.
- **`Reservations::Draft#space_billing`** + **`SpaceComposition#assign_space_billing`** : persistance sur le SpaceBooking, création ET édition.
- **Parité €→cents par construction** : les montants passent par les MÊMES setters `monetize` que le canal direct (aucune conversion manuelle) ; champ vide → nil, jamais 0.
- **Survie garantie à la réédition** : gate `nil` (clé absente du form → no-op, les valeurs existantes survivent) + resoumission des valeurs préremplies. `reconcile_spaces!` passe en `assign_attributes + save!` unique — ne touche jamais `status`/`email` (aucun email déclenché, testé).

### Vérifications
- **RSpec : 741 examples, 0 failures** (+8).
- **Navigateur : 7/7 PASS** — toggle apparition/masquage, création espace en journée sèche avec facturation complète (séjour test #10), préremplissage édition exact, modification de l'acompte persistée, **réédition partielle (période changée) → facturation intacte**, zéro erreur console.
- Le label « Caution (€) ♻️ » reprend volontairement le style du form direct (cohérence).