### PR TITLE
fix(mailer): email de demande terminé + email « acompte reçu » au webhook

### DIFF
--- a/app/mailers/reservation_mailer.rb
+++ b/app/mailers/reservation_mailer.rb
@@ -10,9 +10,28 @@ class ReservationMailer < ApplicationMailer
     # hébergement n'a d'ailleurs pas de booking.
     @token = stay.token
     @quote = quote_from(stay)
+    # L'acompte confirme la réservation : cet email est aussi le filet de
+    # rattrapage si le client a quitté la page Stripe sans payer — il porte
+    # donc le montant et un lien de paiement direct tant que l'acompte est dû.
+    @pending_deposit = stay.payments.pending.where(payment_method: "card")
+                           .order(:created_at).first
     mail(
       to: stay.customer.email,
       subject: "Votre demande de réservation aux 4 Sources"
+    )
+  end
+
+  # Second email du flux (décision 2026-07-20) : envoyé par le webhook Stripe
+  # au PREMIER encaissement d'un séjour encore `pending` — « acompte bien reçu,
+  # notre équipe valide votre demande ». Le solde d'un séjour confirmé ne passe
+  # jamais ici (voir Stripe::CompletedCheckoutService).
+  def deposit_received(payment)
+    @payment = payment
+    @stay = payment.stay
+    @token = @stay.token
+    mail(
+      to: @stay.customer.email,
+      subject: "Acompte bien reçu — votre réservation aux 4 Sources"
     )
   end
 

--- a/app/services/stripe/completed_checkout_service.rb
+++ b/app/services/stripe/completed_checkout_service.rb
@@ -25,6 +25,7 @@ module Stripe
       @payment.stay&.set_payment_status
       @payment.booking&.set_payment_status
       email_admin
+      email_customer_deposit_received
       true
     end
 
@@ -32,6 +33,21 @@ module Stripe
 
     def email_admin
       AdminMailer.payment_received(payment).deliver_later
+    end
+
+    # Second email client du flux funnel (décision 2026-07-20) : « acompte bien
+    # reçu, notre équipe valide votre demande ». UNIQUEMENT au premier
+    # encaissement d'un séjour encore `pending` — le paiement du solde ou tout
+    # encaissement d'un séjour déjà confirmé ne redéclenche pas ce message de
+    # pré-validation. L'idempotence webhook est déjà garantie en amont
+    # (StripeEvent) ; le garde « premier paid » protège en plus contre un rejeu.
+    def email_customer_deposit_received
+      stay = payment.stay
+      return unless stay&.status == "pending"
+      return if stay.customer&.email.blank?
+      return if stay.payments.paid.where.not(id: payment.id).exists?
+
+      ReservationMailer.deposit_received(payment).deliver_later
     end
   end
 end

--- a/app/views/reservation_mailer/confirmation_request.html.slim
+++ b/app/views/reservation_mailer/confirmation_request.html.slim
@@ -1,13 +1,31 @@
+/ NB Slim : deux lignes `|` consécutives se concatènent SANS espace — toujours
+  une seule barre avec continuation indentée pour la prose multi-ligne.
 p Bonjour #{@stay.customer.first_name.presence || ""},
 
 p
-  | Merci pour votre demande de réservation aux 4 Sources. Elle a bien été
-  | enregistrée et sera validée par notre équipe avant confirmation définitive.
+  | Merci pour votre demande de réservation aux 4 Sources. Elle est bien
+    enregistrée.
 
 - if @stay.arrival_date && @stay.departure_date
   p
     strong Dates :
-    | = " #{l(@stay.arrival_date, format: :long)} → #{l(@stay.departure_date, format: :long)}"
+    = " #{l(@stay.arrival_date, format: :long)} → #{l(@stay.departure_date, format: :long)}"
+
+- if @pending_deposit
+  - pay_url = pay_public_payment_url(@pending_deposit, host: ENV.fetch("APPLICATION_HOST", "app.les4sources.be"))
+  p
+    | Pour confirmer votre réservation, il reste l'acompte de
+      #{number_to_currency(@pending_deposit.amount_cents / 100.0, unit: "€", format: "%n %u", precision: 2)}
+      à régler — si ce n'est pas déjà fait :
+  p
+    = link_to "Régler mon acompte", pay_url
+  p
+    | Dès l'acompte reçu, notre équipe valide votre demande et vous envoie la
+      confirmation définitive.
+- else
+  p
+    | Votre demande sera validée par notre équipe avant confirmation
+      définitive.
 
 - if @quote && @quote.lines.any?
   h3 Récapitulatif de votre devis

--- a/app/views/reservation_mailer/confirmation_request.text.erb
+++ b/app/views/reservation_mailer/confirmation_request.text.erb
@@ -1,9 +1,17 @@
 Bonjour <%= @stay.customer.first_name.presence || "" %>,
 
-Merci pour votre demande de réservation aux 4 Sources. Elle a bien été enregistrée et sera validée par notre équipe avant confirmation définitive.
+Merci pour votre demande de réservation aux 4 Sources. Elle est bien enregistrée.
 
 <% if @stay.arrival_date && @stay.departure_date %>
 Dates : <%= l(@stay.arrival_date, format: :long) %> -> <%= l(@stay.departure_date, format: :long) %>
+<% end %>
+<% if @pending_deposit %>
+Pour confirmer votre réservation, il reste l'acompte de <%= number_to_currency(@pending_deposit.amount_cents / 100.0, unit: "€", format: "%n %u", precision: 2) %> à régler — si ce n'est pas déjà fait :
+<%= pay_public_payment_url(@pending_deposit, host: ENV.fetch("APPLICATION_HOST", "app.les4sources.be")) %>
+
+Dès l'acompte reçu, notre équipe valide votre demande et vous envoie la confirmation définitive.
+<% else %>
+Votre demande sera validée par notre équipe avant confirmation définitive.
 <% end %>
 <% if @quote && @quote.lines.any? %>
 Récapitulatif de votre devis :

--- a/app/views/reservation_mailer/deposit_received.html.slim
+++ b/app/views/reservation_mailer/deposit_received.html.slim
@@ -1,0 +1,24 @@
+p Bonjour #{@stay.customer.first_name.presence || ""},
+
+p
+  | Nous avons bien reçu votre acompte de
+    #{number_to_currency(@payment.amount_cents / 100.0, unit: "€", format: "%n %u", precision: 2)}
+    — merci !
+
+p
+  | Votre demande de réservation est maintenant en cours de validation par
+    notre équipe : vous recevrez très vite la confirmation définitive.
+
+- if @stay.arrival_date && @stay.departure_date
+  p
+    strong Dates :
+    = " #{l(@stay.arrival_date, format: :long)} → #{l(@stay.departure_date, format: :long)}"
+
+- if @token
+  - consultation_url = public_stay_url(@token, host: ENV.fetch("APPLICATION_HOST", "app.les4sources.be"))
+  p
+    | Vous pouvez consulter votre séjour à tout moment via ce lien :
+    br
+    = link_to consultation_url, consultation_url
+
+p À très bientôt aux 4 Sources !

--- a/app/views/reservation_mailer/deposit_received.text.erb
+++ b/app/views/reservation_mailer/deposit_received.text.erb
@@ -1,0 +1,14 @@
+Bonjour <%= @stay.customer.first_name.presence || "" %>,
+
+Nous avons bien reçu votre acompte de <%= number_to_currency(@payment.amount_cents / 100.0, unit: "€", format: "%n %u", precision: 2) %> — merci !
+
+Votre demande de réservation est maintenant en cours de validation par notre équipe : vous recevrez très vite la confirmation définitive.
+
+<% if @stay.arrival_date && @stay.departure_date %>
+Dates : <%= l(@stay.arrival_date, format: :long) %> -> <%= l(@stay.departure_date, format: :long) %>
+<% end %>
+<% if @token %>
+Consultez votre séjour : <%= public_stay_url(@token, host: ENV.fetch("APPLICATION_HOST", "app.les4sources.be")) %>
+<% end %>
+
+À très bientôt aux 4 Sources !

--- a/spec/mailers/reservation_mailer_spec.rb
+++ b/spec/mailers/reservation_mailer_spec.rb
@@ -47,5 +47,66 @@ RSpec.describe ReservationMailer, type: :mailer do
       expect(mail.body.encoded).to include("745") # Hulotte 2 nuits = 485 + 260 = 745 €
       expect(mail.body.encoded).to match(/pas de TVA en plus/i)
     end
+
+    # Bug 2026-07-20 : deux lignes `|` Slim consécutives se concatènent sans
+    # espace (« étéenregistrée ») et `| = "…"` sortait littéralement `= "` dans
+    # le corps. On verrouille le rendu réel, espaces normalisés.
+    it "rend une prose propre (pas de mots collés ni de `= \"` littéral)" do
+      html = mail.html_part.body.decoded.gsub(/\s+/, " ")
+
+      expect(html).to include("Elle est bien enregistrée")
+      expect(html).not_to include('= "')
+      expect(html).not_to match(/Dates\s*:=/)
+    end
+
+    context "avec un acompte encore dû (paiement pending)" do
+      let!(:deposit) do
+        Payment.create!(stay: stay, booking: booking, amount_cents: 37_250,
+                        status: "pending", payment_method: "card")
+      end
+
+      it "annonce le montant de l'acompte et le lien de paiement direct" do
+        html = mail.html_part.body.decoded.gsub(/\s+/, " ")
+        text = mail.text_part.body.decoded
+
+        expect(html).to include("372,50 €")
+        expect(html).to include("Régler mon acompte")
+        [html, text].each do |body|
+          expect(body).to include("/payments/#{deposit.id}/pay")
+        end
+      end
+    end
+
+    it "sans acompte dû, replie sur la mention de validation par l'équipe" do
+      html = mail.html_part.body.decoded.gsub(/\s+/, " ")
+
+      expect(html).not_to include("Régler mon acompte")
+      expect(html).to include("validée par notre équipe")
+    end
+  end
+
+  describe "#deposit_received (email post-acompte, décision 2026-07-20)" do
+    let!(:deposit) do
+      Payment.create!(stay: stay, booking: booking, amount_cents: 37_250,
+                      status: "paid", payment_method: "card")
+    end
+
+    subject(:mail) { described_class.deposit_received(deposit) }
+
+    it "adresse le mail au Customer avec le bon sujet" do
+      expect(mail.to).to eq(["guest@example.com"])
+      expect(mail.subject).to include("Acompte bien reçu")
+    end
+
+    it "confirme le montant reçu et la validation à venir (html ET texte)" do
+      html = mail.html_part.body.decoded.gsub(/\s+/, " ")
+      text = mail.text_part.body.decoded
+
+      [html, text].each do |body|
+        expect(body).to include("372,50 €")
+        expect(body).to include("validation par")
+        expect(body).to include("/sejour/#{stay.reload.token}")
+      end
+    end
   end
 end

--- a/spec/services/stripe/completed_checkout_service_spec.rb
+++ b/spec/services/stripe/completed_checkout_service_spec.rb
@@ -56,6 +56,52 @@ RSpec.describe Stripe::CompletedCheckoutService do
     expect(stay.reload.payment_status).to eq("paid")
   end
 
+  # Décision 2026-07-20 : l'acompte confirme la réservation → le client reçoit
+  # « acompte bien reçu » au PREMIER encaissement d'un séjour pending, et
+  # uniquement là.
+  describe "email client « acompte reçu »" do
+    before { ActiveJob::Base.queue_adapter = :test }
+
+    it "part au premier encaissement d'un séjour pending" do
+      payment = Payment.create!(stay: stay, amount_cents: 24_250,
+                                status: "pending", payment_method: "card")
+
+      expect {
+        described_class.new(payment: payment).run!(webhook_params)
+      }.to have_enqueued_mail(ReservationMailer, :deposit_received)
+    end
+
+    it "ne repart PAS pour un paiement suivant (solde) du même séjour" do
+      Payment.create!(stay: stay, amount_cents: 24_250, status: "paid", payment_method: "card")
+      balance = Payment.create!(stay: stay, amount_cents: 24_250,
+                                status: "pending", payment_method: "card")
+
+      expect {
+        described_class.new(payment: balance).run!(webhook_params)
+      }.not_to have_enqueued_mail(ReservationMailer, :deposit_received)
+    end
+
+    it "ne part pas pour un séjour déjà confirmé" do
+      stay.update!(status: "confirmed")
+      payment = Payment.create!(stay: stay, amount_cents: 24_250,
+                                status: "pending", payment_method: "card")
+
+      expect {
+        described_class.new(payment: payment).run!(webhook_params)
+      }.not_to have_enqueued_mail(ReservationMailer, :deposit_received)
+    end
+
+    it "ne part pas pour un paiement legacy sans séjour" do
+      payment = Payment.new(booking: booking, amount_cents: 48_500,
+                            status: "pending", payment_method: "card")
+      payment.save!(validate: false)
+
+      expect {
+        described_class.new(payment: payment).run!(webhook_params)
+      }.not_to have_enqueued_mail(ReservationMailer, :deposit_received)
+    end
+  end
+
   it "ne plante pas sur un paiement historique sans séjour" do
     # Donnée LEGACY d'avant le verrouillage Phase 4 (aucun stay_id) : on
     # contourne la validation pour reproduire l'état réel en base. Le webhook


### PR DESCRIPTION
## Problème

L'email de demande partait avec des coquilles (« étéenregistrée » — deux lignes `|` Slim se concatènent sans espace ; `Dates := "…"` — un `| = "…"` sort le `= "` littéralement) et ne disait rien de l'acompte, alors que c'est lui qui confirme la réservation.

## Nouveau flux (2 emails)

1. **À la soumission** — « Votre demande de réservation aux 4 Sources » : prose corrigée, dates propres, **montant de l'acompte encore dû + bouton « Régler mon acompte »** (lien Stripe direct). C'est le filet de rattrapage si le client abandonne la page Stripe : sans lui, une demande non payée n'avait aucune relance possible. Sans acompte dû, repli sur la mention de validation par l'équipe.
2. **Au webhook Stripe** — « Acompte bien reçu — votre réservation aux 4 Sources » : montant reçu, demande en cours de validation par l'équipe, lien séjour. Déclenché UNIQUEMENT au premier encaissement d'un séjour encore `pending` — le paiement du solde ou un séjour confirmé ne le renvoient jamais.

## Vérifications

- Specs mailer : prose verrouillée (espaces normalisés — un mot collé ou un `= \"` littéral ferait échouer), bloc acompte (montant + lien `/payments/:id/pay`), fallback sans acompte, nouvel email (sujet, montant, lien séjour, html + texte).
- Specs webhook : 4 cas (premier encaissement → envoi ; solde → non ; séjour confirmé → non ; paiement legacy sans séjour → non).
- Suite complète : **818 exemples, 0 échec**.