### PR TITLE
fix(reservation): le clic final du funnel n'aboutissait jamais au paiement

### DIFF
--- a/app/controllers/public/reservations_controller.rb
+++ b/app/controllers/public/reservations_controller.rb
@@ -111,9 +111,12 @@ module Public
         pay = Payments::PayService.new(payment_id: builder.payment.id)
         clear_draft
         if pay.run
-          redirect_to pay.checkout_session_url, allow_other_host: true, data: { turbo: false }
+          redirect_to pay.checkout_session_url, allow_other_host: true
         else
-          redirect_to public_booking_path(builder.booking.token),
+          # Stay-first : le Booking n'existe pas pour un séjour sans hébergement
+          # classique (camping/espaces seuls) — seul le Stay est garanti. Même
+          # cible que le lien du mail de confirmation (/sejour/:token).
+          redirect_to public_stay_path(builder.stay.token),
                       notice: "Votre demande est enregistrée. Nous vous recontactons pour le paiement."
         end
       else

--- a/app/views/public/reservations/contact.html.slim
+++ b/app/views/public/reservations/contact.html.slim
@@ -15,7 +15,11 @@
       / ── Formulaire ─────────────────────────────────────────
       .lg:col-span-2
         .bg-white.rounded-2xl.shadow-sm.border.border-gray-100.p-6.sm:p-8
-          = form_with url: public_reservation_create_path, method: :post do |f|
+          / turbo: false OBLIGATOIRE : la réponse est un redirect vers Stripe
+            Checkout (hôte externe). Un POST Turbo suit ce redirect en fetch,
+            que CORS bloque → aucune navigation, le clic semble mort. En POST
+            natif, le navigateur suit le redirect en top-level sans restriction.
+          = form_with url: public_reservation_create_path, method: :post, data: { turbo: false } do |f|
             / Champs cachés composition
             = hidden_field_tag "reservation[lodging_id]", @draft.lodging_id
             = hidden_field_tag "reservation[arrival_date]", @draft.arrival_date&.iso8601

--- a/spec/requests/public/reservation_payment_redirect_spec.rb
+++ b/spec/requests/public/reservation_payment_redirect_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+# Bug « le clic final ne fait rien » (2026-07-20) — deux causes distinctes :
+#
+# 1. Le formulaire de l'étape coordonnées postait via Turbo alors que la réponse
+#    est un redirect vers Stripe Checkout (hôte externe) : le fetch Turbo suit le
+#    redirect, CORS le bloque, aucune navigation. Le formulaire doit porter
+#    data-turbo="false" pour un POST natif.
+# 2. Si Stripe échoue APRÈS création du séjour, le fallback redirigeait vers
+#    `builder.booking.token` — or un séjour sans hébergement classique (camping,
+#    espaces seuls) n'a PAS de Booking (stay-first, epic #26) → NoMethodError 500,
+#    alors que le Stay et l'email de confirmation existaient déjà.
+RSpec.describe "Public::Reservations — redirection paiement (étape finale)", type: :request do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  let(:arrival) { (Date.today + 40).iso8601 }
+  let(:departure) { (Date.today + 42).iso8601 }
+
+  let(:base_contact) do
+    {
+      arrival_date: arrival, departure_date: departure, dogs_count: 0,
+      adults: 2, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470000000"
+    }
+  end
+
+  describe "formulaire de l'étape coordonnées" do
+    it "désactive Turbo (le redirect Stripe est cross-origin, insuivable en fetch)" do
+      get "/reservation/coordonnees"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-turbo="false"')
+    end
+  end
+
+  describe "échec Stripe après création du séjour" do
+    before do
+      allow(StripeService.instance).to receive(:create_checkout_session)
+        .and_raise(Stripe::AuthenticationError.new("Invalid API Key provided"))
+    end
+
+    it "séjour camping seul (sans Booking) : redirige vers la page séjour, pas de 500" do
+      expect {
+        post "/reservation/coordonnees", params: {
+          reservation: base_contact.merge(campings: [{ kind: "tente", people: 2, nights: 2 }])
+        }
+      }.to change(Stay, :count).by(1)
+
+      stay = Stay.last
+      expect(stay.bookables.grep(Booking)).to be_empty # pas de Booking : le fallback ne peut pas s'appuyer dessus
+      expect(response).to redirect_to("/sejour/#{stay.token}")
+      expect(flash[:notice]).to include("Nous vous recontactons")
+    end
+
+    it "séjour avec hébergement : même cible stay-first (/sejour/:token)" do
+      post "/reservation/coordonnees", params: {
+        reservation: base_contact.merge(lodging_id: hulotte.id)
+      }
+
+      stay = Stay.last
+      expect(response).to redirect_to("/sejour/#{stay.token}")
+    end
+
+    it "la page séjour du fallback se rend (le client atterrit sur du concret)" do
+      post "/reservation/coordonnees", params: {
+        reservation: base_contact.merge(campings: [{ kind: "tente", people: 2, nights: 2 }])
+      }
+      follow_redirect!
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Bug (prod, chemin de revenus)

À la dernière étape du funnel public `/reservation`, cliquer « Envoyer ma demande et payer l'acompte → » ne produit **rien** à l'écran. Aucune erreur JS.

## Causes (deux bugs distincts)

**1. Le bug vu en prod — POST Turbo vs redirect externe Stripe.**
`form_with` de l'étape coordonnées postait via Turbo. La réponse serveur est un redirect vers `checkout.stripe.com` (hôte externe) : le fetch Turbo suit ce redirect, CORS le bloque → aucune navigation, clic silencieusement mort. Sentry prod : zéro erreur — le serveur répondait correctement, tout mourait côté navigateur. Le `data: { turbo: false }` était posé sur le `redirect_to` (où il est inopérant — il part en flash), pas sur le formulaire.

**Fix** : `data: { turbo: false }` sur le form → POST natif, le navigateur suit le redirect Stripe en top-level.

**2. Bug latent déterré par la repro — fallback `builder.booking.token` sur `nil`.**
Si Stripe échoue après création du séjour, le fallback redirigait vers `public_booking_path(builder.booking.token)`. Or depuis stay-first (epic #26), un séjour sans hébergement classique (camping/espaces seuls) **n'a pas de Booking** → `NoMethodError` 500… alors que le Stay est créé, l'email de confirmation parti et le draft vidé. Chaque re-essai du visiteur recréait un séjour + un email.

**Fix** : fallback stay-first `public_stay_path(builder.stay.token)` — le Stay existe toujours, même cible que le lien du mail (aligné sur `PayService#return_url`).

## Vérifications

- **agent-browser, funnel complet local** : `data-turbo="false"` effectif (POST de type Document, plus un fetch), atterrissage `/sejour/:token` en 200 avec la notice « Votre demande est enregistrée… », **zéro erreur console, zéro 4xx/5xx** sur tout le parcours.
- **Specs** : `spec/requests/public/reservation_payment_redirect_spec.rb` (4 exemples : form sans Turbo, fallback camping-seul sans 500, fallback avec hébergement, page d'atterrissage 200).
- **Suite complète** : 804 exemples, 0 échec.

## Note déploiement

Bug bloquant le paiement public en prod → à merger/déployer en priorité. Un seul restart suffit désormais (drop-in systemd posé le 2026-07-20).