### PR TITLE
Epic #81 Phase 8 — Édition unifiée : tous les chemins d'édition passent par le séjour

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -51,6 +51,15 @@ class BookingsController < BaseController
 
   def edit
     @booking = Booking.find_by!(id: params[:id])
+
+    # Édition unifiée (epic #81, Phase 8) : l'édition d'un booking passe désormais
+    # par le form séjour. Un vieux favori / lien email vers /bookings/:id/edit
+    # atterrit au bon endroit. Sans Stay vivant (backfill Phase 1 pas encore
+    # tourné en prod), on tombe sur l'écran legacy ci-dessous — fallback orphelin.
+    if (stay = @booking.stay)
+      return redirect_to edit_stay_path(stay)
+    end
+
     @booking.room_ids = @booking.reservations.map { |r| r.room_id }
     @booking.booking_type = @booking.lodging_id.nil? ? "rooms" : "lodging"
     @booking.tier_lodgings = @booking.tier_rooms = @booking.tier

--- a/app/controllers/space_bookings_controller.rb
+++ b/app/controllers/space_bookings_controller.rb
@@ -56,6 +56,14 @@ class SpaceBookingsController < BaseController
 
   def edit
     @space_booking = SpaceBooking.find_by!(id: params[:id])
+
+    # Édition unifiée (epic #81, Phase 8) : l'édition d'une résa d'espace passe
+    # désormais par le form séjour. Sans Stay vivant (backfill Phase 1 pas encore
+    # tourné en prod), on tombe sur l'écran legacy ci-dessous — fallback orphelin.
+    if (stay = @space_booking.stay)
+      return redirect_to edit_stay_path(stay)
+    end
+
     @space_booking.space_ids = @space_booking.space_reservations.map { |sr| sr.space_id }
     @spaces = Space.all
   end

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -242,6 +242,10 @@ class StaysController < BaseController
   # saisie datée d'un hébergement. À défaut, un draft vierge.
   def build_prefilled_draft
     if (source = duplicate_source)
+      # Le client du séjour source est PRÉSÉLECTIONNÉ dans le <select> « Client
+      # existant » (sinon le prérempli n'atterrissait que dans les champs masqués
+      # du panneau « Nouveau client » et une soumission partait sans customer_id).
+      @preselected_customer_id = source.customer_id
       return Stays::DuplicateService.call(stay: source)
     end
 
@@ -318,7 +322,7 @@ class StaysController < BaseController
     # Client existant : autocomplete via `customers/search` (issue #74). On ne
     # précharge plus TOUS les clients — seul le client courant (édition) alimente
     # le `<select>` de repli sans-JS. La recherche dynamique fait le reste.
-    @customers = Customer.where(id: @stay&.customer_id).to_a
+    @customers = Customer.where(id: [@stay&.customer_id, @preselected_customer_id].compact).to_a
     @assignable_availabilities = ExperienceAvailability.for_user(current_user)
                                                        .upcoming
                                                        .includes(:experience)

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -28,9 +28,16 @@ class StaysController < BaseController
   # (hébergement + activités), en réutilisant `Reservations::Builder` en mode
   # admin (aucun Stripe, aucun email forcé, force-dispo, statut au choix).
 
+  # Saisie rapide datée + duplication (epic #81, Phase 7). Le form NEW se
+  # préremplit selon les params :
+  #   - `duplicate_from` → reprise du séjour source (client + composition, sans
+  #     dates ni paiement ni prix imposé), via `Stays::DuplicateService` ;
+  #   - `date`           → arrivée = date, départ = date + 1 (1 nuit, hébergement) ;
+  #   - `date` + `space` → une ligne d'espace datée, SANS dates de séjour (journée
+  #     sèche : composition d'espace légitime).
   def new
     @stay  = Stay.new(status: "pending")
-    @draft = Reservations::Draft.new
+    @draft = build_prefilled_draft
     prepare_form
   end
 
@@ -60,7 +67,7 @@ class StaysController < BaseController
   end
 
   def edit
-    @draft = draft_from_stay(@stay)
+    @draft = Stays::DraftReconstructor.new(@stay).to_draft
     prepare_form
   end
 
@@ -230,6 +237,33 @@ class StaysController < BaseController
 
   private
 
+  # Draft de préremplissage du form NEW (epic #81, Phase 7). Trois cas, dans
+  # l'ordre de priorité : duplication d'un séjour, saisie datée d'un espace,
+  # saisie datée d'un hébergement. À défaut, un draft vierge.
+  def build_prefilled_draft
+    if (source = duplicate_source)
+      return Stays::DuplicateService.call(stay: source)
+    end
+
+    date = parse_form_date(params[:date])
+    return Reservations::Draft.new if date.nil?
+
+    if params[:space].present?
+      # Espace en journée sèche : une ligne d'espace datée, aucune date de séjour.
+      Reservations::Draft.new(halls: [{ date: date.iso8601 }])
+    else
+      # Hébergement : arrivée = date, départ = lendemain (1 nuit par défaut).
+      Reservations::Draft.new(arrival_date: date.iso8601, departure_date: (date + 1).iso8601)
+    end
+  end
+
+  # Séjour source d'une duplication (`duplicate_from`). nil si absent ou introuvable.
+  def duplicate_source
+    id = params[:duplicate_from]
+    return nil if id.blank?
+    Stay.find_by(id: id)
+  end
+
   # Séjours candidats à la fusion, préchargés pour éviter les N+1 des aperçus.
   def load_merge_stays
     ids = Array(params[:stay_ids]).map(&:to_i).uniq.reject(&:zero?)
@@ -386,110 +420,6 @@ class StaysController < BaseController
       next if kind.blank? || people < 1
       { kind: kind, date: row[:date].to_s.presence, people: people }
     end
-  end
-
-  # Reconstruit un draft depuis un séjour existant, pour préremplir le form edit.
-  def draft_from_stay(stay)
-    booking = stay.stay_items.where(bookable_type: "Booking").first&.bookable
-    # Chambres seules (epic #81, Phase 5) : rétablit le mode + les chambres
-    # cochées. La colonne `booking_type` fait foi ; dérivation des Reservation
-    # en secours pour le legacy (cf. Booking#rooms_mode?).
-    rooms_mode = booking&.rooms_mode?
-    Reservations::Draft.new(
-      lodging_id:     booking&.lodging_id,
-      booking_type:   rooms_mode ? "rooms" : "lodging",
-      room_ids:       rooms_mode ? booking.reservations.map(&:room_id).uniq : [],
-      arrival_date:   stay.arrival_date,
-      departure_date: stay.departure_date,
-      adults:         booking&.adults,
-      children:       booking&.children,
-      group_name:     booking&.group_name,
-      first_name:     stay.customer&.first_name,
-      last_name:      stay.customer&.last_name,
-      email:          stay.customer&.email,
-      phone:          stay.customer&.phone,
-      experiences:    stay.experience_bookings.active.map { |eb|
-        { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
-      },
-      halls:          halls_from_stay(stay),
-      campings:       campings_from_stay(stay),
-      vans:           vans_from_stay(stay),
-      meals:          meals_from_stay(stay),
-      space_billing:  space_billing_from_stay(stay)
-    )
-  end
-
-  # Facturation espace (epic #81, Phase 6) : reconstitue le sous-hash de
-  # facturation depuis le SpaceBooking du séjour, pour préremplir le form edit.
-  # nil si le séjour n'a pas d'espace. Les montants repassent en € (chaîne `%g`
-  # pour éviter les décimales parasites) — miroir du form direct `_payment`.
-  def space_billing_from_stay(stay)
-    sb = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
-    return nil if sb.nil?
-
-    {
-      advance_amount: euro_prefill(sb.advance_amount_cents),
-      deposit_amount: euro_prefill(sb.deposit_amount_cents),
-      payment_method: sb.payment_method,
-      event_id:       sb.event_id,
-      arrival_time:   sb.arrival_time,
-      departure_time: sb.departure_time
-    }
-  end
-
-  # Cents → chaîne € prête pour un number_field (nil si absent, "50" pas "50.0").
-  def euro_prefill(cents)
-    return nil if cents.nil?
-    format("%g", cents / 100.0)
-  end
-
-  # Reconstruit l'entrée camping {kind, people, nights} depuis le CampingBooking
-  # persisté, pour préremplir le form edit (nights déduit de la fenêtre).
-  def campings_from_stay(stay)
-    camping = stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
-    return [] if camping.nil?
-    nights = camping.from_date && camping.to_date ? (camping.to_date - camping.from_date).to_i : stay.experience_bookings.size
-    [{ kind: camping.kind, people: camping.people, nights: [nights, 1].max }]
-  end
-
-  # Reconstruit les entrées van (une par véhicule) depuis le VanBooking persisté.
-  def vans_from_stay(stay)
-    van = stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
-    return [] if van.nil?
-    nights = van.from_date && van.to_date ? (van.to_date - van.from_date).to_i : 1
-    Array.new([van.vehicles, 1].max) { { nights: [nights, 1].max } }
-  end
-
-  # Reconstruit les repas {kind, date, people} depuis les MealOrder du séjour.
-  def meals_from_stay(stay)
-    stay.meal_orders.map do |order|
-      { kind: order.kind, date: order.date&.iso8601, people: order.people }
-    end
-  end
-
-  # Reconstruit les lignes d'espaces {kind, date, period} d'un séjour depuis son
-  # SpaceBooking (réservations existantes), pour préremplir le form edit. Le nom
-  # de la Space est re-mappé vers sa clé de pricing (grande_salle, …).
-  def halls_from_stay(stay)
-    space_booking = stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
-    return [] if space_booking.nil?
-
-    space_booking.space_reservations.map do |res|
-      key = space_key_for(res.space)
-      next if key.nil?
-      { kind: key, date: res.date&.iso8601, period: res.duration }
-    end.compact
-  end
-
-  # `Space` → clé de pricing (inverse du mapping SpaceComposition). Résolution par
-  # le `code` stable d'abord (issue #75), puis repli sur le nom d'affichage.
-  def space_key_for(space)
-    return nil if space.nil?
-
-    by_code = SpaceComposition::SPACE_CODES_BY_KEY.find { |_key, code| code == space.code }&.first
-    return by_code if by_code
-
-    SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(space.name) }&.first
   end
 
   # Coordonnées client : soit un client existant sélectionné (on lit ses

--- a/app/services/stays/draft_reconstructor.rb
+++ b/app/services/stays/draft_reconstructor.rb
@@ -1,0 +1,131 @@
+module Stays
+  # Reconstruit un `Reservations::Draft` COMPLET depuis un séjour persisté, pour
+  # préremplir un formulaire (édition à l'identique, ou duplication après vidage
+  # des dates par `Stays::DuplicateService`).
+  #
+  # Extrait du contrôleur (epic #81, Phase 7) pour éviter la duplication de code :
+  # l'édition (dates conservées) et la duplication (dates vidées) partagent la
+  # MÊME reconstruction de composition. La seule vérité recomposée ici est la
+  # composition tarifable — jamais les paiements ni le prix imposé, absents du Draft.
+  class DraftReconstructor
+    def initialize(stay)
+      @stay = stay
+    end
+
+    def self.call(stay)
+      new(stay).to_draft
+    end
+
+    def to_draft
+      booking = lodging_booking
+      # Chambres seules (epic #81, Phase 5) : rétablit le mode + les chambres
+      # cochées. La colonne `booking_type` fait foi ; dérivation des Reservation
+      # en secours pour le legacy (cf. Booking#rooms_mode?).
+      rooms_mode = booking&.rooms_mode?
+      Reservations::Draft.new(
+        lodging_id:     booking&.lodging_id,
+        booking_type:   rooms_mode ? "rooms" : "lodging",
+        room_ids:       rooms_mode ? booking.reservations.map(&:room_id).uniq : [],
+        arrival_date:   @stay.arrival_date,
+        departure_date: @stay.departure_date,
+        adults:         booking&.adults,
+        children:       booking&.children,
+        group_name:     booking&.group_name,
+        first_name:     @stay.customer&.first_name,
+        last_name:      @stay.customer&.last_name,
+        email:          @stay.customer&.email,
+        phone:          @stay.customer&.phone,
+        experiences:    @stay.experience_bookings.active.map { |eb|
+          { id: eb.experience&.id, availability_id: eb.experience_availability_id, participants: eb.participants }
+        },
+        halls:          halls_from_stay,
+        campings:       campings_from_stay,
+        vans:           vans_from_stay,
+        meals:          meals_from_stay,
+        space_billing:  space_billing_from_stay
+      )
+    end
+
+    private
+
+    def lodging_booking
+      @stay.stay_items.where(bookable_type: "Booking").first&.bookable
+    end
+
+    def space_booking
+      @stay.stay_items.where(bookable_type: "SpaceBooking").first&.bookable
+    end
+
+    # Facturation espace (epic #81, Phase 6) : reconstitue le sous-hash de
+    # facturation depuis le SpaceBooking du séjour. nil si le séjour n'a pas
+    # d'espace. Les montants repassent en € (chaîne `%g` pour éviter les décimales
+    # parasites) — miroir du form direct `_payment`.
+    def space_billing_from_stay
+      sb = space_booking
+      return nil if sb.nil?
+
+      {
+        advance_amount: euro_prefill(sb.advance_amount_cents),
+        deposit_amount: euro_prefill(sb.deposit_amount_cents),
+        payment_method: sb.payment_method,
+        event_id:       sb.event_id,
+        arrival_time:   sb.arrival_time,
+        departure_time: sb.departure_time
+      }
+    end
+
+    # Cents → chaîne € prête pour un number_field (nil si absent, "50" pas "50.0").
+    def euro_prefill(cents)
+      return nil if cents.nil?
+      format("%g", cents / 100.0)
+    end
+
+    # Reconstruit l'entrée camping {kind, people, nights} depuis le CampingBooking
+    # persisté (nights déduit de la fenêtre).
+    def campings_from_stay
+      camping = @stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
+      return [] if camping.nil?
+      nights = camping.from_date && camping.to_date ? (camping.to_date - camping.from_date).to_i : @stay.experience_bookings.size
+      [{ kind: camping.kind, people: camping.people, nights: [nights, 1].max }]
+    end
+
+    # Reconstruit les entrées van (une par véhicule) depuis le VanBooking persisté.
+    def vans_from_stay
+      van = @stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
+      return [] if van.nil?
+      nights = van.from_date && van.to_date ? (van.to_date - van.from_date).to_i : 1
+      Array.new([van.vehicles, 1].max) { { nights: [nights, 1].max } }
+    end
+
+    # Reconstruit les repas {kind, date, people} depuis les MealOrder du séjour.
+    def meals_from_stay
+      @stay.meal_orders.map do |order|
+        { kind: order.kind, date: order.date&.iso8601, people: order.people }
+      end
+    end
+
+    # Reconstruit les lignes d'espaces {kind, date, period} depuis le SpaceBooking.
+    # Le nom de la Space est re-mappé vers sa clé de pricing (grande_salle, …).
+    def halls_from_stay
+      sb = space_booking
+      return [] if sb.nil?
+
+      sb.space_reservations.map do |res|
+        key = space_key_for(res.space)
+        next if key.nil?
+        { kind: key, date: res.date&.iso8601, period: res.duration }
+      end.compact
+    end
+
+    # `Space` → clé de pricing (inverse du mapping SpaceComposition). Résolution par
+    # le `code` stable d'abord (issue #75), puis repli sur le nom d'affichage.
+    def space_key_for(space)
+      return nil if space.nil?
+
+      by_code = SpaceComposition::SPACE_CODES_BY_KEY.find { |_key, code| code == space.code }&.first
+      return by_code if by_code
+
+      SpaceComposition::SPACE_NAMES_BY_KEY.find { |_key, names| names.include?(space.name) }&.first
+    end
+  end
+end

--- a/app/services/stays/duplicate_service.rb
+++ b/app/services/stays/duplicate_service.rb
@@ -1,0 +1,60 @@
+module Stays
+  # Duplication de séjour (epic #81, Phase 7).
+  #
+  # CHOIX D'ARCHITECTURE — pas de clone DB instantané. La duplication NE crée
+  # RIEN en base : elle renvoie un `Reservations::Draft` prérempli depuis le
+  # séjour source, destiné à alimenter le formulaire NEW. L'admin choisit de
+  # NOUVELLES dates puis soumet — c'est la création normale (`Reservations::
+  # Builder`) qui persiste. Pourquoi repasser par le form plutôt que cloner
+  # directement :
+  #   - un clone immédiat aux MÊMES dates surbookerait l'hébergement ET les
+  #     espaces (le veto de dispo compte les Reservation/SpaceReservation) ;
+  #   - les paiements déjà encaissés sur la source n'ont pas eu lieu sur le clone ;
+  #   - un prix imposé figé ne vaut plus pour un séjour à d'autres dates.
+  # On délègue donc la décision de dates/prix à l'admin, via le form.
+  #
+  # COPIÉ : client + composition (hébergement/mode chambres, espaces + facturation,
+  # camping, van, repas, activités réutilisables) — tout ce que
+  # `Stays::DraftReconstructor` sait reconstruire.
+  # EXCLU :
+  #   - toutes les dates (séjour ET éléments datés espace/repas) → re-planification
+  #     forcée, anti-surbooking ;
+  #   - les paiements → jamais reconstruits par le Draft, et le canal admin n'en
+  #     crée aucun à la création ;
+  #   - le prix imposé → absent du Draft ; le devis B2C se recalcule et l'admin le
+  #     re-saisira si besoin.
+  # Le statut du séjour dupliqué reste « pending » (défaut du form NEW).
+  class DuplicateService
+    def self.call(stay:)
+      new(stay: stay).call
+    end
+
+    def initialize(stay:)
+      @stay = stay
+    end
+
+    def call
+      draft = DraftReconstructor.new(@stay).to_draft
+      blank_all_dates!(draft)
+      draft
+    end
+
+    private
+
+    # Vide TOUTES les dates du draft : niveau séjour (arrivée/départ) et niveau
+    # élément (espaces, repas). L'admin re-date l'ensemble depuis le form.
+    def blank_all_dates!(draft)
+      draft.arrival_date   = nil
+      draft.departure_date = nil
+      draft.halls = strip_dates(draft.halls)
+      draft.meals = strip_dates(draft.meals)
+    end
+
+    def strip_dates(rows)
+      Array(rows).map do |row|
+        row = row.symbolize_keys if row.respond_to?(:symbolize_keys)
+        row.merge(date: nil)
+      end
+    end
+  end
+end

--- a/app/views/bookings/_table.html.slim
+++ b/app/views/bookings/_table.html.slim
@@ -23,9 +23,12 @@
             = booking.status_emoji
           td.py-4.px-6.font-medium.text-gray-900.whitespace-nowrap[scope="row"]
             strong(class="#{booking.declined? ? "line-through" : nil}")
-              = link_to booking.group_or_name, 
-                        booking_path(booking),
-                        class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700 focus:text-blue-700"
+              / Édition unifiée (epic #81, Phase 8) : la liste renvoie vers le form
+              / séjour quand un Stay vivant existe ; sinon fiche booking legacy.
+              - if (stay = booking.stay)
+                = link_to booking.group_or_name, edit_stay_path(stay), class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700 focus:text-blue-700"
+              - else
+                = link_to booking.group_or_name, booking_path(booking), class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700 focus:text-blue-700"
             .mt-1.text-gray-900
               = booking.date_range
           td.py-4.px-6.hidden.md:table-cell

--- a/app/views/bookings/show.html.slim
+++ b/app/views/bookings/show.html.slim
@@ -1,4 +1,8 @@
 - content_for :page_header do
+  / Édition unifiée (epic #81, Phase 8) : « Mettre à jour » passe par le form
+  / séjour quand un Stay vivant existe. Sinon, lien legacy (fallback orphelin —
+  / disparaît après le backfill Phase 1).
+  - edit_path = @booking.stay ? edit_stay_path(@booking.stay) : edit_booking_path(@booking)
   = render 'layouts/components/page_header',
            title: @booking.name,
            secondary: "Du #{@booking.from_date} au #{@booking.to_date}",
@@ -8,7 +12,7 @@
              delete_link(@booking.object, "Supprimer cette réservation"),
              link_to( \
                "Mettre à jour",
-               edit_booking_path(@booking),
+               edit_path,
                class: "btn-page-header" \
              ) \
            ] : nil

--- a/app/views/pages/calendar/_bookings.html.slim
+++ b/app/views/pages/calendar/_bookings.html.slim
@@ -41,9 +41,12 @@
         .block.min-w-0.w-full
           div.min-w-0
             strong.block.min-w-0.break-words
-              = link_to space_booking.decorate.group_or_name.html_safe,
-                        space_booking_path(space_booking),
-                        class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+              / Édition unifiée (epic #81, Phase 8) : avec un séjour vivant, le lien
+              / ouvre la modale séjour (comme l'overlay). Sinon, lien espace legacy.
+              - if stay
+                = link_to space_booking.decorate.group_or_name.html_safe, stay_path(stay), data: { action: "stay-details#open" }, class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+              - else
+                = link_to space_booking.decorate.group_or_name.html_safe, space_booking_path(space_booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
             - if space_booking.event.presence
               .text-gray-500.leading-none.mb-2.font-semibold = space_booking.event.name_with_color
 

--- a/app/views/pages/calendar/_day_bookings.html.slim
+++ b/app/views/pages/calendar/_day_bookings.html.slim
@@ -23,9 +23,12 @@
       .block.min-w-0.w-full
         div.min-w-0
           strong.block.min-w-0.break-words
-            = link_to booking.decorate.group_or_name.html_safe,
-                      booking_path(booking),
-                      class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+            / Édition unifiée (epic #81, Phase 8) : avec un séjour vivant, le lien
+            / ouvre la modale séjour (comme l'overlay). Sinon, lien booking legacy.
+            - if stay
+              = link_to booking.decorate.group_or_name.html_safe, stay_path(stay), data: { action: "stay-details#open" }, class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+            - else
+              = link_to booking.decorate.group_or_name.html_safe, booking_path(booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
 
           span.text-gray-500 =< booking.dates_counter(date)
 

--- a/app/views/pages/day.html.slim
+++ b/app/views/pages/day.html.slim
@@ -73,10 +73,12 @@
                     - @room_reservations.where(room: room).each do |reservation|
                       .grid.grid-cols-3.gap-4
                         div
-                          = link_to reservation.booking.group_or_name, 
-                                    booking_path(reservation.booking),
-                                    data: { "turbo-frame": "_top" },
-                                    class: "claudy-link"
+                          / Édition unifiée (epic #81, Phase 8) : hors modale, on
+                          / renvoie vers le form séjour ; sinon fiche booking legacy.
+                          - if (stay = reservation.booking.stay)
+                            = link_to reservation.booking.group_or_name, edit_stay_path(stay), data: { "turbo-frame": "_top" }, class: "claudy-link"
+                          - else
+                            = link_to reservation.booking.group_or_name, booking_path(reservation.booking), data: { "turbo-frame": "_top" }, class: "claudy-link"
                         div
                           = reservation.booking.people_emojis
                         .text-right
@@ -104,10 +106,12 @@
                     - @room_reservations.where(room: room).each do |reservation|
                       .grid.grid-cols-3.gap-4
                         div
-                          = link_to reservation.booking.group_or_name, 
-                                    booking_path(reservation.booking),
-                                    data: { "turbo-frame": "_top" },
-                                    class: "claudy-link"
+                          / Édition unifiée (epic #81, Phase 8) : hors modale, on
+                          / renvoie vers le form séjour ; sinon fiche booking legacy.
+                          - if (stay = reservation.booking.stay)
+                            = link_to reservation.booking.group_or_name, edit_stay_path(stay), data: { "turbo-frame": "_top" }, class: "claudy-link"
+                          - else
+                            = link_to reservation.booking.group_or_name, booking_path(reservation.booking), data: { "turbo-frame": "_top" }, class: "claudy-link"
                         div
                           = reservation.booking.people_emojis
                         .text-right
@@ -135,10 +139,12 @@
                     - @room_reservations.where(room: room).each do |reservation|
                       .grid.grid-cols-3.gap-4
                         div
-                          = link_to reservation.booking.group_or_name, 
-                                    booking_path(reservation.booking),
-                                    data: { "turbo-frame": "_top" },
-                                    class: "claudy-link"
+                          / Édition unifiée (epic #81, Phase 8) : hors modale, on
+                          / renvoie vers le form séjour ; sinon fiche booking legacy.
+                          - if (stay = reservation.booking.stay)
+                            = link_to reservation.booking.group_or_name, edit_stay_path(stay), data: { "turbo-frame": "_top" }, class: "claudy-link"
+                          - else
+                            = link_to reservation.booking.group_or_name, booking_path(reservation.booking), data: { "turbo-frame": "_top" }, class: "claudy-link"
                         div
                           = reservation.booking.people_emojis
                         .text-right
@@ -175,10 +181,12 @@
                     - @space_reservations.where(space: space).each do |space_reservation|
                       .grid.grid-cols-3.gap-4
                         div
-                          = link_to space_reservation.space_booking.group_or_name, 
-                                    space_booking_path(space_reservation.space_booking), 
-                                    data: { "turbo-frame": "_top" },
-                                    class: "claudy-link"
+                          / Édition unifiée (epic #81, Phase 8) : hors modale, on
+                          / renvoie vers le form séjour ; sinon fiche espace legacy.
+                          - if (stay = space_reservation.space_booking.stay)
+                            = link_to space_reservation.space_booking.group_or_name, edit_stay_path(stay), data: { "turbo-frame": "_top" }, class: "claudy-link"
+                          - else
+                            = link_to space_reservation.space_booking.group_or_name, space_booking_path(space_reservation.space_booking), data: { "turbo-frame": "_top" }, class: "claudy-link"
                         div
                           = space_reservation.space_booking.duration
                         .text-right

--- a/app/views/pages/other_bookings.html.slim
+++ b/app/views/pages/other_bookings.html.slim
@@ -17,10 +17,13 @@
                 div(class="flex mt-2 py-1 px-2 #{booking.calendar_class}")
                   .block
                     div
-                      strong 
-                        = link_to booking.decorate.name.html_safe, 
-                                  booking_path(booking), 
-                                  class: "text-blue-700 hover:text-blue-900 focus:text-blue-900"
+                      strong
+                        / Édition unifiée (epic #81, Phase 8) : hors modale, on renvoie
+                        / vers le form séjour ; sinon fiche booking legacy.
+                        - if (stay = booking.stay)
+                          = link_to booking.decorate.name.html_safe, edit_stay_path(stay), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900"
+                        - else
+                          = link_to booking.decorate.name.html_safe, booking_path(booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900"
                       - if booking.group_name.present?
                         .text-gray-500.leading-none.mb-2 = booking.group_name
 

--- a/app/views/pages/other_space_bookings.html.slim
+++ b/app/views/pages/other_space_bookings.html.slim
@@ -17,10 +17,13 @@
                 div(class="flex mt-2 py-1 px-2 #{space_booking.calendar_class}")
                   .block
                     div
-                      strong 
-                        = link_to space_booking.decorate.name.html_safe, 
-                                  space_booking_path(space_booking), 
-                                  class: "text-blue-700 hover:text-blue-900 focus:text-blue-900"
+                      strong
+                        / Édition unifiée (epic #81, Phase 8) : hors modale, on renvoie
+                        / vers le form séjour ; sinon fiche espace legacy.
+                        - if (stay = space_booking.stay)
+                          = link_to space_booking.decorate.name.html_safe, edit_stay_path(stay), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900"
+                        - else
+                          = link_to space_booking.decorate.name.html_safe, space_booking_path(space_booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900"
                       - if space_booking.group_name.present?
                         .text-gray-500.leading-none.mb-2 = space_booking.group_name
 

--- a/app/views/simple_calendar/_dashboard_calendar.html.erb
+++ b/app/views/simple_calendar/_dashboard_calendar.html.erb
@@ -115,8 +115,9 @@
 
                   <div class="flex">
                     <% if Date.today <= day %>
-                      <%= link_to "H+", new_booking_path(date: day.strftime("%Y-%m-%d")), class: "mr-2 text-blue-700 hover:text-blue-900" %>
-                      <%= link_to "E+", new_space_booking_path(date: day.strftime("%Y-%m-%d")), class: "mr-2 text-blue-700 hover:text-blue-900" %>
+                      <%# Saisie rapide datée (epic #81, Phase 7) : les chips H+/E+ pointent désormais vers le form SÉJOUR prérempli à la date cliquée (plus de création directe Booking/SpaceBooking depuis le calendrier). %>
+                      <%= link_to "H+", new_stay_path(date: day.iso8601), title: "Nouveau séjour hébergement à cette date", class: "mr-2 text-blue-700 hover:text-blue-900" %>
+                      <%= link_to "E+", new_stay_path(date: day.iso8601, space: 1), title: "Nouveau séjour espace à cette date", class: "mr-2 text-blue-700 hover:text-blue-900" %>
                     <% end %>
 
                     <%= link_to new_note_path(date: day.strftime("%Y-%m-%d")), data: { turbo_frame: "modal" } do %>

--- a/app/views/space_bookings/_table.html.slim
+++ b/app/views/space_bookings/_table.html.slim
@@ -27,9 +27,12 @@
             = space_booking.status_emoji
           td.py-4.px-6.font-medium.text-gray-900.whitespace-nowrap[scope="row"]
             strong(class="#{space_booking.declined? ? "line-through" : nil}")
-              = link_to space_booking.group_or_name, 
-                        space_booking_path(space_booking),
-                        class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700 focus:text-blue-700"
+              / Édition unifiée (epic #81, Phase 8) : la liste renvoie vers le form
+              / séjour quand un Stay vivant existe ; sinon fiche espace legacy.
+              - if (stay = space_booking.stay)
+                = link_to space_booking.group_or_name, edit_stay_path(stay), class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700 focus:text-blue-700"
+              - else
+                = link_to space_booking.group_or_name, space_booking_path(space_booking), class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700 focus:text-blue-700"
             .md:hidden.mt-1.text-gray-900
               = space_booking.date_range
           / td.py-4.px-6

--- a/app/views/space_bookings/past.html.slim
+++ b/app/views/space_bookings/past.html.slim
@@ -33,8 +33,13 @@
         tr.border-b(class="#{space_booking.tr_class}")
           td.py-4.px-6.font-medium.text-gray-900.whitespace-nowrap(class="#{space_booking.tr_border_class}")
             strong
-              = link_to space_booking.name, 
-                        space_booking_path(space_booking)
+              / Édition unifiée (epic #81, Phase 8) : renvoie vers le form séjour
+              / quand un Stay vivant existe ; sinon fiche espace legacy. Parité avec
+              / bookings/past (repointée via le partial _table partagé).
+              - if (stay = space_booking.stay)
+                = link_to space_booking.name, edit_stay_path(stay)
+              - else
+                = link_to space_booking.name, space_booking_path(space_booking)
             - if space_booking.group_name.present?
               .text-gray-500 = space_booking.group_name
           td.py-4.px-6

--- a/app/views/space_bookings/show.html.slim
+++ b/app/views/space_bookings/show.html.slim
@@ -1,4 +1,8 @@
 - content_for :page_header do
+  / Édition unifiée (epic #81, Phase 8) : « Mettre à jour » passe par le form
+  / séjour quand un Stay vivant existe. Sinon, lien legacy (fallback orphelin —
+  / disparaît après le backfill Phase 1).
+  - edit_path = @space_booking.stay ? edit_stay_path(@space_booking.stay) : edit_space_booking_path(@space_booking)
   = render 'layouts/components/page_header',
            title: @space_booking.group_or_name,
            secondary: "Du #{@space_booking.from_date} au #{@space_booking.to_date}",
@@ -8,7 +12,7 @@
              delete_link(@space_booking.object, "Supprimer cette réservation"),
              link_to( \
                "Mettre à jour",
-               edit_space_booking_path(@space_booking),
+               edit_path,
                class: "btn-page-header" \
              ) \
            ] : nil

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -8,6 +8,9 @@ div id="stay-details-#{@stay.id}"
       .flex.items-center.gap-2
         = @stay.platform_badge
         = @stay.status_badge
+        / Duplication (epic #81, Phase 7) : ouvre le form NEW prérempli depuis ce
+        / séjour (client + composition), dates/paiement/prix imposé exclus.
+        = link_to "Dupliquer", new_stay_path(duplicate_from: @stay.id), title: "Dupliquer ce séjour (nouvelles dates à choisir)", class: "text-sm font-medium text-gray-500 hover:text-gray-700 hover:underline"
         = link_to "Modifier le séjour", edit_stay_path(@stay), class: "text-sm font-medium text-indigo-600 hover:underline"
 
     / Actions rapides (issue #76) : bascule de statut + accès solde, sans ouvrir

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -1,6 +1,7 @@
 / Formulaire CRUD Séjour admin (epic #66, Phase 1). Locals : url, method, submit_label.
 / Champs sous le namespace `stay[...]`. Devis B2C forfaitaire (PricingModel).
-- selected_customer_id = @stay.persisted? ? @stay.customer_id : nil
+/ Duplication (epic #81, Phase 7) : le client du séjour source est présélectionné.
+- selected_customer_id = (@stay.persisted? ? @stay.customer_id : nil) || @preselected_customer_id
 - current_status = (@stay.status.presence || "pending")
 - selected_experiences = {}
 - Array(@draft&.experiences).each { |e| selected_experiences[e[:availability_id].to_i] = e[:participants] }

--- a/app/views/stays/edit.html.slim
+++ b/app/views/stays/edit.html.slim
@@ -3,5 +3,9 @@
     div
       h1.text-xl.font-semibold.text-gray-900 = "Modifier le séjour ##{@stay.id}"
       p.mt-1.text-sm.text-gray-600 Modifiez la composition du séjour (hébergement + activités). Aucun paiement n'est déclenché.
-    = button_to "Supprimer le séjour", stay_path(@stay), method: :delete, data: { turbo_confirm: "Supprimer ce séjour ? Cette action est réversible (soft-delete)." }, class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+    .flex.items-center.gap-2
+      / Duplication (epic #81, Phase 7) : form NEW prérempli depuis ce séjour,
+      / dates/paiement/prix imposé exclus.
+      = link_to "Dupliquer", new_stay_path(duplicate_from: @stay.id), title: "Dupliquer ce séjour (nouvelles dates à choisir)", class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      = button_to "Supprimer le séjour", stay_path(@stay), method: :delete, data: { turbo_confirm: "Supprimer ce séjour ? Cette action est réversible (soft-delete)." }, class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
   = render "form", url: stay_path(@stay), method: :patch, submit_label: "Enregistrer les modifications"

--- a/spec/requests/calendar_stay_modal_spec.rb
+++ b/spec/requests/calendar_stay_modal_spec.rb
@@ -49,10 +49,15 @@ RSpec.describe "Calendrier — modale séjour depuis les blocs (epic #66, Phase 
 
       get "/"
 
-      expect(response.body).to include('data-action="stay-details#open"')
-      expect(response.body).to include("href=\"#{stay_path(stay)}\"")
-      # Le lien historique reste présent (anti-régression Phase 4).
-      expect(response.body).to include(booking_path(booking))
+      # On borne les assertions à la GRILLE (avant le flux « Activité récente »,
+      # qui garde légitimement son lien booking historique — hors scope Phase 8).
+      grid = response.body.split("Activité récente").first
+
+      expect(grid).to include('data-action="stay-details#open"')
+      expect(grid).to include("href=\"#{stay_path(stay)}\"")
+      # Édition unifiée (epic #81, Phase 8) : le lien booking legacy a disparu du
+      # bloc dès qu'un séjour vivant le porte — le nom pointe vers la modale.
+      expect(grid).not_to include(booking_path(booking))
     end
   end
 
@@ -68,9 +73,11 @@ RSpec.describe "Calendrier — modale séjour depuis les blocs (epic #66, Phase 
 
       get "/"
 
-      expect(response.body).to include("href=\"#{stay_path(stay)}\"")
-      # Lien historique espace conservé.
-      expect(response.body).to include(space_booking_path(space_booking))
+      grid = response.body.split("Activité récente").first
+      expect(grid).to include("href=\"#{stay_path(stay)}\"")
+      # Édition unifiée (epic #81, Phase 8) : le lien espace legacy a disparu du
+      # bloc dès qu'un séjour vivant le porte.
+      expect(grid).not_to include(space_booking_path(space_booking))
     end
   end
 

--- a/spec/requests/calendar_stays_grouping_spec.rb
+++ b/spec/requests/calendar_stays_grouping_spec.rb
@@ -89,13 +89,18 @@ RSpec.describe "Calendrier — regroupement par séjour (epic #66, Phase 4)", ty
   describe "occupations chambres — anti-régression veto Grand-Duc" do
     it "rend toujours un bloc par jour réservé avec le badge chambre" do
       from = Date.today.next_occurring(:friday)
-      _stay, booking = stay_with_lodging(from: from, to: from + 2)
+      stay, booking = stay_with_lodging(from: from, to: from + 2)
 
       get "/"
 
       # Deux nuits réservées → deux entrées jour (la source de vérité du veto).
       expect(response.body.scan("data-booking-day-entry=\"#{booking.id}\"").size).to eq(2)
-      expect(response.body).to include(booking_path(booking))
+      # Édition unifiée (epic #81, Phase 8) : le bloc pointe vers la modale séjour,
+      # plus vers la fiche booking legacy. On borne à la grille (le flux d'activité,
+      # hors scope, garde son lien booking historique).
+      grid = response.body.split("Activité récente").first
+      expect(grid).to include(stay_path(stay))
+      expect(grid).not_to include(booking_path(booking))
     end
 
     it "retombe sur la couleur historique (par type) pour un booking SANS séjour" do

--- a/spec/requests/stays_quick_create_spec.rb
+++ b/spec/requests/stays_quick_create_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+# Epic #81, Phase 7 — Saisie rapide datée depuis le calendrier + duplication.
+#
+# A. Le form NEW lit `date`/`space`/`duplicate_from` et se préremplit :
+#    - `date`               → arrivée = date, départ = date + 1 (hébergement) ;
+#    - `date` + `space=1`   → une ligne d'espace datée, SANS dates de séjour ;
+#    - `duplicate_from`     → client + composition du séjour source, dates VIDES.
+# B. La modale du calendrier expose un bouton « Dupliquer » vers ce form.
+RSpec.describe "Stays — saisie rapide datée & duplication (epic #81, Phase 7)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-quick-create@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:lodging)      { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+  let(:date)          { Date.today + 30 }
+
+  describe "GET /stays/new?date=… — préremplissage hébergement" do
+    it "préremplit l'arrivée à la date et le départ au lendemain (1 nuit)" do
+      get new_stay_path(date: date.iso8601)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match(/name="stay\[arrival_date\]"[^>]*value="#{date.iso8601}"/)
+      expect(response.body).to match(/name="stay\[departure_date\]"[^>]*value="#{(date + 1).iso8601}"/)
+    end
+  end
+
+  describe "GET /stays/new?date=…&space=1 — préremplissage espace daté" do
+    it "ouvre une ligne d'espace datée, SANS dates de séjour" do
+      get new_stay_path(date: date.iso8601, space: 1)
+      expect(response).to have_http_status(:ok)
+      # Une ligne d'espace porte la date cliquée.
+      expect(response.body).to match(/name="stay\[halls\]\[0\]\[date\]"[^>]*value="#{date.iso8601}"/)
+      # Aucune date de séjour (journée sèche : l'admin ne saisit pas de nuitée).
+      expect(response.body).not_to match(/name="stay\[arrival_date\]"[^>]*value="\d/)
+      expect(response.body).not_to match(/name="stay\[departure_date\]"[^>]*value="\d/)
+    end
+  end
+
+  describe "GET /stays/new?duplicate_from=… — préremplissage par duplication" do
+    let!(:source) do
+      draft = Reservations::Draft.new(
+        lodging_id:     lodging.id,
+        arrival_date:   date,
+        departure_date: date + 2,
+        adults:         2,
+        dogs_count:     0,
+        first_name:     "Alice",
+        last_name:      "Martin",
+        email:          "alice@example.com",
+        phone:          "0470111222",
+        halls:          [{ kind: "grande_salle", date: date.iso8601, period: "journee" }],
+        meals:          [{ kind: "buffet", date: date.iso8601, people: 3 }]
+      )
+      builder = Reservations::Builder.new(draft: draft, admin: true, source: "manual", price_override_cents: 88_800)
+      builder.run!
+      builder.stay
+    end
+
+    it "reprend le client et la composition, mais laisse les dates vides" do
+      get new_stay_path(duplicate_from: source.id)
+      expect(response).to have_http_status(:ok)
+
+      # Client conservé (nom pré-rempli dans le panneau « nouveau client » de repli).
+      expect(response.body).to include('value="Alice"')
+      expect(response.body).to include('value="Martin"')
+      # Composition conservée : hébergement présélectionné + une ligne d'espace.
+      expect(response.body).to match(/selected="selected" value="#{lodging.id}"/)
+      expect(response.body).to match(/selected="selected" value="grande_salle"/)
+
+      # Dates de séjour VIDES (un clone aux mêmes dates surbookerait).
+      expect(response.body).not_to match(/name="stay\[arrival_date\]"[^>]*value="\d/)
+      expect(response.body).not_to match(/name="stay\[departure_date\]"[^>]*value="\d/)
+      # Prix imposé NON copié (champ vide malgré l'override du séjour source).
+      expect(response.body).not_to match(/name="stay\[price_override\]"[^>]*value="\d/)
+    end
+  end
+
+  describe "modale séjour — bouton Dupliquer" do
+    let!(:stay) do
+      draft = Reservations::Draft.new(
+        lodging_id: lodging.id, arrival_date: date, departure_date: date + 1,
+        adults: 2, dogs_count: 0,
+        first_name: "Bob", last_name: "Durand", email: "bob@example.com", phone: "0470999888"
+      )
+      builder = Reservations::Builder.new(draft: draft, admin: true, source: "manual")
+      builder.run!
+      builder.stay
+    end
+
+    it "affiche un lien Dupliquer vers le form NEW prérempli" do
+      get stay_path(stay)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(new_stay_path(duplicate_from: stay.id))
+      expect(response.body).to include("Dupliquer")
+    end
+  end
+end

--- a/spec/requests/stays_quick_create_spec.rb
+++ b/spec/requests/stays_quick_create_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe "Stays — saisie rapide datée & duplication (epic #81, Phase 7)
       # Client conservé (nom pré-rempli dans le panneau « nouveau client » de repli).
       expect(response.body).to include('value="Alice"')
       expect(response.body).to include('value="Martin"')
+      # …et surtout PRÉSÉLECTIONNÉ dans le <select> « Client existant » (passe
+      # navigateur Phase 7) : sans ça, la soumission partait en mode « existant »
+      # avec customer_id vide.
+      expect(response.body).to match(/name="stay\[customer_id\]".*?<option selected[^>]*value="#{source.customer_id}"/m)
       # Composition conservée : hébergement présélectionné + une ligne d'espace.
       expect(response.body).to match(/selected="selected" value="#{lodging.id}"/)
       expect(response.body).to match(/selected="selected" value="grande_salle"/)

--- a/spec/requests/unified_edit_consultation_spec.rb
+++ b/spec/requests/unified_edit_consultation_spec.rb
@@ -1,0 +1,172 @@
+require "rails_helper"
+
+# Epic #81, Phase 8 — Édition unifiée, liens de CONSULTATION sur les pages SANS
+# la modale séjour (day, index). Décision : ces pages renvoient vers le form
+# séjour (`edit_stay_path`, page pleine avec layout) quand un Stay VIVANT porte
+# le record — `stays#show` rend un fragment sans layout, inexploitable en
+# navigation directe, et le form séjour EST le point d'entrée unifié de l'epic.
+# Sans Stay (backfill Phase 1 pas encore tourné), lien legacy conservé — et
+# aucune page ne rend de lien mort.
+RSpec.describe "Édition unifiée — consultation hors modale (epic #81, Phase 8)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user)    { User.create!(email: "agent-unified-conso@les4sources.be", password: "password123") }
+  let(:lodging) { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+  let(:room) do
+    # `code` valide : la vue jour rend l'image `images/rooms/#{code}.jpg` (présente
+    # dans le manifest vite-test).
+    r = Room.create!(name: "Chambre 1", level: 1, code: "BAL")
+    lodging.rooms << r
+    r
+  end
+  let(:space) { Space.create!(name: "Grande Salle", capacity: 40) }
+
+  before { sign_in user }
+
+  def confirmed_booking(from:, to:)
+    booking = Booking.create!(firstname: "Alex", group_name: "Groupe", lodging: lodging,
+                              from_date: from, to_date: to, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0)
+    (from...to).each { |date| Reservation.create!(booking: booking, room: room, date: date) }
+    booking
+  end
+
+  def confirmed_space_booking(on:)
+    sb = SpaceBooking.create!(firstname: "Alex", group_name: "Groupe", tier: "neutre",
+                              from_date: on, to_date: on, status: "confirmed")
+    SpaceReservation.create!(space: space, space_booking: sb, date: on)
+    sb
+  end
+
+  describe "vue jour (pages#day)" do
+    it "renvoie le lien d'un booking à séjour vers le form séjour (pas la fiche legacy)" do
+      from = Date.today.next_occurring(:friday)
+      booking = confirmed_booking(from: from, to: from + 1)
+      stay = Stays::EnsureForBooking.call(booking)
+
+      get day_details_path(date: from.iso8601)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(booking_path(booking))
+    end
+
+    it "garde le lien booking legacy quand le booking n'a pas de séjour" do
+      from = Date.today.next_occurring(:friday)
+      booking = confirmed_booking(from: from, to: from + 1)
+
+      get day_details_path(date: from.iso8601)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(booking_path(booking))
+    end
+
+    it "renvoie le lien d'une résa d'espace à séjour vers le form séjour" do
+      from = Date.today.next_occurring(:friday)
+      sb = confirmed_space_booking(on: from)
+      stay = Stays::EnsureForSpaceBooking.call(sb)
+
+      get day_details_path(date: from.iso8601)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(space_booking_path(sb))
+    end
+
+    it "garde le lien espace legacy quand la résa d'espace n'a pas de séjour" do
+      from = Date.today.next_occurring(:friday)
+      sb = confirmed_space_booking(on: from)
+
+      get day_details_path(date: from.iso8601)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(space_booking_path(sb))
+    end
+  end
+
+  describe "index hébergements (bookings#index)" do
+    it "renvoie un booking à séjour vers le form séjour (pas la fiche legacy)" do
+      from = Date.today.next_occurring(:friday)
+      booking = confirmed_booking(from: from, to: from + 2)
+      stay = Stays::EnsureForBooking.call(booking)
+
+      get bookings_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(booking_path(booking))
+    end
+
+    it "garde le lien legacy pour un booking sans séjour (aucun lien mort)" do
+      from = Date.today.next_occurring(:friday)
+      booking = confirmed_booking(from: from, to: from + 2)
+
+      get bookings_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(booking_path(booking))
+    end
+  end
+
+  describe "toast « autres réservations » (pages#other_bookings)" do
+    it "renvoie un booking à séjour vers le form séjour" do
+      from = Date.today.next_occurring(:friday)
+      other = confirmed_booking(from: from, to: from + 2)
+      stay = Stays::EnsureForBooking.call(other)
+
+      get "/pages/other_bookings", params: { from_date: from.iso8601, to_date: (from + 2).iso8601, booking_id: 0 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(booking_path(other))
+    end
+
+    it "garde le lien legacy pour un booking sans séjour" do
+      from = Date.today.next_occurring(:friday)
+      other = confirmed_booking(from: from, to: from + 2)
+
+      get "/pages/other_bookings", params: { from_date: from.iso8601, to_date: (from + 2).iso8601, booking_id: 0 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(booking_path(other))
+    end
+  end
+
+  describe "toast « autres réservations » espaces (pages#other_space_bookings)" do
+    it "renvoie une résa d'espace à séjour vers le form séjour" do
+      from = Date.today.next_occurring(:friday)
+      sb = confirmed_space_booking(on: from)
+      stay = Stays::EnsureForSpaceBooking.call(sb)
+
+      get "/pages/other_space_bookings", params: { from_date: from.iso8601, to_date: (from + 1).iso8601, space_booking_id: 0 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(space_booking_path(sb))
+    end
+  end
+
+  describe "index espaces (space_bookings#index)" do
+    it "renvoie une résa d'espace à séjour vers le form séjour" do
+      from = Date.today.next_occurring(:friday)
+      sb = confirmed_space_booking(on: from)
+      stay = Stays::EnsureForSpaceBooking.call(sb)
+
+      get space_bookings_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(space_booking_path(sb))
+    end
+
+    it "garde le lien legacy pour une résa d'espace sans séjour" do
+      from = Date.today.next_occurring(:friday)
+      sb = confirmed_space_booking(on: from)
+
+      get space_bookings_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(space_booking_path(sb))
+    end
+  end
+end

--- a/spec/requests/unified_edit_redirect_spec.rb
+++ b/spec/requests/unified_edit_redirect_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+# Epic #81, Phase 8 — Édition unifiée. L'édition d'un Booking/SpaceBooking
+# existant passe par le form séjour : `bookings#edit` et `space_bookings#edit`
+# redirigent (302) vers `edit_stay_path` dès qu'un Stay VIVANT porte le record.
+# Sans Stay (backfill Phase 1 pas encore tourné en prod), l'écran legacy est
+# encore servi — fallback orphelin, appelé à disparaître en Phase 9.
+RSpec.describe "Édition unifiée — redirection edit → séjour (epic #81, Phase 8)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user)    { User.create!(email: "agent-unified-edit@les4sources.be", password: "password123") }
+  let(:lodging) { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+  let(:room) do
+    r = Room.create!(name: "Chambre 1", level: 1)
+    lodging.rooms << r
+    r
+  end
+  let(:space) { Space.create!(name: "Grande Salle", capacity: 40) }
+
+  before { sign_in user }
+
+  def booking_with_stay(from:, to:)
+    booking = Booking.create!(firstname: "Alex", group_name: "Groupe", lodging: lodging,
+                              from_date: from, to_date: to, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0)
+    (from...to).each { |date| Reservation.create!(booking: booking, room: room, date: date) }
+    [booking, Stays::EnsureForBooking.call(booking)]
+  end
+
+  def space_booking_with_stay(on:)
+    space_booking = SpaceBooking.create!(firstname: "Alex", group_name: "Groupe",
+                                         from_date: on, to_date: on, status: "confirmed")
+    SpaceReservation.create!(space: space, space_booking: space_booking, date: on)
+    [space_booking, Stays::EnsureForSpaceBooking.call(space_booking)]
+  end
+
+  describe "GET /bookings/:id/edit" do
+    it "redirige vers l'édition du séjour quand un Stay vivant existe" do
+      from = Date.today.next_occurring(:friday)
+      booking, stay = booking_with_stay(from: from, to: from + 1)
+
+      get edit_booking_path(booking)
+
+      expect(response).to redirect_to(edit_stay_path(stay))
+    end
+
+    it "sert encore l'écran legacy quand le booking n'a pas de Stay (fallback orphelin)" do
+      from = Date.today.next_occurring(:friday)
+      booking = Booking.create!(firstname: "Sans", group_name: "Séjour", lodging: lodging,
+                                from_date: from, to_date: from + 1, adults: 1, children: 0, babies: 0,
+                                status: "confirmed", booking_type: "lodging", price_cents: 0)
+      Reservation.create!(booking: booking, room: room, date: from)
+
+      get edit_booking_path(booking)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(booking_path(booking)) # le form legacy soumet toujours
+    end
+  end
+
+  describe "GET /space_bookings/:id/edit" do
+    it "redirige vers l'édition du séjour quand un Stay vivant existe" do
+      from = Date.today.next_occurring(:friday)
+      space_booking, stay = space_booking_with_stay(on: from)
+
+      get edit_space_booking_path(space_booking)
+
+      expect(response).to redirect_to(edit_stay_path(stay))
+    end
+
+    it "sert encore l'écran legacy quand la résa d'espace n'a pas de Stay (fallback orphelin)" do
+      from = Date.today.next_occurring(:friday)
+      space_booking = SpaceBooking.create!(firstname: "Sans", group_name: "Séjour",
+                                           from_date: from, to_date: from, status: "confirmed")
+      SpaceReservation.create!(space: space, space_booking: space_booking, date: from)
+
+      get edit_space_booking_path(space_booking)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(space_booking_path(space_booking)) # form legacy soumet toujours
+    end
+  end
+end

--- a/spec/requests/unified_edit_redirect_spec.rb
+++ b/spec/requests/unified_edit_redirect_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Édition unifiée — redirection edit → séjour (epic #81, Ph
   end
 
   def space_booking_with_stay(on:)
-    space_booking = SpaceBooking.create!(firstname: "Alex", group_name: "Groupe",
+    space_booking = SpaceBooking.create!(firstname: "Alex", group_name: "Groupe", tier: "neutre",
                                          from_date: on, to_date: on, status: "confirmed")
     SpaceReservation.create!(space: space, space_booking: space_booking, date: on)
     [space_booking, Stays::EnsureForSpaceBooking.call(space_booking)]
@@ -55,6 +55,53 @@ RSpec.describe "Édition unifiée — redirection edit → séjour (epic #81, Ph
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(booking_path(booking)) # le form legacy soumet toujours
+    end
+  end
+
+  describe "bouton « Mettre à jour » de la fiche booking" do
+    it "pointe vers l'édition du séjour quand un Stay vivant existe" do
+      from = Date.today.next_occurring(:friday)
+      booking, stay = booking_with_stay(from: from, to: from + 1)
+
+      get booking_path(booking)
+
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(edit_booking_path(booking))
+    end
+
+    it "garde le lien legacy quand le booking n'a pas de Stay (fallback orphelin)" do
+      from = Date.today.next_occurring(:friday)
+      booking = Booking.create!(firstname: "Sans", group_name: "Séjour", lodging: lodging,
+                                from_date: from, to_date: from + 1, adults: 1, children: 0, babies: 0,
+                                status: "confirmed", booking_type: "lodging", price_cents: 0)
+      Reservation.create!(booking: booking, room: room, date: from)
+
+      get booking_path(booking)
+
+      expect(response.body).to include(edit_booking_path(booking))
+    end
+  end
+
+  describe "bouton « Mettre à jour » de la fiche résa d'espace" do
+    it "pointe vers l'édition du séjour quand un Stay vivant existe" do
+      from = Date.today.next_occurring(:friday)
+      space_booking, stay = space_booking_with_stay(on: from)
+
+      get space_booking_path(space_booking)
+
+      expect(response.body).to include(edit_stay_path(stay))
+      expect(response.body).not_to include(edit_space_booking_path(space_booking))
+    end
+
+    it "garde le lien legacy quand la résa d'espace n'a pas de Stay (fallback orphelin)" do
+      from = Date.today.next_occurring(:friday)
+      space_booking = SpaceBooking.create!(firstname: "Sans", group_name: "Séjour", tier: "neutre",
+                                           from_date: from, to_date: from, status: "confirmed")
+      SpaceReservation.create!(space: space, space_booking: space_booking, date: from)
+
+      get space_booking_path(space_booking)
+
+      expect(response.body).to include(edit_space_booking_path(space_booking))
     end
   end
 

--- a/spec/services/stays/duplicate_service_spec.rb
+++ b/spec/services/stays/duplicate_service_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+# Epic #81, Phase 7 — Duplication de séjour. Le service NE clone PAS en base :
+# il reconstruit un `Reservations::Draft` prérempli depuis le séjour source, prêt
+# à alimenter le form NEW. L'admin choisit de NOUVELLES dates puis soumet — c'est
+# la création normale (Reservations::Builder) qui écrit en base.
+#
+# Ce qui est COPIÉ : client, composition (hébergement, espaces + facturation,
+# repas…). Ce qui est EXCLU : toutes les dates (séjour + éléments datés), les
+# paiements (jamais reconstruits par le draft) et le prix imposé (le devis se
+# recalcule ; l'admin le re-saisit au besoin).
+RSpec.describe Stays::DuplicateService, type: :service do
+  let!(:lodging)      { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+  let!(:grande_salle) { Space.create!(name: "Grande Salle", capacity: 1) }
+  let(:arrival)       { Date.today + 30 }
+  let(:departure)     { Date.today + 32 }
+
+  # Séjour source multi-éléments : hébergement + espace facturé + repas, créé via
+  # le Builder admin (aucun paiement, aucun email — parité canal admin).
+  def build_source_stay(price_override_cents: nil)
+    draft = Reservations::Draft.new(
+      lodging_id:     lodging.id,
+      arrival_date:   arrival,
+      departure_date: departure,
+      adults:         2,
+      dogs_count:     0,
+      first_name:     "Alice",
+      last_name:      "Martin",
+      email:          "alice@example.com",
+      phone:          "0470111222",
+      halls:          [{ kind: "grande_salle", date: arrival.iso8601, period: "journee" }],
+      meals:          [{ kind: "buffet", date: arrival.iso8601, people: 3 }],
+      space_billing:  { advance_amount: "50", deposit_amount: "200", payment_method: "bank_transfer" }
+    )
+    builder = Reservations::Builder.new(
+      draft: draft, admin: true, source: "manual",
+      price_override_cents: price_override_cents
+    )
+    builder.run!
+    builder.stay
+  end
+
+  subject(:draft) { described_class.call(stay: source) }
+
+  describe ".call — reconstruction de la composition" do
+    let(:source) { build_source_stay }
+
+    it "renvoie un Reservations::Draft" do
+      expect(draft).to be_a(Reservations::Draft)
+    end
+
+    it "conserve le client (prénom, nom, email)" do
+      expect(draft.first_name).to eq("Alice")
+      expect(draft.last_name).to eq("Martin")
+      expect(draft.email).to eq("alice@example.com")
+    end
+
+    it "conserve l'hébergement et son mode d'occupation" do
+      expect(draft.lodging_id).to eq(lodging.id)
+      expect(draft.booking_type).to eq("lodging")
+    end
+
+    it "conserve la composition espace + sa facturation" do
+      hall = draft.halls.first
+      expect(hall[:kind]).to eq("grande_salle")
+      expect(hall[:period]).to eq("journee")
+      # Facturation espace reconstruite depuis le SpaceBooking (acompte/caution/mode).
+      expect(draft.space_billing[:advance_amount]).to eq("50")
+      expect(draft.space_billing[:deposit_amount]).to eq("200")
+      expect(draft.space_billing[:payment_method]).to eq("bank_transfer")
+    end
+
+    it "conserve les repas (type + convives)" do
+      meal = draft.meals.first
+      expect(meal[:kind]).to eq("buffet")
+      expect(meal[:people]).to eq(3)
+    end
+  end
+
+  describe ".call — dates vidées (re-planification forcée, anti-surbooking)" do
+    let(:source) { build_source_stay }
+
+    it "n'emporte aucune date de séjour" do
+      expect(draft.arrival_date).to be_nil
+      expect(draft.departure_date).to be_nil
+    end
+
+    it "n'emporte aucune date d'élément (espace, repas)" do
+      expect(draft.halls.first[:date]).to be_blank
+      expect(draft.meals.first[:date]).to be_blank
+    end
+  end
+
+  describe ".call — paiements et prix imposé jamais copiés" do
+    # Source avec un prix imposé ET un paiement encaissé : la duplication ne doit
+    # ni figer le prix, ni reprendre le paiement.
+    let(:source) do
+      stay = build_source_stay(price_override_cents: 99_900)
+      Payment.create!(stay: stay, amount_cents: 10_000, status: "paid", payment_method: "card")
+      stay
+    end
+
+    it "reconstruite puis rebâtie avec de nouvelles dates → aucun paiement, pas d'override" do
+      # Le draft dupliqué ne porte pas de prix imposé (attribut absent du Draft) ;
+      # l'admin lui redonne de nouvelles dates — au niveau séjour ET des éléments
+      # datés (l'espace exige sa date) — et on le rebâtit comme une création normale.
+      new_day = Date.today + 60
+      draft.arrival_date   = new_day
+      draft.departure_date = new_day + 2
+      draft.halls = draft.halls.map { |h| h.merge(date: new_day.iso8601) }
+      draft.meals = draft.meals.map { |m| m.merge(date: new_day.iso8601) }
+
+      rebuilt = Reservations::Builder.new(draft: draft, admin: true, source: "manual")
+      rebuilt.run!
+      new_stay = rebuilt.stay
+
+      expect(new_stay.id).not_to eq(source.id)
+      expect(new_stay.payments).to be_empty
+      expect(new_stay.price_override_cents).to be_nil
+      # La composition, elle, est bien répliquée.
+      expect(new_stay.stay_items.where(bookable_type: "Booking")).to be_present
+      expect(new_stay.stay_items.where(bookable_type: "SpaceBooking")).to be_present
+      expect(new_stay.meal_orders).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Epic #81 — Phase 8 : édition unifiée

PR **empilée sur #97** (Phase 7). Le form séjour devient LE chemin d'édition ; les écrans legacy ne sont plus liés nulle part (leur retrait est la Phase 9).

### Contenu
- **Redirections contrôleur** : `bookings#edit` / `space_bookings#edit` → 302 vers `edit_stay_path(stay)` quand un séjour vivant existe (les vieux favoris/liens atterrissent au bon endroit). `#update` intacts (les forms legacy accessibles en fallback doivent soumettre).
- **11 emplacements repointés** (inventaire exhaustif dans le rapport de phase) : fiches show, blocs calendrier (→ modale séjour via le pattern overlay), vue jour, other_bookings/other_space_bookings, tables des index, vues past.
- **Dégradation orpheline partout** : sans séjour vivant → lien/écran legacy (commenté « disparaît après le backfill Phase 1 »). Il reste ~660 bookings + ~540 space_bookings orphelins en base de dev — le backfill de la Phase 1 les rattachera.
- **Exclusions délibérées** : feed « Activité récente » (journal d'audit → l'enregistrement historique, sa fiche mène au séjour), comptabilité (drill-down financier), chemins publics token, emails (Phase 9).
- **Décision consultation** : pages avec `stay-details` (calendrier) → modale ; pages sans (jour, index, past) → `edit_stay_path` pleine page (plutôt qu'un `stays#show` avec layout conditionnel — plus simple, et le form séjour EST le point d'entrée unifié).

### Vérifications
- **RSpec : 772 examples, 0 failures** (+19 : redirections, consultation avec/sans séjour, anti-régression bornée à la grille).
- **Navigateur : 5/5 PASS** — modale depuis le bloc, form séjour depuis la vue jour, redirection du vieux favori `/bookings/827/edit` → `/stays/2/edit`, orphelin réel (booking 822) servi en legacy sans redirection, index bookings/space_bookings repointés. Zéro erreur console.
- Note pour les futures vérifs agent-browser : en headless, les rendus Turbo attendent `requestAnimationFrame` — forcer une frame (screenshot) débloque l'injection des modales.