### PR TITLE
Epic #81 Phase 7 — Saisie rapide datée depuis le calendrier + duplication de séjour

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -242,6 +242,10 @@ class StaysController < BaseController
   # saisie datée d'un hébergement. À défaut, un draft vierge.
   def build_prefilled_draft
     if (source = duplicate_source)
+      # Le client du séjour source est PRÉSÉLECTIONNÉ dans le <select> « Client
+      # existant » (sinon le prérempli n'atterrissait que dans les champs masqués
+      # du panneau « Nouveau client » et une soumission partait sans customer_id).
+      @preselected_customer_id = source.customer_id
       return Stays::DuplicateService.call(stay: source)
     end
 
@@ -318,7 +322,7 @@ class StaysController < BaseController
     # Client existant : autocomplete via `customers/search` (issue #74). On ne
     # précharge plus TOUS les clients — seul le client courant (édition) alimente
     # le `<select>` de repli sans-JS. La recherche dynamique fait le reste.
-    @customers = Customer.where(id: @stay&.customer_id).to_a
+    @customers = Customer.where(id: [@stay&.customer_id, @preselected_customer_id].compact).to_a
     @assignable_availabilities = ExperienceAvailability.for_user(current_user)
                                                        .upcoming
                                                        .includes(:experience)

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -28,9 +28,16 @@ class StaysController < BaseController
   # (hébergement + activités), en réutilisant `Reservations::Builder` en mode
   # admin (aucun Stripe, aucun email forcé, force-dispo, statut au choix).
 
+  # Saisie rapide datée + duplication (epic #81, Phase 7). Le form NEW se
+  # préremplit selon les params :
+  #   - `duplicate_from` → reprise du séjour source (client + composition, sans
+  #     dates ni paiement ni prix imposé), via `Stays::DuplicateService` ;
+  #   - `date`           → arrivée = date, départ = date + 1 (1 nuit, hébergement) ;
+  #   - `date` + `space` → une ligne d'espace datée, SANS dates de séjour (journée
+  #     sèche : composition d'espace légitime).
   def new
     @stay  = Stay.new(status: "pending")
-    @draft = Reservations::Draft.new
+    @draft = build_prefilled_draft
     prepare_form
   end
 
@@ -60,7 +67,7 @@ class StaysController < BaseController
   end
 
   def edit
-    @draft = draft_from_stay(@stay)
+    @draft = Stays::DraftReconstructor.new(@stay).to_draft
     prepare_form
   end
 
@@ -230,6 +237,33 @@ class StaysController < BaseController
 
   private
 
+  # Draft de préremplissage du form NEW (epic #81, Phase 7). Trois cas, dans
+  # l'ordre de priorité : duplication d'un séjour, saisie datée d'un espace,
+  # saisie datée d'un hébergement. À défaut, un draft vierge.
+  def build_prefilled_draft
+    if (source = duplicate_source)
+      return Stays::DuplicateService.call(stay: source)
+    end
+
+    date = parse_form_date(params[:date])
+    return Reservations::Draft.new if date.nil?
+
+    if params[:space].present?
+      # Espace en journée sèche : une ligne d'espace datée, aucune date de séjour.
+      Reservations::Draft.new(halls: [{ date: date.iso8601 }])
+    else
+      # Hébergement : arrivée = date, départ = lendemain (1 nuit par défaut).
+      Reservations::Draft.new(arrival_date: date.iso8601, departure_date: (date + 1).iso8601)
+    end
+  end
+
+  # Séjour source d'une duplication (`duplicate_from`). nil si absent ou introuvable.
+  def duplicate_source
+    id = params[:duplicate_from]
+    return nil if id.blank?
+    Stay.find_by(id: id)
+  end
+
   # Séjours candidats à la fusion, préchargés pour éviter les N+1 des aperçus.
   def load_merge_stays
     ids = Array(params[:stay_ids]).map(&:to_i).uniq.reject(&:zero?)
@@ -386,110 +420,6 @@ class StaysController < BaseController
       next if kind.blank? || people < 1
       { kind: kind, date: row[:date].to_s.presence, people: people }
     end
-  end
-
-  # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
-  def draft_from_stay(stay)
-    booking = stay.stay_items.where(bookable_type: "Booking").first&.bookable
-    # Chambres seules (epic #81, Phase 5) : rétablit le mode + les chambres
-    # cochées. La colonne `booking_type` fait foi ; dérivation des Reservation
-    # en secours pour le legacy (cf. Booking#rooms_mode?).
-    rooms_mode = booking&.rooms_mode?
-    Reservations::Draft.new(
-      lodging_id:     booking&.lodging_id,
-      booking_type:   rooms_mode ? "rooms" : "lodging",
-      room_ids:       rooms_mode ? booking.reservations.map(&:room_id).uniq : [],
-      arrival_date:   stay.arrival_date,
-      departure_date: stay.departure_date,
-      adults:         booking&.adults,
-      children:       booking&.children,
-      group_name:     booking&.group_name,
-      first_name:     stay.customer&.first_name,
-      last_name:      stay.customer&.last_name,
-      email:          stay.customer&.email,
-      phone:          stay.customer&.phone,
-      experiences:    stay.experience_bookings.active.map { |eb|
-        { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
-      },
-      halls:          halls_from_stay(stay),
-      campings:       campings_from_stay(stay),
-      vans:           vans_from_stay(stay),
-      meals:          meals_from_stay(stay),
-      space_billing:  space_billing_from_stay(stay)
-    )
-  end
-
-  # Facturation espace (epic #81, Phase 6) : reconstitue le sous-hash de
-  # facturation depuis le SpaceBooking du séjour, pour préremplir le form edit.
-  # nil si le séjour n'a pas d'espace. Les montants repassent en € (chaîne `%g`
-  # pour éviter les décimales parasites) — miroir du form direct `_payment`.
-  def space_billing_from_stay(stay)
-    sb = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
-    return nil if sb.nil?
-
-    {
-      advance_amount: euro_prefill(sb.advance_amount_cents),
-      deposit_amount: euro_prefill(sb.deposit_amount_cents),
-      payment_method: sb.payment_method,
-      event_id:       sb.event_id,
-      arrival_time:   sb.arrival_time,
-      departure_time: sb.departure_time
-    }
-  end
-
-  # Cents → chaîne € prête pour un number_field (nil si absent, "50" pas "50.0").
-  def euro_prefill(cents)
-    return nil if cents.nil?
-    format("%g", cents / 100.0)
-  end
-
-  # Reconstruit l'entrée camping {kind, people, nights} depuis le CampingBooking
-  # persisté, pour préremplir le form edit (nights déduit de la fenêtre).
-  def campings_from_stay(stay)
-    camping = stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
-    return [] if camping.nil?
-    nights = camping.from_date && camping.to_date ? (camping.to_date - camping.from_date).to_i : stay.experience_bookings.size
-    [{ kind: camping.kind, people: camping.people, nights: [nights, 1].max }]
-  end
-
-  # Reconstruit les entrées van (une par véhicule) depuis le VanBooking persisté.
-  def vans_from_stay(stay)
-    van = stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
-    return [] if van.nil?
-    nights = van.from_date && van.to_date ? (van.to_date - van.from_date).to_i : 1
-    Array.new([van.vehicles, 1].max) { { nights: [nights, 1].max } }
-  end
-
-  # Reconstruit les repas {kind, date, people} depuis les MealOrder du séjour.
-  def meals_from_stay(stay)
-    stay.meal_orders.map do |order|
-      { kind: order.kind, date: order.date&.iso8601, people: order.people }
-    end
-  end
-
-  # Reconstruit les lignes d'espaces {kind, date, period} d'un séjour depuis son
-  # SpaceBooking (réservations existantes), pour préremplir le form edit. Le nom
-  # de la Space est re-mappé vers sa clé de pricing (grande_salle, …).
-  def halls_from_stay(stay)
-    space_booking = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
-    return [] if space_booking.nil?
-
-    space_booking.space_reservations.map do |res|
-      key = space_key_for(res.space)
-      next if key.nil?
-      { kind: key, date: res.date&.iso8601, period: res.duration }
-    end.compact
-  end
-
-  # `Space` → clé de pricing (inverse du mapping SpaceComposition). Résolution par
-  # le `code` stable d'abord (issue #75), puis repli sur le nom d'affichage.
-  def space_key_for(space)
-    return nil if space.nil?
-
-    by_code = SpaceComposition::SPACE_CODES_BY_KEY.find { |_key, code| code == space.code }&.first
-    return by_code if by_code
-
-    SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(space.name) }&.first
   end
 
   # Coordonnées client : soit un client existant sélectionné (on lit ses

--- a/app/services/stays/draft_reconstructor.rb
+++ b/app/services/stays/draft_reconstructor.rb
@@ -1,0 +1,131 @@
+module Stays
+  # Reconstruit un `Reservations::Draft` COMPLET depuis un séjour persisté, pour
+  # préremplir un formulaire (édition à l'identique, ou duplication après vidage
+  # des dates par `Stays::DuplicateService`).
+  #
+  # Extrait du contrôleur (epic #81, Phase 7) pour éviter la duplication de code :
+  # l'édition (dates conservées) et la duplication (dates vidées) partagent la
+  # MÊME reconstruction de composition. La seule vérité recomposée ici est la
+  # composition tarifable — jamais les paiements ni le prix imposé, absents du Draft.
+  class DraftReconstructor
+    def initialize(stay)
+      @stay = stay
+    end
+
+    def self.call(stay)
+      new(stay).to_draft
+    end
+
+    def to_draft
+      booking = lodging_booking
+      # Chambres seules (epic #81, Phase 5) : rétablit le mode + les chambres
+      # cochées. La colonne `booking_type` fait foi ; dérivation des Reservation
+      # en secours pour le legacy (cf. Booking#rooms_mode?).
+      rooms_mode = booking&.rooms_mode?
+      Reservations::Draft.new(
+        lodging_id:     booking&.lodging_id,
+        booking_type:   rooms_mode ? "rooms" : "lodging",
+        room_ids:       rooms_mode ? booking.reservations.map(&:room_id).uniq : [],
+        arrival_date:   @stay.arrival_date,
+        departure_date: @stay.departure_date,
+        adults:         booking&.adults,
+        children:       booking&.children,
+        group_name:     booking&.group_name,
+        first_name:     @stay.customer&.first_name,
+        last_name:      @stay.customer&.last_name,
+        email:          @stay.customer&.email,
+        phone:          @stay.customer&.phone,
+        experiences:    @stay.experience_bookings.active.map { |eb|
+          { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
+        },
+        halls:          halls_from_stay,
+        campings:       campings_from_stay,
+        vans:           vans_from_stay,
+        meals:          meals_from_stay,
+        space_billing:  space_billing_from_stay
+      )
+    end
+
+    private
+
+    def lodging_booking
+      @stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    end
+
+    def space_booking
+      @stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+    end
+
+    # Facturation espace (epic #81, Phase 6) : reconstitue le sous-hash de
+    # facturation depuis le SpaceBooking du séjour. nil si le séjour n'a pas
+    # d'espace. Les montants repassent en € (chaîne `%g` pour éviter les décimales
+    # parasites) — miroir du form direct `_payment`.
+    def space_billing_from_stay
+      sb = space_booking
+      return nil if sb.nil?
+
+      {
+        advance_amount: euro_prefill(sb.advance_amount_cents),
+        deposit_amount: euro_prefill(sb.deposit_amount_cents),
+        payment_method: sb.payment_method,
+        event_id:       sb.event_id,
+        arrival_time:   sb.arrival_time,
+        departure_time: sb.departure_time
+      }
+    end
+
+    # Cents → chaîne € prête pour un number_field (nil si absent, "50" pas "50.0").
+    def euro_prefill(cents)
+      return nil if cents.nil?
+      format("%g", cents / 100.0)
+    end
+
+    # Reconstruit l'entrée camping {kind, people, nights} depuis le CampingBooking
+    # persisté (nights déduit de la fenêtre).
+    def campings_from_stay
+      camping = @stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
+      return [] if camping.nil?
+      nights = camping.from_date && camping.to_date ? (camping.to_date - camping.from_date).to_i : @stay.experience_bookings.size
+      [{ kind: camping.kind, people: camping.people, nights: [nights, 1].max }]
+    end
+
+    # Reconstruit les entrées van (une par véhicule) depuis le VanBooking persisté.
+    def vans_from_stay
+      van = @stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
+      return [] if van.nil?
+      nights = van.from_date && van.to_date ? (van.to_date - van.from_date).to_i : 1
+      Array.new([van.vehicles, 1].max) { { nights: [nights, 1].max } }
+    end
+
+    # Reconstruit les repas {kind, date, people} depuis les MealOrder du séjour.
+    def meals_from_stay
+      @stay.meal_orders.map do |order|
+        { kind: order.kind, date: order.date&.iso8601, people: order.people }
+      end
+    end
+
+    # Reconstruit les lignes d'espaces {kind, date, period} depuis le SpaceBooking.
+    # Le nom de la Space est re-mappé vers sa clé de pricing (grande_salle, …).
+    def halls_from_stay
+      sb = space_booking
+      return [] if sb.nil?
+
+      sb.space_reservations.map do |res|
+        key = space_key_for(res.space)
+        next if key.nil?
+        { kind: key, date: res.date&.iso8601, period: res.duration }
+      end.compact
+    end
+
+    # `Space` → clé de pricing (inverse du mapping SpaceComposition). Résolution par
+    # le `code` stable d'abord (issue #75), puis repli sur le nom d'affichage.
+    def space_key_for(space)
+      return nil if space.nil?
+
+      by_code = SpaceComposition::SPACE_CODES_BY_KEY.find { |_key, code| code == space.code }&.first
+      return by_code if by_code
+
+      SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(space.name) }&.first
+    end
+  end
+end

--- a/app/services/stays/duplicate_service.rb
+++ b/app/services/stays/duplicate_service.rb
@@ -1,0 +1,60 @@
+module Stays
+  # Duplication de séjour (epic #81, Phase 7).
+  #
+  # CHOIX D'ARCHITECTURE — pas de clone DB instantané. La duplication NE crée
+  # RIEN en base : elle renvoie un `Reservations::Draft` prérempli depuis le
+  # séjour source, destiné à alimenter le formulaire NEW. L'admin choisit de
+  # NOUVELLES dates puis soumet — c'est la création normale (`Reservations::
+  # Builder`) qui persiste. Pourquoi repasser par le form plutôt que cloner
+  # directement :
+  #   - un clone immédiat aux MÊMES dates surbookerait l'hébergement ET les
+  #     espaces (le veto de dispo compte les Reservation/SpaceReservation) ;
+  #   - les paiements déjà encaissés sur la source n'ont pas eu lieu sur le clone ;
+  #   - un prix imposé figé ne vaut plus pour un séjour à d'autres dates.
+  # On délègue donc la décision de dates/prix à l'admin, via le form.
+  #
+  # COPIÉ : client + composition (hébergement/mode chambres, espaces + facturation,
+  # camping, van, repas, activités réutilisables) — tout ce que
+  # `Stays::DraftReconstructor` sait reconstruire.
+  # EXCLU :
+  #   - toutes les dates (séjour ET éléments datés espace/repas) → re-planification
+  #     forcée, anti-surbooking ;
+  #   - les paiements → jamais reconstruits par le Draft, et le canal admin n'en
+  #     crée aucun à la création ;
+  #   - le prix imposé → absent du Draft ; le devis B2C se recalcule et l'admin le
+  #     re-saisira si besoin.
+  # Le statut du séjour dupliqué reste « pending » (défaut du form NEW).
+  class DuplicateService
+    def self.call(stay:)
+      new(stay: stay).call
+    end
+
+    def initialize(stay:)
+      @stay = stay
+    end
+
+    def call
+      draft = DraftReconstructor.new(@stay).to_draft
+      blank_all_dates!(draft)
+      draft
+    end
+
+    private
+
+    # Vide TOUTES les dates du draft : niveau séjour (arrivée/départ) et niveau
+    # élément (espaces, repas). L'admin re-date l'ensemble depuis le form.
+    def blank_all_dates!(draft)
+      draft.arrival_date   = nil
+      draft.departure_date = nil
+      draft.halls = strip_dates(draft.halls)
+      draft.meals = strip_dates(draft.meals)
+    end
+
+    def strip_dates(rows)
+      Array(rows).map do |row|
+        row = row.symbolize_keys if row.respond_to?(:symbolize_keys)
+        row.merge(date: nil)
+      end
+    end
+  end
+end

--- a/app/views/simple_calendar/_dashboard_calendar.html.erb
+++ b/app/views/simple_calendar/_dashboard_calendar.html.erb
@@ -115,8 +115,9 @@
 
                   <div class="flex">
                     <% if Date.today <= day %>
-                      <%= link_to "H+", new_booking_path(date: day.strftime("%Y-%m-%d")), class: "mr-2 text-blue-700 hover:text-blue-900" %>
-                      <%= link_to "E+", new_space_booking_path(date: day.strftime("%Y-%m-%d")), class: "mr-2 text-blue-700 hover:text-blue-900" %>
+                      <%# Saisie rapide datée (epic #81, Phase 7) : les chips H+/E+ pointent désormais vers le form SÉJOUR prérempli à la date cliquée (plus de création directe Booking/SpaceBooking depuis le calendrier). %>
+                      <%= link_to "H+", new_stay_path(date: day.iso8601), title: "Nouveau séjour hébergement à cette date", class: "mr-2 text-blue-700 hover:text-blue-900" %>
+                      <%= link_to "E+", new_stay_path(date: day.iso8601, space: 1), title: "Nouveau séjour espace à cette date", class: "mr-2 text-blue-700 hover:text-blue-900" %>
                     <% end %>
 
                     <%= link_to new_note_path(date: day.strftime("%Y-%m-%d")), data: { turbo_frame: "modal" } do %>

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -8,6 +8,9 @@ div id="stay-details-#{@stay.id}"
       .flex.items-center.gap-2
         = @stay.platform_badge
         = @stay.status_badge
+        / Duplication (epic #81, Phase 7) : ouvre le form NEW prérempli depuis ce
+        / séjour (client + composition), dates/paiement/prix imposé exclus.
+        = link_to "Dupliquer", new_stay_path(duplicate_from: @stay.id), title: "Dupliquer ce séjour (nouvelles dates à choisir)", class: "text-sm font-medium text-gray-500 hover:text-gray-700 hover:underline"
         = link_to "Modifier le séjour", edit_stay_path(@stay), class: "text-sm font-medium text-indigo-600 hover:underline"
 
     / Actions rapides (issue #76) : bascule de statut + accès solde, sans ouvrir

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -1,6 +1,7 @@
 / Formulaire CRUD Séjour admin (epic #66, Phase 1). Locals : url, method, submit_label.
 / Champs sous le namespace `stay[...]`. Devis B2C forfaitaire (PricingModel).
-- selected_customer_id = @stay.persisted? ? @stay.customer_id : nil
+/ Duplication (epic #81, Phase 7) : le client du séjour source est présélectionné.
+- selected_customer_id = (@stay.persisted? ? @stay.customer_id : nil) || @preselected_customer_id
 - current_status = (@stay.status.presence || "pending")
 - selected_experiences = {}
 - Array(@draft&.experiences).each { |e| selected_experiences[e[:availability_id].to_i] = e[:participants] }

--- a/app/views/stays/edit.html.slim
+++ b/app/views/stays/edit.html.slim
@@ -3,5 +3,9 @@
     div
       h1.text-xl.font-semibold.text-gray-900 = "Modifier le séjour ##{@stay.id}"
       p.mt-1.text-sm.text-gray-600 Modifiez la composition du séjour (hébergement + activités). Aucun paiement n'est déclenché.
-    = button_to "Supprimer le séjour", stay_path(@stay), method: :delete, data: { turbo_confirm: "Supprimer ce séjour ? Cette action est réversible (soft-delete)." }, class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+    .flex.items-center.gap-2
+      / Duplication (epic #81, Phase 7) : form NEW prérempli depuis ce séjour,
+      / dates/paiement/prix imposé exclus.
+      = link_to "Dupliquer", new_stay_path(duplicate_from: @stay.id), title: "Dupliquer ce séjour (nouvelles dates à choisir)", class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      = button_to "Supprimer le séjour", stay_path(@stay), method: :delete, data: { turbo_confirm: "Supprimer ce séjour ? Cette action est réversible (soft-delete)." }, class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
   = render "form", url: stay_path(@stay), method: :patch, submit_label: "Enregistrer les modifications"

--- a/spec/requests/stays_quick_create_spec.rb
+++ b/spec/requests/stays_quick_create_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+# Epic #81, Phase 7 — Saisie rapide datée depuis le calendrier + duplication.
+#
+# A. Le form NEW lit `date`/`space`/`duplicate_from` et se préremplit :
+#    - `date`               → arrivée = date, départ = date + 1 (hébergement) ;
+#    - `date` + `space=1`   → une ligne d'espace datée, SANS dates de séjour ;
+#    - `duplicate_from`     → client + composition du séjour source, dates VIDES.
+# B. La modale du calendrier expose un bouton « Dupliquer » vers ce form.
+RSpec.describe "Stays — saisie rapide datée & duplication (epic #81, Phase 7)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-quick-create@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:lodging)      { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+  let(:date)          { Date.today + 30 }
+
+  describe "GET /stays/new?date=… — préremplissage hébergement" do
+    it "préremplit l'arrivée à la date et le départ au lendemain (1 nuit)" do
+      get new_stay_path(date: date.iso8601)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match(/name="stay\[arrival_date\]"[^>]*value="#{date.iso8601}"/)
+      expect(response.body).to match(/name="stay\[departure_date\]"[^>]*value="#{(date + 1).iso8601}"/)
+    end
+  end
+
+  describe "GET /stays/new?date=…&space=1 — préremplissage espace daté" do
+    it "ouvre une ligne d'espace datée, SANS dates de séjour" do
+      get new_stay_path(date: date.iso8601, space: 1)
+      expect(response).to have_http_status(:ok)
+      # Une ligne d'espace porte la date cliquée.
+      expect(response.body).to match(/name="stay\[halls\]\[0\]\[date\]"[^>]*value="#{date.iso8601}"/)
+      # Aucune date de séjour (journée sèche : l'admin ne saisit pas de nuitée).
+      expect(response.body).not_to match(/name="stay\[arrival_date\]"[^>]*value="\d/)
+      expect(response.body).not_to match(/name="stay\[departure_date\]"[^>]*value="\d/)
+    end
+  end
+
+  describe "GET /stays/new?duplicate_from=… — préremplissage par duplication" do
+    let!(:source) do
+      draft = Reservations::Draft.new(
+        lodging_id:     lodging.id,
+        arrival_date:   date,
+        departure_date: date + 2,
+        adults:         2,
+        dogs_count:     0,
+        first_name:     "Alice",
+        last_name:      "Martin",
+        email:          "alice@example.com",
+        phone:          "0470111222",
+        halls:          [{ kind: "grande_salle", date: date.iso8601, period: "journee" }],
+        meals:          [{ kind: "buffet", date: date.iso8601, people: 3 }]
+      )
+      builder = Reservations::Builder.new(draft: draft, admin: true, source: "manual", price_override_cents: 88_800)
+      builder.run!
+      builder.stay
+    end
+
+    it "reprend le client et la composition, mais laisse les dates vides" do
+      get new_stay_path(duplicate_from: source.id)
+      expect(response).to have_http_status(:ok)
+
+      # Client conservé (nom pré-rempli dans le panneau « nouveau client » de repli).
+      expect(response.body).to include('value="Alice"')
+      expect(response.body).to include('value="Martin"')
+      # Composition conservée : hébergement présélectionné + une ligne d'espace.
+      expect(response.body).to match(/selected="selected" value="#{lodging.id}"/)
+      expect(response.body).to match(/selected="selected" value="grande_salle"/)
+
+      # Dates de séjour VIDES (un clone aux mêmes dates surbookerait).
+      expect(response.body).not_to match(/name="stay\[arrival_date\]"[^>]*value="\d/)
+      expect(response.body).not_to match(/name="stay\[departure_date\]"[^>]*value="\d/)
+      # Prix imposé NON copié (champ vide malgré l'override du séjour source).
+      expect(response.body).not_to match(/name="stay\[price_override\]"[^>]*value="\d/)
+    end
+  end
+
+  describe "modale séjour — bouton Dupliquer" do
+    let!(:stay) do
+      draft = Reservations::Draft.new(
+        lodging_id: lodging.id, arrival_date: date, departure_date: date + 1,
+        adults: 2, dogs_count: 0,
+        first_name: "Bob", last_name: "Durand", email: "bob@example.com", phone: "0470999888"
+      )
+      builder = Reservations::Builder.new(draft: draft, admin: true, source: "manual")
+      builder.run!
+      builder.stay
+    end
+
+    it "affiche un lien Dupliquer vers le form NEW prérempli" do
+      get stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(new_stay_path(duplicate_from: stay.id))
+      expect(response.body).to include("Dupliquer")
+    end
+  end
+end

--- a/spec/requests/stays_quick_create_spec.rb
+++ b/spec/requests/stays_quick_create_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe "Stays — saisie rapide datée & duplication (epic #81, Phase 7)
       # Client conservé (nom pré-rempli dans le panneau « nouveau client » de repli).
       expect(response.body).to include('value="Alice"')
       expect(response.body).to include('value="Martin"')
+      # …et surtout PRÉSÉLECTIONNÉ dans le <select> « Client existant » (passe
+      # navigateur Phase 7) : sans ça, la soumission partait en mode « existant »
+      # avec customer_id vide.
+      expect(response.body).to match(/name="stay\[customer_id\]".*?<option selected[^>]*value="#{source.customer_id}"/m)
       # Composition conservée : hébergement présélectionné + une ligne d'espace.
       expect(response.body).to match(/selected="selected" value="#{lodging.id}"/)
       expect(response.body).to match(/selected="selected" value="grande_salle"/)

--- a/spec/services/stays/duplicate_service_spec.rb
+++ b/spec/services/stays/duplicate_service_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+# Epic #81, Phase 7 — Duplication de séjour. Le service NE clone PAS en base :
+# il reconstruit un `Reservations::Draft` prérempli depuis le séjour source, prêt
+# à alimenter le form NEW. L'admin choisit de NOUVELLES dates puis soumet — c'est
+# la création normale (Reservations::Builder) qui écrit en base.
+#
+# Ce qui est COPIÉ : client, composition (hébergement, espaces + facturation,
+# repas…). Ce qui est EXCLU : toutes les dates (séjour + éléments datés), les
+# paiements (jamais reconstruits par le draft) et le prix imposé (le devis se
+# recalcule ; l'admin le re-saisit au besoin).
+RSpec.describe Stays::DuplicateService, type: :service do
+  let!(:lodging)      { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+  let(:arrival)       { Date.today + 30 }
+  let(:departure)     { Date.today + 32 }
+
+  # Séjour source multi-éléments : hébergement + espace facturé + repas, créé via
+  # le Builder admin (aucun paiement, aucun email — parité canal admin).
+  def build_source_stay(price_override_cents: nil)
+    draft = Reservations::Draft.new(
+      lodging_id:     lodging.id,
+      arrival_date:   arrival,
+      departure_date: departure,
+      adults:         2,
+      dogs_count:     0,
+      first_name:     "Alice",
+      last_name:      "Martin",
+      email:          "alice@example.com",
+      phone:          "0470111222",
+      halls:          [{ kind: "grande_salle", date: arrival.iso8601, period: "journee" }],
+      meals:          [{ kind: "buffet", date: arrival.iso8601, people: 3 }],
+      space_billing:  { advance_amount: "50", deposit_amount: "200", payment_method: "bank_transfer" }
+    )
+    builder = Reservations::Builder.new(
+      draft: draft, admin: true, source: "manual",
+      price_override_cents: price_override_cents
+    )
+    builder.run!
+    builder.stay
+  end
+
+  subject(:draft) { described_class.call(stay: source) }
+
+  describe ".call — reconstruction de la composition" do
+    let(:source) { build_source_stay }
+
+    it "renvoie un Reservations::Draft" do
+      expect(draft).to be_a(Reservations::Draft)
+    end
+
+    it "conserve le client (prénom, nom, email)" do
+      expect(draft.first_name).to eq("Alice")
+      expect(draft.last_name).to eq("Martin")
+      expect(draft.email).to eq("alice@example.com")
+    end
+
+    it "conserve l'hébergement et son mode d'occupation" do
+      expect(draft.lodging_id).to eq(lodging.id)
+      expect(draft.booking_type).to eq("lodging")
+    end
+
+    it "conserve la composition espace + sa facturation" do
+      hall = draft.halls.first
+      expect(hall[:kind]).to eq("grande_salle")
+      expect(hall[:period]).to eq("journee")
+      # Facturation espace reconstruite depuis le SpaceBooking (acompte/caution/mode).
+      expect(draft.space_billing[:advance_amount]).to eq("50")
+      expect(draft.space_billing[:deposit_amount]).to eq("200")
+      expect(draft.space_billing[:payment_method]).to eq("bank_transfer")
+    end
+
+    it "conserve les repas (type + convives)" do
+      meal = draft.meals.first
+      expect(meal[:kind]).to eq("buffet")
+      expect(meal[:people]).to eq(3)
+    end
+  end
+
+  describe ".call — dates vidées (re-planification forcée, anti-surbooking)" do
+    let(:source) { build_source_stay }
+
+    it "n'emporte aucune date de séjour" do
+      expect(draft.arrival_date).to be_nil
+      expect(draft.departure_date).to be_nil
+    end
+
+    it "n'emporte aucune date d'élément (espace, repas)" do
+      expect(draft.halls.first[:date]).to be_blank
+      expect(draft.meals.first[:date]).to be_blank
+    end
+  end
+
+  describe ".call — paiements et prix imposé jamais copiés" do
+    # Source avec un prix imposé ET un paiement encaissé : la duplication ne doit
+    # ni figer le prix, ni reprendre le paiement.
+    let(:source) do
+      stay = build_source_stay(price_override_cents: 99_900)
+      Payment.create!(stay: stay, amount_cents: 10_000, status: "paid", payment_method: "card")
+      stay
+    end
+
+    it "reconstruite puis rebâtie avec de nouvelles dates → aucun paiement, pas d'override" do
+      # Le draft dupliqué ne porte pas de prix imposé (attribut absent du Draft) ;
+      # l'admin lui redonne de nouvelles dates — au niveau séjour ET des éléments
+      # datés (l'espace exige sa date) — et on le rebâtit comme une création normale.
+      new_day = Date.today + 60
+      draft.arrival_date   = new_day
+      draft.departure_date = new_day + 2
+      draft.halls = draft.halls.map { |h| h.merge(date: new_day.iso8601) }
+      draft.meals = draft.meals.map { |m| m.merge(date: new_day.iso8601) }
+
+      rebuilt = Reservations::Builder.new(draft: draft, admin: true, source: "manual")
+      rebuilt.run!
+      new_stay = rebuilt.stay
+
+      expect(new_stay.id).not_to eq(source.id)
+      expect(new_stay.payments).to be_empty
+      expect(new_stay.price_override_cents).to be_nil
+      # La composition, elle, est bien répliquée.
+      expect(new_stay.stay_items.where(bookable_type: "Booking")).to be_present
+      expect(new_stay.stay_items.where(bookable_type: "SpaceBooking")).to be_present
+      expect(new_stay.meal_orders).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Epic #81 — Phase 7 : commodités

PR **empilée sur #96** (Phase 6). Les deux commodités qui rendaient le canal direct encore attractif passent au séjour — dernier prérequis fonctionnel avant l'édition unifiée (Phase 8) et le retrait (Phase 9).

### Contenu
- **Saisie rapide datée** : les chips « H+ » / « E+ » du calendrier (affordances inchangées — tu les connais par cœur) pointent vers le **form séjour prérempli** : H+ → arrivée = jour cliqué, départ = lendemain ; E+ → ligne d'espace datée, sans dates de séjour (journée sèche légitime). **Plus aucun lien de création directe Booking/SpaceBooking depuis le calendrier.**
- **Duplication** : bouton « Dupliquer » (modale calendrier + page édition) → `Stays::DuplicateService` → **form NEW prérempli** : client présélectionné, composition complète (mode chambres, espaces + facturation, camping/van/repas/activités). **Exclus volontairement** : les dates (un clone aux mêmes dates surbookerait — re-planification forcée), les paiements, le prix imposé (devis recalculé). Pas de clone DB instantané, par conception.
- **Refactor** : `draft_from_stay` + 7 helpers extraits du contrôleur vers `Stays::DraftReconstructor` (partagé édition ↔ duplication).

### Bug attrapé par la passe navigateur
Le prérempli client de la duplication n'atterrissait que dans les champs masqués du panneau « Nouveau client » — soumission possible sans `customer_id`. Corrigé : le client source est **présélectionné dans « Client existant »** (le contrôleur customer-search affiche son libellé), spec ajoutée, revérifié au navigateur (« Test Chambres » affiché, select = bon id).

### Vérifications
- **RSpec : 753 examples, 0 failures** (+12).
- **Navigateur : 5/5 PASS après correctif** — 70 chips auditées au DOM (0 lien direct restant), préremplissages H+/E+/duplication exacts, panneau facturation masqué tant qu'aucun espace choisi, zéro erreur console.
- Frictions mineures relevées (liens overlay dupliqués pour lecteurs d'écran, logs debug résiduels en console) : pré-existantes, hors périmètre — notées pour plus tard.