### PR TITLE
🚨 Hotfix — Calendrier public de disponibilité en 500 (indentation Slim)

### DIFF
--- a/app/views/public/calendars/lodgings.html.slim
+++ b/app/views/public/calendars/lodgings.html.slim
@@ -14,16 +14,16 @@
         .availability-calendar__section.availability-calendar__section--lodgings
           .availability-calendar__section-label Hébergements
           - @lodgings.each do |lodging|
-          - if lodging.available_on?(date)
-            .availability-calendar__pill.availability-calendar__pill--available
-              .availability-calendar__pill-text
-                span.availability-calendar__pill-name = lodging.name
-                .availability-calendar__pill-summary = lodging.summary
-          - else
-            .availability-calendar__pill.availability-calendar__pill--unavailable
-              .availability-calendar__pill-text
-                span.availability-calendar__pill-name = lodging.name
-                .availability-calendar__pill-summary = lodging.summary
+            - if lodging.available_on?(date)
+              .availability-calendar__pill.availability-calendar__pill--available
+                .availability-calendar__pill-text
+                  span.availability-calendar__pill-name = lodging.name
+                  .availability-calendar__pill-summary = lodging.summary
+            - else
+              .availability-calendar__pill.availability-calendar__pill--unavailable
+                .availability-calendar__pill-text
+                  span.availability-calendar__pill-name = lodging.name
+                  .availability-calendar__pill-summary = lodging.summary
 
         .availability-calendar__section-label Espaces
         - @spaces.each do |space|

--- a/spec/requests/public_calendars_spec.rb
+++ b/spec/requests/public_calendars_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+# Calendrier de disponibilité PUBLIC (sans Devise) — embarqué en iframe sur le
+# site des 4 Sources. Smoke test de rendu : cette page a déjà été cassée en prod
+# (500) par une erreur d'indentation Slim (pills hors du bloc each → NameError)
+# passée inaperçue faute de couverture. Plus jamais.
+RSpec.describe "Public — calendrier de disponibilité", type: :request do
+  let!(:lodging) { Lodging.create!(name: "La Hulotte", summary: "gîte", available_for_bookings: true) }
+  let!(:space)   { Space.create!(name: "Grande Salle", capacity: 10) }
+
+  it "rend la page sans authentification, avec hébergements et espaces" do
+    get "/public/calendrier-hebergements"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("La Hulotte")
+    expect(response.body).to include("Grande Salle")
+  end
+
+  it "rend la modale du calendrier" do
+    get "/public/calendar-lodgings-modal", params: { date: (Date.today + 7).iso8601 }
+
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## Incident production

**https://app.les4sources.be/public/calendrier-hebergements est en 500 en production** — c'est le calendrier de disponibilité embarqué en iframe sur le site des 4 Sources.

Cause : dans `public/calendars/lodgings.html.slim`, les pills hébergements sont sorties du bloc `- @lodgings.each do |lodging|` (erreur d'indentation Slim, commit « Improve public calendar UX ») → `NameError: lodging` → 500. Aucune spec ne couvrait la page, d'où le silence de la suite.

Attrapé par la passe navigateur groupée finale de l'epic #81.

## Contenu
- Réindentation du bloc (10 lignes).
- **Smoke specs** de rendu (page + modale) pour que ça ne repasse plus jamais inaperçu.

Suite complète sur base main : **621 examples, 0 failures**.

## ⚠️ Après merge : déployer via Hatchbox (ne pas oublier le double redémarrage habituel).

NB : la pile epic #81 (PRs #90→#99… #90-#98 + Phase 9) porte le même correctif (contenu identique → merge propre garanti).