### PR TITLE
Issue #94 — Rotations dos-à-dos acceptées (bornes de nuits sur les vetos de dispo)

### DIFF
--- a/app/models/lodging.rb
+++ b/app/models/lodging.rb
@@ -76,10 +76,29 @@ class Lodging < ApplicationRecord
   # blind). Kept public so the composition logic and any caller that explicitly
   # wants the physical-unit answer can reach it; behaviour for non-composed
   # lodgings is identical to the previous available_between?/available_on?.
+  #
+  # CONTRAT DE DATES (issue #94). `(from_date, to_date)` décrit une FENÊTRE DE
+  # SÉJOUR `[from_date, to_date)` : arrivée le jour `from_date`, départ le jour
+  # `to_date` — le jour de départ n'est PAS occupé. L'occupation est portée par
+  # des `Reservation` NUITÉES : un séjour occupe les nuits `from_date..(to_date-1)`.
+  # On interroge donc les `Reservation` sur cet intervalle de NUITS (borne haute
+  # EXCLUANT le jour de départ) — sinon un enchaînement dos-à-dos (départ le jour J,
+  # arrivée d'un autre séjour le même jour J) serait faussement refusé.
+  #
+  # Garde-fou ANTI-SURBOOKING : `available_on?(d)` appelle `(d, d)` pour demander
+  # « la NUIT d est-elle libre ? ». Une borne haute naïve `to_date - 1` donnerait
+  # ici un intervalle VIDE (`d..d-1`) → « toujours disponible » → surbooking
+  # silencieux. Le `max` avec `from_date` ramène l'appel nuit-unique `(d, d)` à la
+  # nuit `d`, tout en gardant la sémantique de fenêtre quand `to_date > from_date`.
+  #
+  # Les `Unavailability` (indispos posées à la main) gardent leur sémantique de
+  # JOURNÉES PLEINES : `from_date..to_date` INCLUSIF — volontairement différente
+  # des nuits (une indispo posée sur le jour de départ d'une fenêtre bloque).
   def self_available_between?(from_date, to_date)
+    last_night = [to_date - 1, from_date].max
     Reservation.includes(:booking)
                .where(
-                 date: from_date..to_date,
+                 date: from_date..last_night,
                  room: rooms.pluck(:id),
                  booking: { status: "confirmed" }
                ).none? && unavailabilities.where(date: from_date..to_date).none?
@@ -108,8 +127,14 @@ class Lodging < ApplicationRecord
     scoped = rooms.where(id: ids).pluck(:id)
     return false if scoped.empty?
 
+    # Même contrat de dates que `self_available_between?` (issue #94) : `(from_date,
+    # to_date)` est une fenêtre de séjour `[from_date, to_date)`. Les `Reservation`
+    # sont NUITÉES → on borne la requête aux nuits `from_date..(to_date-1)` (borne
+    # haute excluant le jour de départ), avec le même garde-fou `max` pour l'appel
+    # nuit-unique `(d, d)`. Les `Unavailability` restent en journées pleines (inclusif).
+    last_night = [to_date - 1, from_date].max
     Reservation.includes(:booking)
-               .where(date: from_date..to_date, room: scoped, booking: { status: "confirmed" })
+               .where(date: from_date..last_night, room: scoped, booking: { status: "confirmed" })
                .none? && unavailabilities.where(date: from_date..to_date).none?
   end
 

--- a/app/services/concerns/bookable.rb
+++ b/app/services/concerns/bookable.rb
@@ -22,11 +22,16 @@ module Bookable
         end
       else
         # Gite
-        # Not available if any reservations for the same date range
+        # Not available if any reservations for the same date range.
+        # Requête directe déjà en NUITS : `from..(to-1.day)` couvre les nuits du
+        # séjour (le jour de départ n'est pas occupé) — sémantique correcte, inchangée.
+        # `available_between?` attend en revanche une FENÊTRE DE SÉJOUR `[from, to)`
+        # (contrat issue #94) et retranche lui-même le jour de départ : on lui passe
+        # donc `to_date` NON décrémenté (sinon double soustraction → dernière nuit ignorée).
         if room.reservations
             .includes(:booking)
             .where(date: (@booking.from_date)..(@booking.to_date - 1.day), booking: { status: "confirmed", deleted_at: nil })
-            .any? || !@booking.lodging.available_between?(@booking.from_date, @booking.to_date - 1.day)
+            .any? || !@booking.lodging.available_between?(@booking.from_date, @booking.to_date)
           set_error_message("Cet hébergement n'est pas disponible à cette date.")
           return false
         end

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -180,11 +180,19 @@ module Stays
         end
       end
 
+      # Contrat de dates (issue #94) : `[arrival_date, departure_date)` est une
+      # fenêtre de séjour ; le jour de départ n'est PAS occupé. Les `Reservation`
+      # sont NUITÉES → on borne aux nuits `arrival_date..(departure_date-1)` (borne
+      # haute excluant le jour de départ) pour ne pas refuser une rotation dos-à-dos.
+      # Le `max` garde un intervalle valide même sur une fenêtre dégénérée (0 nuit).
+      last_night = [@draft.departure_date - 1, @draft.arrival_date].max
       scope = Reservation.joins(:booking)
-                         .where(date: @draft.arrival_date..@draft.departure_date,
+                         .where(date: @draft.arrival_date..last_night,
                                 room_id: ids, bookings: { status: "confirmed" })
       own_ids = @stay.stay_items.where(bookable_type: "Booking").pluck(:bookable_id)
       scope = scope.where.not(bookings: { id: own_ids }) if own_ids.any?
+      # Les `Unavailability` gardent leur sémantique de JOURNÉES PLEINES (inclusif
+      # du jour de départ) — volontairement différente des nuits ci-dessus.
       scope.none? &&
         @draft.lodging.unavailabilities.where(date: @draft.arrival_date..@draft.departure_date).none?
     end

--- a/spec/models/lodging_back_to_back_availability_spec.rb
+++ b/spec/models/lodging_back_to_back_availability_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+# Issue #94 — sur-blocage au jour de rotation.
+# Les `Reservation` d'occupation couvrent les NUITS `[arrivée, départ)` : le jour
+# de départ n'est PAS occupé. Les requêtes de disponibilité doivent donc interroger
+# les nuits `from..(départ-1)` et non `from..départ` inclusif — sinon une rotation
+# dos-à-dos (départ le jour J / arrivée d'un autre séjour le même jour J) est
+# faussement refusée. Le garde-fou : l'appel nuit-unique `available_on?(d)` (=
+# `available_between?(d, d)`) doit rester exact (anti-surbooking).
+RSpec.describe Lodging, "disponibilité dos-à-dos (issue #94)", type: :model do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << room
+    lodging
+  end
+  let(:room) { Room.create!(name: "Chambre 1", level: 1) }
+
+  # Jours de référence.
+  let(:d1) { Date.new(2026, 8, 1) }
+  let(:d2) { Date.new(2026, 8, 2) }
+  let(:d3) { Date.new(2026, 8, 3) }
+  let(:d4) { Date.new(2026, 8, 4) }
+  let(:d5) { Date.new(2026, 8, 5) }
+
+  # Occupe (confirmé) une chambre sur les NUITS `[from, to)` — le jour `to`
+  # (départ) n'est jamais réservé, comme en production.
+  def occupy(target_room, from:, to:)
+    booking = Booking.create!(firstname: "Occ", from_date: from, to_date: to, adults: 1, status: "confirmed", lodging: hulotte)
+    (from...to).each { |date| Reservation.create!(booking: booking, room: target_room, date: date) }
+    booking
+  end
+
+  describe "gîte entier (#available_between?)" do
+    it "reste disponible pour un séjour APRÈS un séjour dos-à-dos (A[1→3] puis B[3→5])" do
+      occupy(room, from: d1, to: d3) # nuits 1, 2
+      expect(hulotte.available_between?(d3, d5)).to be(true)
+    end
+
+    it "reste disponible pour un séjour AVANT un séjour dos-à-dos (B[3→5] puis A[1→3])" do
+      # Cas discriminant : avant le fix, la requête `date: 1..3` INCLUSIVE captait
+      # la nuit d'arrivée (jour 3) de B et refusait A à tort.
+      occupy(room, from: d3, to: d5) # nuits 3, 4
+      expect(hulotte.available_between?(d1, d3)).to be(true)
+    end
+
+    it "refuse un vrai chevauchement (A[1→3] vs [2→4], nuit 2 commune)" do
+      occupy(room, from: d1, to: d3) # nuits 1, 2
+      expect(hulotte.available_between?(d2, d4)).to be(false)
+    end
+
+    it "refuse une fenêtre partageant une seule nuit (A[1→3] vs [2→3], nuit 2 commune)" do
+      occupy(room, from: d1, to: d3) # nuits 1, 2
+      expect(hulotte.available_between?(d2, d3)).to be(false)
+    end
+  end
+
+  describe "chambres seules (#rooms_available_between?)" do
+    it "reste disponible pour un séjour APRÈS un séjour dos-à-dos sur la même chambre" do
+      occupy(room, from: d1, to: d3)
+      expect(hulotte.rooms_available_between?([room.id], d3, d5)).to be(true)
+    end
+
+    it "reste disponible pour un séjour AVANT un séjour dos-à-dos sur la même chambre" do
+      occupy(room, from: d3, to: d5)
+      expect(hulotte.rooms_available_between?([room.id], d1, d3)).to be(true)
+    end
+
+    it "refuse un vrai chevauchement sur la même chambre (nuit 2 commune)" do
+      occupy(room, from: d1, to: d3)
+      expect(hulotte.rooms_available_between?([room.id], d2, d4)).to be(false)
+      expect(hulotte.rooms_available_between?([room.id], d2, d3)).to be(false)
+    end
+  end
+
+  describe "nuit unique préservée (garde-fou anti-surbooking, #available_on?)" do
+    before { occupy(room, from: d2, to: d3) } # occupe UNIQUEMENT la nuit 2
+
+    it "est indisponible sur la nuit couverte par une Reservation confirmée" do
+      expect(hulotte.available_on?(d2)).to be(false)
+    end
+
+    it "reste disponible sur une nuit libre — AUCUN sur-blocage" do
+      expect(hulotte.available_on?(d1)).to be(true) # veille libre
+      expect(hulotte.available_on?(d3)).to be(true) # jour de départ, non occupé
+      expect(hulotte.available_on?(d5)).to be(true) # nuit sans lien
+    end
+  end
+
+  describe "Unavailability (indispo manuelle — sémantique JOURNÉE PLEINE conservée)" do
+    it "bloque une fenêtre dont le JOUR DE DÉPART porte une indisponibilité" do
+      # Contrairement aux Reservation nuitées, l'indispo posée à la main couvre la
+      # journée pleine `from..to` INCLUSIF : une indispo sur le jour de départ bloque.
+      Unavailability.create!(lodging: hulotte, date: d3)
+      expect(hulotte.available_between?(d1, d3)).to be(false)
+      expect(hulotte.rooms_available_between?([room.id], d1, d3)).to be(false)
+    end
+  end
+end

--- a/spec/requests/stays_availability_spec.rb
+++ b/spec/requests/stays_availability_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe "Stays — disponibilité temps réel (issue #77)", type: :reques
     expect(body["available"]).to be(false)
   end
 
+  it "renvoie available: true pour une rotation dos-à-dos (issue #94)" do
+    # Séjour existant B[+32 → +34] confirmé : occupe les NUITS +32 et +33.
+    later_from = Date.today + 32
+    later_to   = Date.today + 34
+    occ = Booking.create!(firstname: "Occ", from_date: later_from, to_date: later_to, adults: 1, status: "confirmed")
+    (later_from...later_to).each { |d| Reservation.create!(booking: occ, room: hulotte.rooms.first, date: d) }
+
+    # Nouveau séjour A[+30 → +32] : son jour de départ (+32) = jour d'arrivée de B.
+    # Avant le fix, la requête inclusive `date: +30..+32` captait la nuit +32 de B
+    # et refusait A à tort. Désormais A ne vérifie que les nuits +30 et +31 : libre.
+    body = get_availability(arrival_date: (Date.today + 30).iso8601, departure_date: (Date.today + 32).iso8601)
+    expect(body["checkable"]).to be(true)
+    expect(body["available"]).to be(true)
+  end
+
   it "renvoie checkable: false sans hébergement ou sans dates" do
     expect(get_availability(lodging_id: "")["checkable"]).to be(false)
     expect(get_availability(arrival_date: "")["checkable"]).to be(false)

--- a/spec/services/reservations/builder_back_to_back_spec.rb
+++ b/spec/services/reservations/builder_back_to_back_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+# Issue #94 — bout en bout : deux séjours dos-à-dos doivent être créables via
+# `Reservations::Builder` SANS forçage de disponibilité. Le sur-blocage au jour de
+# rotation refusait/avertissait à tort le second séjour quand son jour de départ
+# (ou d'arrivée) coïncidait avec la rotation d'un séjour confirmé voisin.
+RSpec.describe Reservations::Builder, "rotation dos-à-dos (issue #94)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  # Séjour existant B[+32 → +34] confirmé : occupe les NUITS +32 et +33.
+  let(:later_from) { Date.today + 32 }
+  let(:later_to)   { Date.today + 34 }
+  before do
+    occ = Booking.create!(firstname: "Occ", from_date: later_from, to_date: later_to, adults: 1, status: "confirmed", lodging: hulotte)
+    (later_from...later_to).each { |d| Reservation.create!(booking: occ, room: hulotte.rooms.first, date: d) }
+  end
+
+  # Nouveau séjour A[+30 → +32] : son jour de départ (+32) = arrivée de B.
+  def draft(**overrides)
+    Reservations::Draft.new({
+      lodging_id: hulotte.id,
+      arrival_date: (Date.today + 30).iso8601,
+      departure_date: (Date.today + 32).iso8601,
+      dogs_count: 0,
+      first_name: "Camille",
+      last_name: "Martin",
+      email: "camille@example.com",
+      phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  it "crée le séjour dos-à-dos sans forçage ni avertissement de disponibilité" do
+    builder = described_class.new(draft: draft)
+
+    expect(builder.run).to be(true)
+    expect(builder.availability_warning).to be_blank
+    expect(builder.stay).to be_persisted
+    expect(builder.booking.lodging_id).to eq(hulotte.id)
+  end
+end

--- a/spec/services/stays/admin_updater_back_to_back_spec.rb
+++ b/spec/services/stays/admin_updater_back_to_back_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+# Issue #94 (revue Forge F2) — le veto d'ÉDITION (`AdminUpdater#lodging_available?`)
+# duplique la requête de nuits au lieu de déléguer à Lodging : on couvre donc SES
+# deux sens à lui. (a) Permissif : rééditer un séjour dos-à-dos d'un voisin
+# confirmé passe sans forçage. (b) Bloquant : le faire chevaucher réellement le
+# voisin est refusé — un veto cassé « toujours oui » serait attrapé ici.
+RSpec.describe Stays::AdminUpdater, "rotation dos-à-dos en édition (issue #94)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  # Voisin confirmé B[+32 → +34] : occupe les NUITS +32 et +33.
+  let(:neighbor_from) { Date.today + 32 }
+  before do
+    occ = Booking.create!(firstname: "Occ", from_date: neighbor_from, to_date: neighbor_from + 2,
+                          adults: 1, status: "confirmed", lodging: hulotte)
+    (neighbor_from...(neighbor_from + 2)).each { |d| Reservation.create!(booking: occ, room: hulotte.rooms.first, date: d) }
+  end
+
+  def draft(arrival:, departure:)
+    Reservations::Draft.new(
+      lodging_id: hulotte.id,
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille-edit@example.com", phone: "+32470112233"
+    )
+  end
+
+  # Séjour à éditer A[+30 → +32] : départ = arrivée du voisin (dos-à-dos).
+  let(:stay) do
+    builder = Reservations::Builder.new(
+      draft: draft(arrival: Date.today + 30, departure: Date.today + 32),
+      admin: true, status: "confirmed", source: "manual"
+    )
+    builder.run!
+    builder.stay
+  end
+
+  it "réédite un séjour dos-à-dos du voisin sans forçage ni avertissement" do
+    updater = described_class.new(
+      stay: stay,
+      draft: draft(arrival: Date.today + 30, departure: Date.today + 32),
+      status: "confirmed"
+    )
+
+    expect(updater.run).to be(true)
+    expect(updater.availability_warning).to be_blank
+  end
+
+  it "refuse une édition qui chevauche RÉELLEMENT le voisin (nuit +32 commune)" do
+    updater = described_class.new(
+      stay: stay,
+      draft: draft(arrival: Date.today + 31, departure: Date.today + 33),
+      status: "confirmed"
+    )
+
+    expect(updater.run).to be(false)
+    expect(updater.error_message).to include("plus disponibles")
+  end
+end


### PR DESCRIPTION
## Issue #94 — sur-blocage au jour de rotation

Les `Reservation` couvrent les **nuits** `[arrivée, départ)`, mais les vetos de dispo interrogeaient `where(date: from..to)` **inclusif du jour de départ** : un enchaînement dos-à-dos (A part le 8, B arrive le 8) était refusé à tort. Hérité du legacy, relevé par la revue Forge de la Phase 5 de l'epic #81.

### Contenu
- **Bornes de nuits** `from..[départ-1, from].max` sur les 3 vetos : `Lodging#self_available_between?`, `Lodging#rooms_available_between?`, `AdminUpdater#lodging_available?` (+ réalignement du concern `Bookable#available?`, mort mais qui aurait subi une double soustraction).
- **Le `max` est le garde-fou central** : `available_on?(d)` = `available_between?(d, d)` signifie « cette nuit » — une borne exclusive naïve donnait une plage vide → tout « disponible » → surbooking silencieux. Contrat documenté dans le code.
- **`Unavailability` inchangées** (journées pleines, inclusives) — une indispo posée sur un jour de départ bloque toujours.
- **Audit exhaustif** des 16 sites `Reservation` × plage de dates (tableau dans le rapport de branche) : seuls les vetos changent, tout l'affichage (calendrier, funnel, stats d'occupation) garde sa sémantique.

### Vérifications
- **RSpec : 800 examples, 0 failures** (+14) — avec validation **Red→Green** (les 4 specs discriminantes échouent sans le fix) et les DEUX sens testés à chaque niveau : dos-à-dos accepté ET chevauchement/nuit occupée refusés (Lodging, Builder bout-en-bout, endpoint availability, **et le veto d'édition AdminUpdater** — seule requête non couverte, relevée par Forge F2, comblée).
- **Revue Forge : SHIP** — chasse exclusive aux sous-blocages : les 5 appelants tracés (aucune double soustraction), fenêtres dégénérées plus strictes qu'avant, Unavailability inclusives vérifiées aux 3 sites. **Passe croisée GPT-5.4 exécutée** : accord 4/5, son 5e point réfuté comme pré-existant hors périmètre (exclusion own_ids, correctif Phase 5 antérieur).
- **Navigateur : 6/6 PASS** — séjour A confirmé [6→8 sept 2027], B dos-à-dos [8→10] créé **sans forçage** (indicateur « Disponible », zéro avertissement), C chevauchant [7→9] **refusé** (422 « plus disponibles »), nuits uniques exactes dans les deux sens, blocs calendrier contigus sans trou, données de test nettoyées. Zéro erreur console.

Le funnel public et l'endpoint `stays#availability` bénéficient du fix sans changement (mêmes méthodes).

### Impact concret
Les rotations départ-matin / arrivée-après-midi — le cas standard en location — ne demandent plus jamais de « Forcer la disponibilité ».