### PR TITLE
feat(stripe): page Checkout lisible — dates, acompte vs total, composition

### DIFF
--- a/app/external_services/stripe_service.rb
+++ b/app/external_services/stripe_service.rb
@@ -1,7 +1,11 @@
 class StripeService
   include Singleton
 
-  def create_checkout_session(client_reference_id:, success_url:, cancel_url:, item: {}, metadata: {})
+  def create_checkout_session(client_reference_id:, success_url:, cancel_url:, item: {}, metadata: {}, customer_email: nil)
+    # Stripe refuse une description vide : on ne pose la clé que si fournie.
+    product_data = { name: item[:name] }
+    product_data[:description] = item[:description] if item[:description].present?
+
     params = {
       mode: "payment",
       client_reference_id: client_reference_id,
@@ -9,9 +13,7 @@ class StripeService
         price_data: {
           currency: "eur",
           unit_amount: item[:amount],
-          product_data: {
-            name: item[:name]
-          }
+          product_data: product_data
         },
         quantity: 1,
       }],
@@ -27,6 +29,7 @@ class StripeService
       success_url: success_url,
       cancel_url: cancel_url,
     }
+    params[:customer_email] = customer_email if customer_email.present?
     Stripe::Checkout::Session.create(params)
   end
 end

--- a/app/services/payments/pay_service.rb
+++ b/app/services/payments/pay_service.rb
@@ -33,9 +33,11 @@ module Payments
         client_reference_id: @payment.id,
         success_url: return_url,
         cancel_url: return_url,
+        customer_email: prefill_email,
         item: {
           id: @payment.id,
           name: checkout_label,
+          description: checkout_description,
           amount: @payment.amount_cents
         }
       )
@@ -52,12 +54,72 @@ module Payments
       end
     end
 
+    # Libellé lisible par le CLIENT sur la page Stripe — plus de token brut :
+    # les dates situent immédiatement le séjour. Repli générique sans dates ;
+    # les paiements historiques booking-seuls gardent leur libellé d'origine.
     def checkout_label
-      if @payment.stay&.token.present?
-        "Séjour ##{@payment.stay.token}"
+      stay = @payment.stay
+      return "Réservation ##{@payment.booking.token}" if stay&.token.blank?
+
+      if stay.arrival_date.present? && stay.departure_date.present?
+        "Séjour aux 4 Sources · du #{I18n.l(stay.arrival_date, format: :long)} " \
+          "au #{I18n.l(stay.departure_date, format: :long)}"
       else
-        "Réservation ##{@payment.booking.token}"
+        "Séjour aux 4 Sources"
       end
+    end
+
+    # Sous-titre Stripe : nature du paiement (acompte / solde / total) puis
+    # composition du séjour — de quoi reconnaître SON séjour et comprendre
+    # pourquoi le montant demandé diffère du total.
+    def checkout_description
+      stay = @payment.stay
+      return nil unless stay
+
+      [payment_nature(stay), composition_summary(stay)].compact.join(" — ").presence
+    end
+
+    # Adossé au TOTAL PRÉVU (`total_amount_cents`) : la notion que le client
+    # connaît (devis, email de récap). Acompte tant que rien n'est encaissé,
+    # solde ensuite ; rien à préciser si le paiement couvre tout le séjour.
+    def payment_nature(stay)
+      total = stay.total_amount_cents.to_i
+      return nil unless total.positive?
+
+      if @payment.amount_cents >= total
+        "Montant total du séjour"
+      elsif stay.amount_paid_cents.positive?
+        "Solde de #{euros(@payment.amount_cents)} sur un séjour de #{euros(total)}"
+      else
+        "Acompte de #{euros(@payment.amount_cents)} sur un séjour de #{euros(total)}"
+      end
+    end
+
+    # Résumé de la composition : hébergement(s) nommé(s), espaces, camping,
+    # van, activités actives.
+    def composition_summary(stay)
+      parts = stay.bookables.filter_map do |bookable|
+        case bookable
+        when Booking        then bookable.lodging&.name || "Hébergement"
+        when SpaceBooking   then "Salles & espaces"
+        when CampingBooking then "Camping"
+        when VanBooking     then "Emplacement van"
+        end
+      end.uniq
+      activities = stay.experience_bookings.active.count
+      parts << "#{activities} activité#{"s" if activities > 1}" if activities.positive?
+      parts.presence&.join(", ")
+    end
+
+    def euros(cents)
+      Money.new(cents, "EUR").format
+    end
+
+    # Pré-remplit l'email sur la page Stripe (une saisie de moins pour le
+    # client). Jamais bloquant : sans email exploitable, Stripe le demandera.
+    def prefill_email
+      email = @payment.stay&.customer&.email.presence || @payment.booking&.email.presence
+      email if email&.match?(URI::MailTo::EMAIL_REGEXP)
     end
   end
 end

--- a/spec/services/payments/pay_service_spec.rb
+++ b/spec/services/payments/pay_service_spec.rb
@@ -40,11 +40,55 @@ RSpec.describe Payments::PayService do
       expect(args[:cancel_url]).to include(expected)
     end
 
-    it "libelle la ligne Stripe « Séjour #<token> »" do
+    it "libelle la ligne Stripe avec les dates du séjour (lisible client, pas un token)" do
+      stay.update!(arrival_date: Date.new(2026, 9, 15), departure_date: Date.new(2026, 9, 17))
       payment = Payment.create!(stay: stay, booking: booking, amount_cents: 24_250,
                                 status: "pending", payment_method: "card")
 
-      expect(captured_args_for(payment)[:item][:name]).to eq("Séjour ##{stay.reload.token}")
+      name = captured_args_for(payment)[:item][:name]
+      expect(name).to eq("Séjour aux 4 Sources · du 15 septembre 2026 au 17 septembre 2026")
+    end
+
+    it "replie sur un libellé générique quand le séjour n'a pas de dates" do
+      payment = Payment.create!(stay: stay, booking: booking, amount_cents: 24_250,
+                                status: "pending", payment_method: "card")
+
+      expect(captured_args_for(payment)[:item][:name]).to eq("Séjour aux 4 Sources")
+    end
+
+    it "décrit un ACOMPTE (montant vs total) + la composition du séjour" do
+      lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+      booking.update!(lodging: lodging)
+      stay.stay_items.create!(bookable: booking)
+      payment = Payment.create!(stay: stay, booking: booking, amount_cents: 24_250,
+                                status: "pending", payment_method: "card")
+
+      description = captured_args_for(payment)[:item][:description]
+      expect(description).to include("Acompte de 242,50 €")
+      expect(description).to include("sur un séjour de 485 €") # no_cents_if_whole
+      expect(description).to include("La Hulotte")
+    end
+
+    it "décrit un SOLDE quand un encaissement existe déjà" do
+      Payment.create!(stay: stay, amount_cents: 24_250, status: "paid", payment_method: "card")
+      payment = Payment.create!(stay: stay, amount_cents: 24_250,
+                                status: "pending", payment_method: "card")
+
+      expect(captured_args_for(payment)[:item][:description]).to include("Solde de 242,50 €")
+    end
+
+    it "décrit « Montant total du séjour » quand le paiement couvre tout" do
+      payment = Payment.create!(stay: stay, amount_cents: 48_500,
+                                status: "pending", payment_method: "card")
+
+      expect(captured_args_for(payment)[:item][:description]).to include("Montant total du séjour")
+    end
+
+    it "pré-remplit l'email du client sur la page Stripe" do
+      payment = Payment.create!(stay: stay, booking: booking, amount_cents: 24_250,
+                                status: "pending", payment_method: "card")
+
+      expect(captured_args_for(payment)[:customer_email]).to eq("stripe@example.com")
     end
 
     it "fonctionne pour un séjour SANS hébergement (aucun booking)" do


### PR DESCRIPTION
## Avant / après

**Avant** : `Séjour #fa8GodJyaydfG_P61wgjSS21zqQ` + un montant sec (553,75 €), sans explication.

**Après** (même paiement) :
- **Séjour aux 4 Sources · du 15 septembre 2026 au 17 septembre 2026**
- *Acompte de 553,75 € sur un séjour de 1 107,50 € — La Hulotte, Camping*
- Email du client pré-rempli sur la page Stripe.

## Détails

- La description distingue **acompte** (rien d'encaissé), **solde** (un encaissement existe — le paiement du solde passe aussi par `PayService`, donc couvert) et **montant total**.
- Composition : gîte nommé, « Salles & espaces », « Camping », « Emplacement van », nombre d'activités actives.
- Paiements historiques booking-seuls : libellé inchangé (`Réservation #token`).
- `StripeService` ne pose `description`/`customer_email` que si présents (Stripe refuse les valeurs vides).
- Montants au format maison (`Money#format`, symbole après, centimes omis si ronds).

## Vérifications

- 8 specs `Payments::PayService` sur les arguments réellement envoyés à Stripe (nom daté, repli sans dates, acompte, solde, total, composition, email pré-rempli, legacy).
- Suite complète : **809 exemples, 0 échec**.
- ⚠️ Rendu Stripe réel non testable en dev (clé factice) — à valider d'un coup d'œil lors de ton prochain test prod.