### PR TITLE
feat(calendar): un seul bloc par séjour et par jour sur le calendrier admin

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,14 +21,14 @@ class PagesController < BaseController
       # regrouper les occupations par `stay_id` sans requête N+1.
       @space_reservations = SpaceReservation.all
         .includes(:space_booking)
-        .preload(:space, space_booking: [:event, :space_reservations, :stay])
+        .preload(:space, space_booking: [:event, :space_reservations, { stay: :customer }])
         .where.not(space_booking: { status: ["declined", "canceled"] })
         .between_times(@first, @last, field: :date)
       @grouped_space_reservations = @space_reservations.to_a.group_by { |sr| sr.date }
       # group reservations by day (préchargement du séjour porteur, cf. supra)
       @reservations = Reservation.all
         .includes(:booking)
-        .preload(:room, booking: [:lodging, :reservations, :stay])
+        .preload(:room, booking: [:lodging, :reservations, { stay: :customer }])
         .where.not(booking: { status: ["declined", "canceled"] })
         .between_times(@first, @last, field: :date)
       @grouped_reservations = @reservations.to_a.group_by { |r| r.date }
@@ -38,13 +38,13 @@ class PagesController < BaseController
       # séjour. Préchargement du séjour (anti-N+1).
       @grouped_camping_bookings = nights_grouped_by_day(
         CampingBooking
-          .includes(:stay)
+          .includes(stay: :customer)
           .where.not(status: ["declined", "canceled"])
           .where("from_date < ? AND to_date > ?", @last.to_date, @first.to_date)
       )
       @grouped_van_bookings = nights_grouped_by_day(
         VanBooking
-          .includes(:stay)
+          .includes(stay: :customer)
           .where.not(status: ["declined", "canceled"])
           .where("from_date < ? AND to_date > ?", @last.to_date, @first.to_date)
       )

--- a/app/frontend/controllers/dashboard_calendar_controller.js
+++ b/app/frontend/controllers/dashboard_calendar_controller.js
@@ -8,12 +8,7 @@ export default class extends Controller {
     'pastWeeksToggler'
   ]
 
-  connect() {
-    console.log('connect dashboard-calendar')
-  }
-
   initialize() {
-    console.log('initialize dashboard-calendar')
     const isCurrent = this.data.get('current')
     if (isCurrent == 'true') {
       this.hidePastWeeks()
@@ -21,7 +16,6 @@ export default class extends Controller {
   }
 
   hidePastWeeks() {
-    console.log('hidePastWeeks')
     this.weekTargets.forEach((el, i) => {
       if (el.dataset.pastWeek == 'true') {
         el.classList.add('hidden')
@@ -36,9 +30,7 @@ export default class extends Controller {
 
   clickCalendar(e) {
     // hide popovers
-    console.log('click calendar', e.target.dataset.popoverTarget)
     document.querySelectorAll('.popover').forEach((element) => {
-      console.log(element.id, e.target.dataset.popoverTarget)
       if (element.id != e.target.dataset.popoverTarget) {
         element.classList.replace('visible', 'invisible')
       }

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -61,7 +61,10 @@ module CalendarHelper
     total_nights = (to - from).to_i
     return nil if total_nights <= 1
 
-    day = (current_date.to_date - from + 1).to_i
+    # Borné : une occupation posée le jour du départ (espace réservé le jour du
+    # checkout — les dates du séjour dérivent du max des bookables) afficherait
+    # sinon un « (3/2) » absurde. Revue Forge F1.
+    day = (current_date.to_date - from + 1).to_i.clamp(1, total_nights)
     "(#{day}/#{total_nights})"
   end
 

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -48,6 +48,23 @@ module CalendarHelper
     end
   end
 
+  # Compteur de nuits AU NIVEAU DU SÉJOUR pour le bloc unifié (« (2/3) »). Même
+  # convention que `BookingDecorator#dates_counter`, mais adossée aux dates du
+  # séjour (arrival/departure) plutôt qu'à un bookable isolé : un seul compteur
+  # pour tout le séjour, quel que soit le nombre de composants. Renvoie `nil`
+  # pour une nuitée unique (rien à compter) ou si les dates manquent.
+  def stay_nights_counter(stay, current_date)
+    from = stay&.arrival_date
+    to   = stay&.departure_date
+    return nil if from.blank? || to.blank?
+
+    total_nights = (to - from).to_i
+    return nil if total_nights <= 1
+
+    day = (current_date.to_date - from + 1).to_i
+    "(#{day}/#{total_nights})"
+  end
+
   def button_to_next_month(current_date, data = {}, options = {})
     link_to(params.permit(:date, :no_title, :view).merge(date: current_date.next_month), class: "btn-page-header-with-icon", data: data) do
       if options[:no_label].nil?

--- a/app/presenters/calendar/day_stay_blocks.rb
+++ b/app/presenters/calendar/day_stay_blocks.rb
@@ -45,28 +45,31 @@ module Calendar
     # Blocs unifiés (un par séjour), triés par id de séjour puis date d'arrivée
     # — même ordre stable qu'avant, pour ne pas faire sautiller le calendrier.
     def stay_blocks
+      # Clé = stay.id (revue Forge F4) : les quatre collections viennent de
+      # requêtes préchargées distinctes, donc d'INSTANCES Ruby différentes du
+      # même Stay — l'unicité du bloc ne doit pas dépendre de l'égalité AR.
       by_stay = {}
 
       @booking_groups.each do |group|
         stay = group.booking.stay
         next if stay.nil?
-        (by_stay[stay] ||= new_block(stay)).booking_groups << group
+        (by_stay[stay.id] ||= new_block(stay)).booking_groups << group
       end
 
       @space_groups.each do |group|
         stay = group.space_booking.stay
         next if stay.nil?
-        (by_stay[stay] ||= new_block(stay)).space_groups << group
+        (by_stay[stay.id] ||= new_block(stay)).space_groups << group
       end
 
       @camping.each do |camping|
         next if camping.stay.nil?
-        (by_stay[camping.stay] ||= new_block(camping.stay)).camping_bookings << camping
+        (by_stay[camping.stay.id] ||= new_block(camping.stay)).camping_bookings << camping
       end
 
       @van.each do |van|
         next if van.stay.nil?
-        (by_stay[van.stay] ||= new_block(van.stay)).van_bookings << van
+        (by_stay[van.stay.id] ||= new_block(van.stay)).van_bookings << van
       end
 
       by_stay.values.sort_by { |block| [block.stay.id.to_i, block.stay.arrival_date.to_s] }

--- a/app/presenters/calendar/day_stay_blocks.rb
+++ b/app/presenters/calendar/day_stay_blocks.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Calendar
+  # Agrège, pour UNE date, toutes les occupations calendrier d'un même séjour
+  # (chambres, gîte entier, espaces, camping, van) en UN SEUL bloc par séjour.
+  # C'est de la PURE AGRÉGATION D'AFFICHAGE : aucune logique de dispo / de veto,
+  # aucune requête modifiée — on recompose seulement ce que le contrôleur a déjà
+  # chargé dans les hash `@grouped_*` (epic #66) pour le rendu du calendrier.
+  #
+  # Les occupations SANS séjour rattaché (bookings legacy, OTA, space bookings
+  # orphelins) sont renvoyées À PART et gardent leur rendu bloc-par-bloc
+  # historique, popovers compris — voir `_day_bookings` / `_bookings`.
+  class DayStayBlocks
+    # Un bloc unifié : un séjour et ses composants présents ce jour-là.
+    StayBlock = Struct.new(
+      :stay, :booking_groups, :space_groups, :camping_bookings, :van_bookings,
+      keyword_init: true
+    ) do
+      # Le bookable « nommé » (Booking ou SpaceBooking, tous deux décorés et
+      # porteurs de `group_or_name`) qui donne le titre du bloc. Priorité à
+      # l'hébergement, puis aux espaces.
+      def named_bookable
+        booking_groups.first&.booking || space_groups.first&.space_booking
+      end
+
+      # Repli quand le séjour n'a que du camping / van (pas de bookable nommé).
+      def fallback_bookable
+        camping_bookings.first || van_bookings.first
+      end
+    end
+
+    # Sous-groupe hébergement : un Booking décoré + ses Reservation (chambres).
+    BookingGroup = Struct.new(:booking, :reservations, keyword_init: true)
+    # Sous-groupe espace : un SpaceBooking décoré + ses SpaceReservation.
+    SpaceGroup = Struct.new(:space_booking, :space_reservations, keyword_init: true)
+
+    def initialize(date, grouped_reservations:, grouped_space_reservations:,
+                   grouped_camping_bookings:, grouped_van_bookings:)
+      @booking_groups = build_booking_groups(grouped_reservations && grouped_reservations[date])
+      @space_groups   = build_space_groups(grouped_space_reservations && grouped_space_reservations[date])
+      @camping        = Array(grouped_camping_bookings && grouped_camping_bookings[date])
+      @van            = Array(grouped_van_bookings && grouped_van_bookings[date])
+    end
+
+    # Blocs unifiés (un par séjour), triés par id de séjour puis date d'arrivée
+    # — même ordre stable qu'avant, pour ne pas faire sautiller le calendrier.
+    def stay_blocks
+      by_stay = {}
+
+      @booking_groups.each do |group|
+        stay = group.booking.stay
+        next if stay.nil?
+        (by_stay[stay] ||= new_block(stay)).booking_groups << group
+      end
+
+      @space_groups.each do |group|
+        stay = group.space_booking.stay
+        next if stay.nil?
+        (by_stay[stay] ||= new_block(stay)).space_groups << group
+      end
+
+      @camping.each do |camping|
+        next if camping.stay.nil?
+        (by_stay[camping.stay] ||= new_block(camping.stay)).camping_bookings << camping
+      end
+
+      @van.each do |van|
+        next if van.stay.nil?
+        (by_stay[van.stay] ||= new_block(van.stay)).van_bookings << van
+      end
+
+      by_stay.values.sort_by { |block| [block.stay.id.to_i, block.stay.arrival_date.to_s] }
+    end
+
+    # Hébergements SANS séjour : [BookingGroup, ...] (rendu bloc-par-bloc legacy).
+    def no_stay_booking_groups
+      @booking_groups.select { |group| group.booking.stay.nil? }
+    end
+
+    # Camping / van SANS séjour : gardent leur bloc informatif « Camping » / « Van ».
+    def no_stay_camping
+      @camping.select { |camping| camping.stay.nil? }
+    end
+
+    def no_stay_van
+      @van.select { |van| van.stay.nil? }
+    end
+
+    private
+
+    def new_block(stay)
+      StayBlock.new(stay: stay, booking_groups: [], space_groups: [],
+                    camping_bookings: [], van_bookings: [])
+    end
+
+    # Réplique le regroupement historique des vues : trie par heure, regroupe par
+    # booking, décore, retrie par séjour — mais renvoie des structs typées.
+    def build_booking_groups(reservations)
+      return [] if reservations.blank?
+
+      reservations
+        .sort_by(&:start_time)
+        .group_by { |reservation| reservation.booking.id }
+        .map do |_booking_id, grouped|
+          BookingGroup.new(
+            booking: BookingDecorator.new(grouped.first.booking),
+            reservations: grouped
+          )
+        end
+        .sort_by { |group| [group.booking.stay&.id.to_i, group.reservations.first.start_time] }
+    end
+
+    def build_space_groups(space_reservations)
+      return [] if space_reservations.blank?
+
+      space_reservations
+        .sort_by(&:start_time)
+        .group_by { |space_reservation| space_reservation.space_booking.id }
+        .map do |_space_booking_id, grouped|
+          SpaceGroup.new(
+            space_booking: SpaceBookingDecorator.new(grouped.first.space_booking),
+            space_reservations: grouped
+          )
+        end
+        .sort_by { |group| [group.space_booking.stay&.id.to_i, group.space_reservations.first.start_time] }
+    end
+  end
+end

--- a/app/views/pages/calendar/_bookings.html.slim
+++ b/app/views/pages/calendar/_bookings.html.slim
@@ -21,32 +21,24 @@
                       class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
       .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-event-#{event.id}" data-popover-trigger-value="click")
 
-  / Space reservations — regroupées et colorées PAR SÉJOUR (epic #66, Phase 4) :
-  / couleur stable par `stay_id` (style inline), blocs triés par séjour, un bloc
-  / par ESPACE occupé conservé, `data-stay-id` posé pour la modale Phase 5.
+  / Space reservations SANS séjour rattaché uniquement (bloc par ESPACE + popover
+  / historique). Les espaces AVEC séjour ont rejoint le BLOC SÉJOUR UNIFIÉ rendu
+  / dans la cellule du jour (pages/calendar/_day_bookings via Calendar::DayStayBlocks) :
+  / on ne les rend donc PLUS ici, pour ne pas les afficher deux fois.
   - if @grouped_space_reservations[date]
-    - @grouped_space_reservations[date].sort_by {|sr| sr.start_time }.group_by { |sr| sr.space_booking.id }.sort_by { |_space_booking_id, space_reservations| [space_reservations.first.space_booking.stay&.id.to_i, space_reservations.first.start_time] }.each do |grouped_space_reservations|
+    - @grouped_space_reservations[date].select { |sr| sr.space_booking.stay.nil? }.sort_by {|sr| sr.start_time }.group_by { |sr| sr.space_booking.id }.sort_by { |_space_booking_id, space_reservations| space_reservations.first.start_time }.each do |grouped_space_reservations|
       - space_reservation = grouped_space_reservations.last.first
       - space_booking = SpaceBookingDecorator.new(space_reservation.space_booking)
-      - stay = space_booking.stay
-      - block_style = stay ? stay_block_style(stay.id) : nil
-      / Sans séjour rattaché : on garde le popover d'info historique (fallback).
-      - if stay.nil?
-        .popover.absolute.z-10.invisible.inline-block.w-64.text-sm.font-light.text-gray-500.transition-opacity.duration-300.bg-white.border.border-gray-200.rounded-lg.shadow-sm.opacity-0[id="popover-space-reservation-#{space_reservation.id}" data-popover role="tooltip"]
-          = render "space_bookings/popover",
-                   space_booking: space_booking
-          div[data-popper-arrow]
+      .popover.absolute.z-10.invisible.inline-block.w-64.text-sm.font-light.text-gray-500.transition-opacity.duration-300.bg-white.border.border-gray-200.rounded-lg.shadow-sm.opacity-0[id="popover-space-reservation-#{space_reservation.id}" data-popover role="tooltip"]
+        = render "space_bookings/popover",
+                 space_booking: space_booking
+        div[data-popper-arrow]
 
-      div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{space_booking.calendar_block_class}" style=block_style data-space-booking-day-entry=space_booking.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
+      div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{space_booking.calendar_block_class}" data-space-booking-day-entry=space_booking.id)
         .block.min-w-0.w-full
           div.min-w-0
             strong.block.min-w-0.break-words
-              / Édition unifiée (issue #99) : avec un séjour vivant, le lien ouvre la
-              / modale séjour (comme l'overlay). Cas résiduel sans séjour → fiche show.
-              - if stay
-                = link_to space_booking.decorate.group_or_name.html_safe, stay_path(stay), data: { action: "stay-details#open" }, class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
-              - else
-                = link_to space_booking.decorate.group_or_name.html_safe, space_booking_path(space_booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+              = link_to space_booking.decorate.group_or_name.html_safe, space_booking_path(space_booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
             - if space_booking.event.presence
               .text-gray-500.leading-none.mb-2.font-semibold = space_booking.event.name_with_color
 
@@ -58,12 +50,7 @@
 
           .block.text-gray-500
             = space_booking.duration
-        / Overlay cliquable : ouvre la modale séjour (epic #66, Phase 5). Sans
-        / séjour, on retombe sur le popover d'info historique.
-        - if stay
-          a.absolute.top-0.left-0.w-full.h-full(href=stay_path(stay) data-action="stay-details#open" aria-label="Voir le séjour ##{stay.id}")
-        - else
-          .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-space-reservation-#{space_reservation.id}" data-popover-trigger-value="click")
+        .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-space-reservation-#{space_reservation.id}" data-popover-trigger-value="click")
 
   / Les séjours (bookings hébergement) ne sont plus rendus ici : ils vivent dans
   / la cellule du jour, entre les avatars veilleurs et les notes — voir

--- a/app/views/pages/calendar/_day_bookings.html.slim
+++ b/app/views/pages/calendar/_day_bookings.html.slim
@@ -1,79 +1,57 @@
 / Séjours du jour, rendus dans la cellule entre les avatars veilleurs et les
-/ notes (demande Michael 2026-07-13 — remplace les barres hebdo de l'issue #10).
-/ Depuis l'epic #66 Phase 4, les occupations sont REGROUPÉES ET COLORÉES PAR
-/ SÉJOUR (`stay_id`) : couleur stable par séjour (style inline, cf.
-/ CalendarHelper#stay_block_style), blocs triés par séjour, et `data-stay-id`
-/ posé pour câbler la modale séjour en Phase 5. On garde UN BLOC PAR RESSOURCE
-/ occupée (chambre/lodging) — source de vérité du veto Grand-Duc, inchangée.
-- if @grouped_reservations && @grouped_reservations[date]
-  - @grouped_reservations[date].sort_by {|r| r.start_time }.group_by { |r| r.booking.id }.sort_by { |_booking_id, reservations| [reservations.first.booking.stay&.id.to_i, reservations.first.start_time] }.each do |grouped_reservations|
-    - reservation = grouped_reservations.last.first
-    - booking = BookingDecorator.new(reservation.booking)
-    - stay = booking.stay
-    - block_style = stay ? stay_block_style(stay.id) : nil
+/ notes. Depuis cette passe « bloc unifié », les occupations D'UN MÊME SÉJOUR
+/ (chambres + gîte + espaces + camping + van) sont fusionnées en UN SEUL bloc par
+/ séjour et par jour (badges compacts) — plus lisible qu'un bloc par composant.
+/ L'agrégation (pure affichage, aucune logique de dispo/veto) vit dans
+/ Calendar::DayStayBlocks. Les occupations SANS séjour gardent leur rendu
+/ bloc-par-bloc historique et leurs popovers (fallbacks plus bas).
+- blocks = Calendar::DayStayBlocks.new(date, grouped_reservations: @grouped_reservations, grouped_space_reservations: @grouped_space_reservations, grouped_camping_bookings: @grouped_camping_bookings, grouped_van_bookings: @grouped_van_bookings)
 
-    / Sans séjour rattaché : on garde le popover d'info historique (fallback).
-    - if stay.nil?
-      .popover.absolute.z-10.invisible.inline-block.w-64.text-sm.font-light.text-gray-500.transition-opacity.duration-300.bg-white.border.border-gray-200.rounded-lg.shadow-sm.opacity-0[id="popover-reservation-#{reservation.id}" data-popover role="tooltip"]
-        = render "bookings/popover",
-                 booking: booking
-        div[data-popper-arrow]
+/ 1) Blocs SÉJOUR unifiés (un par séjour), couleur stable + câblage modale/fusion.
+- blocks.stay_blocks.each do |stay_block|
+  = render "pages/calendar/day_stay_block", block: stay_block, date: date
 
-    div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_block_class}" style=block_style data-booking-day-entry=booking.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
-      .block.min-w-0.w-full
-        div.min-w-0
-          strong.block.min-w-0.break-words
-            / Édition unifiée (issue #99) : avec un séjour vivant, le lien ouvre la
-            / modale séjour (comme l'overlay). Cas résiduel sans séjour → fiche show.
-            - if stay
-              = link_to booking.decorate.group_or_name.html_safe, stay_path(stay), data: { action: "stay-details#open" }, class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
-            - else
-              = link_to booking.decorate.group_or_name.html_safe, booking_path(booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+/ 2) Hébergements SANS séjour rattaché (bookings legacy / OTA) : bloc par booking,
+/ avec le popover d'info historique — comportement strictement inchangé.
+- blocks.no_stay_booking_groups.each do |group|
+  - booking = group.booking
+  - reservation = group.reservations.first
+  .popover.absolute.z-10.invisible.inline-block.w-64.text-sm.font-light.text-gray-500.transition-opacity.duration-300.bg-white.border.border-gray-200.rounded-lg.shadow-sm.opacity-0[id="popover-reservation-#{reservation.id}" data-popover role="tooltip"]
+    = render "bookings/popover",
+             booking: booking
+    div[data-popper-arrow]
 
-          span.text-gray-500 =< booking.dates_counter(date)
+  div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 #{booking.calendar_block_class}" data-booking-day-entry=booking.id)
+    .block.min-w-0.w-full
+      div.min-w-0
+        strong.block.min-w-0.break-words
+          = link_to booking.decorate.group_or_name.html_safe, booking_path(booking), class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
 
-        - if !booking.lodging.nil?
-          = booking.lodging_badge
-        - else
-          .grid.grid-cols-3.gap-1
-            - grouped_reservations.last.each do |reservation|
-              = room_badge(reservation.room)
-      / Overlay cliquable : ouvre la modale séjour (epic #66, Phase 5). Sans
-      / séjour, on retombe sur le popover d'info historique.
-      - if stay
-        a.absolute.top-0.left-0.w-full.h-full(href=stay_path(stay) data-action="stay-details#open" aria-label="Voir le séjour ##{stay.id}")
+        span.text-gray-500 =< booking.dates_counter(date)
+
+      - if !booking.lodging.nil?
+        = booking.lodging_badge
       - else
-        .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-reservation-#{reservation.id}" data-popover-trigger-value="click")
+        .grid.grid-cols-3.gap-1
+          - group.reservations.each do |reservation|
+            = room_badge(reservation.room)
+    .absolute.top-0.left-0.w-full.h-full(data-controller="popover" data-action="click->popover#toggle click@window->popover#hideOnClickOutside" data-popover-target-value="popover-reservation-#{reservation.id}" data-popover-trigger-value="click")
 
-/ Camping (epic #66, Phase 4) — bloc agrégé « Camping » par nuit occupée, coloré
-/ par séjour. Capacité GLOBALE du terrain : pas de ressource nommée (décision
-/ figée) donc pas de badge chambre/espace, ni de veto par ressource. Pas de route
-/ admin dédiée à ce jour → bloc informatif, `data-stay-id` prêt pour la Phase 5.
-- if @grouped_camping_bookings && @grouped_camping_bookings[date]
-  - @grouped_camping_bookings[date].sort_by { |cb| [cb.stay&.id.to_i, cb.from_date.to_s] }.each do |camping|
-    - stay = camping.stay
-    - block_style = stay ? stay_block_style(stay.id) : "border-left-color: #0d9488; background-color: #f0fdfa;"
-    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"hover:cursor-pointer hover:shadow-xl" if stay} #{"opacity-50" unless camping.confirmed?}" style=block_style data-camping-booking-entry=camping.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
-      .block.min-w-0.w-full
-        strong.block.min-w-0.break-words.text-gray-700
-          = camping.group_name.presence || camping.name.presence || "Camping"
-        .text-xs.text-gray-500
-          | ⛺ Camping · #{camping.people} pers.
-      / Camping cliquable (epic #66, Phase 5) : ouvre la modale de son séjour porteur.
-      - if stay
-        a.absolute.top-0.left-0.w-full.h-full(href=stay_path(stay) data-action="stay-details#open" aria-label="Voir le séjour ##{stay.id}")
+/ 3) Camping SANS séjour (epic #66, Phase 4) — bloc agrégé « Camping » par nuit,
+/ capacité GLOBALE du terrain : pas de ressource nommée, pas de veto par ressource.
+- blocks.no_stay_camping.each do |camping|
+  div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"opacity-50" unless camping.confirmed?}" style="border-left-color: #0d9488; background-color: #f0fdfa;" data-camping-booking-entry=camping.id)
+    .block.min-w-0.w-full
+      strong.block.min-w-0.break-words.text-gray-700
+        = camping.group_name.presence || camping.name.presence || "Camping"
+      .text-xs.text-gray-500
+        | ⛺ Camping · #{camping.people} pers.
 
-/ Van / camping-car (epic #66, Phase 4) — même logique que le camping.
-- if @grouped_van_bookings && @grouped_van_bookings[date]
-  - @grouped_van_bookings[date].sort_by { |vb| [vb.stay&.id.to_i, vb.from_date.to_s] }.each do |van|
-    - stay = van.stay
-    - block_style = stay ? stay_block_style(stay.id) : "border-left-color: #0d9488; background-color: #f0fdfa;"
-    div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"hover:cursor-pointer hover:shadow-xl" if stay} #{"opacity-50" unless van.confirmed?}" style=block_style data-van-booking-entry=van.id data-stay-id=stay&.id data-stay-label=(stay && stay_short_label(stay)) data-stay-dates=(stay && stay_short_dates(stay)))
-      .block.min-w-0.w-full
-        strong.block.min-w-0.break-words.text-gray-700
-          = van.group_name.presence || van.name.presence || "Van"
-        .text-xs.text-gray-500
-          | 🚐 Van · #{van.vehicles} véh.
-      / Van cliquable (epic #66, Phase 5) : ouvre la modale de son séjour porteur.
-      - if stay
-        a.absolute.top-0.left-0.w-full.h-full(href=stay_path(stay) data-action="stay-details#open" aria-label="Voir le séjour ##{stay.id}")
+/ 4) Van / camping-car SANS séjour — même logique que le camping.
+- blocks.no_stay_van.each do |van|
+  div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4 #{"opacity-50" unless van.confirmed?}" style="border-left-color: #0d9488; background-color: #f0fdfa;" data-van-booking-entry=van.id)
+    .block.min-w-0.w-full
+      strong.block.min-w-0.break-words.text-gray-700
+        = van.group_name.presence || van.name.presence || "Van"
+      .text-xs.text-gray-500
+        | 🚐 Van · #{van.vehicles} véh.

--- a/app/views/pages/calendar/_day_stay_block.html.slim
+++ b/app/views/pages/calendar/_day_stay_block.html.slim
@@ -1,0 +1,49 @@
+/ Bloc SÉJOUR UNIFIÉ — UN SEUL bloc par séjour et par jour (remplace les blocs
+/ par composant : chambres + gîte + espaces + camping + van fusionnés en badges
+/ compacts sur un même bloc). Couleur stable par séjour (style inline via
+/ CalendarHelper#stay_block_style). Le câblage `data-stay-*` + l'overlay
+/ `stay-details#open` sont IDENTIQUES aux anciens blocs : la modale séjour ET le
+/ mode fusion (stay_merge, sélection par `[data-stay-id]`) continuent de marcher —
+/ un seul bloc sélectionnable par séjour et par jour. Agrégation : voir
+/ Calendar::DayStayBlocks. Locals : `block` (StayBlock), `date`.
+- stay = block.stay
+- confirmed = stay.status.to_s == "confirmed"
+- named = block.named_bookable
+- fallback = block.fallback_bookable
+- counter = stay_nights_counter(stay, date)
+div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min-w-0 shadow border-l-4 #{"opacity-50" unless confirmed}" style=stay_block_style(stay.id) data-stay-id=stay.id data-stay-label=stay_short_label(stay) data-stay-dates=stay_short_dates(stay))
+  .block.min-w-0.w-full
+    div.min-w-0
+      strong.block.min-w-0.break-words
+        / Titre = nom du groupe/client (comme avant). Le lien ouvre la modale séjour.
+        - if named
+          = link_to named.group_or_name.html_safe, stay_path(stay), data: { action: "stay-details#open" }, class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+        - else
+          = link_to (fallback&.group_name.presence || fallback&.name.presence || stay_short_label(stay)), stay_path(stay), data: { action: "stay-details#open" }, class: "text-blue-700 hover:text-blue-900 focus:text-blue-900 text-base/6 break-words"
+      - if counter
+        span.text-gray-500 =< counter
+
+    / Badges compacts de tous les composants du séjour, sur le même bloc.
+    .flex.flex-wrap.items-center.gap-1.mt-1
+      / Hébergement : gîte entier (un badge) OU chambres (un badge par chambre).
+      - block.booking_groups.each do |group|
+        - if group.booking.lodging.nil?
+          - group.reservations.each do |reservation|
+            = room_badge(reservation.room)
+        - else
+          = group.booking.lodging_badge
+      / Espaces : un badge par espace occupé, suivi de la durée si pertinente.
+      - block.space_groups.each do |group|
+        - group.space_reservations.each do |space_reservation|
+          = space_badge(space_reservation.space)
+        span.text-xs.text-gray-500.whitespace-nowrap = group.space_booking.duration
+      / Camping : capacité globale du terrain (pas de ressource nommée) → chip info.
+      - block.camping_bookings.each do |camping|
+        span(class="text-xs text-gray-600 whitespace-nowrap") ⛺ Camping · #{camping.people} pers.
+      / Van / camping-car : même logique que le camping.
+      - block.van_bookings.each do |van|
+        span(class="text-xs text-gray-600 whitespace-nowrap") 🚐 Van · #{van.vehicles} véh.
+
+  / Overlay cliquable : ouvre la modale séjour (epic #66, Phase 5) et sert de
+  / cible unique au mode fusion pour tout le séjour.
+  a.absolute.top-0.left-0.w-full.h-full(href=stay_path(stay) data-action="stay-details#open" aria-label="Voir le séjour ##{stay.id}")

--- a/spec/requests/calendar_stay_modal_spec.rb
+++ b/spec/requests/calendar_stay_modal_spec.rb
@@ -96,7 +96,10 @@ RSpec.describe "Calendrier — modale séjour depuis les blocs (epic #66, Phase 
       get "/"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("data-camping-booking-entry=\"#{camping.id}\"")
+      # Camping AVEC séjour : désormais agrégé dans le bloc SÉJOUR UNIFIÉ, qui
+      # porte `data-stay-id` et ouvre la modale via l'overlay `stay_path`.
+      expect(response.body).to include("data-stay-id=\"#{stay.id}\"")
+      expect(response.body).to include("⛺ Camping")
       expect(response.body).to include("href=\"#{stay_path(stay)}\"")
     end
   end

--- a/spec/requests/calendar_stays_grouping_spec.rb
+++ b/spec/requests/calendar_stays_grouping_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Calendrier — regroupement par séjour (epic #66, Phase 4)", ty
       expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
     end
 
-    it "groupe un séjour MULTI-RESSOURCES (hébergement + espace) sous le même séjour et la même couleur" do
+    it "fusionne un séjour MULTI-RESSOURCES (hébergement + espace) en UN SEUL bloc" do
       from = Date.today.next_occurring(:friday)
       stay, _booking = stay_with_lodging(from: from, to: from + 1)
 
@@ -58,11 +58,12 @@ RSpec.describe "Calendrier — regroupement par séjour (epic #66, Phase 4)", ty
 
       get "/"
 
-      # Le bloc chambre ET le bloc espace portent le même stay_id…
-      expect(response.body).to include("data-booking-day-entry=\"#{_booking.id}\"")
-      expect(response.body).to include("data-space-booking-day-entry=\"#{space_booking.id}\"")
-      # …et la même teinte de séjour.
-      expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to be >= 2
+      # Bloc SÉJOUR UNIFIÉ : un seul `data-stay-id` ce jour-là (avant : un bloc
+      # par ressource, donc plusieurs). L'hébergement ET l'espace sont agrégés…
+      expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to eq(1)
+      # …le badge espace (orange) figure bien dans ce bloc unifié…
+      expect(response.body).to include("bg-orange-100")
+      # …et la teinte stable du séjour colore le bloc.
       expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
     end
 
@@ -87,14 +88,17 @@ RSpec.describe "Calendrier — regroupement par séjour (epic #66, Phase 4)", ty
   end
 
   describe "occupations chambres — anti-régression veto Grand-Duc" do
-    it "rend toujours un bloc par jour réservé avec le badge chambre" do
+    it "rend un bloc séjour par jour réservé, la source du veto restant les Reservation en base" do
       from = Date.today.next_occurring(:friday)
       stay, booking = stay_with_lodging(from: from, to: from + 2)
 
       get "/"
 
-      # Deux nuits réservées → deux entrées jour (la source de vérité du veto).
-      expect(response.body.scan("data-booking-day-entry=\"#{booking.id}\"").size).to eq(2)
+      # Deux nuits réservées → deux cellules du jour → deux blocs séjour unifiés.
+      expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to eq(2)
+      # La VRAIE source de vérité du veto reste la table Reservation (inchangée
+      # par la fusion d'affichage) : une réservation de chambre par nuit.
+      expect(Reservation.where(booking: booking).count).to eq(2)
       # Édition unifiée (epic #81, Phase 8) : le bloc pointe vers la modale séjour,
       # plus vers la fiche booking legacy. On borne à la grille (le flux d'activité,
       # hors scope, garde son lien booking historique).
@@ -120,7 +124,7 @@ RSpec.describe "Calendrier — regroupement par séjour (epic #66, Phase 4)", ty
   end
 
   describe "camping / van agrégés, groupés par séjour" do
-    it "rend un bloc « Camping » par nuit occupée, coloré par le séjour" do
+    it "rend un bloc séjour par nuit occupée avec la chip camping agrégée, coloré par le séjour" do
       from = Date.today.next_occurring(:friday)
       to   = from + 2 # 2 nuits
       camping = CampingBooking.create!(firstname: "Cam", group_name: "Groupe Camping",
@@ -134,10 +138,12 @@ RSpec.describe "Calendrier — regroupement par séjour (epic #66, Phase 4)", ty
       get "/"
 
       expect(response).to have_http_status(:ok)
-      # Une entrée camping par nuit (2), colorée par le séjour.
-      expect(response.body.scan("data-camping-booking-entry=\"#{camping.id}\"").size).to eq(2)
+      # Bloc séjour unifié : une entrée par nuit (2), colorée par le séjour, avec
+      # la chip camping agrégée (avant : un bloc « Camping » distinct par nuit).
+      expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to eq(2)
       expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
       expect(response.body).to include("Groupe Camping")
+      expect(response.body).to include("⛺ Camping · 4 pers.")
     end
   end
 

--- a/spec/requests/calendar_unified_stay_block_spec.rb
+++ b/spec/requests/calendar_unified_stay_block_spec.rb
@@ -68,6 +68,62 @@ RSpec.describe "Calendrier — bloc séjour unifié", type: :request do
     expect(response.body).to include("href=\"#{stay_path(stay)}\"")
   end
 
+  # Revue Forge F3 — les cas subtils du split avec/sans séjour, verrouillés.
+  it "rend UN bloc pour un séjour espaces-seuls (sans hébergement)" do
+    from = Date.today.next_occurring(:friday)
+
+    customer = Customers::UpsertByEmail.call(email: "salle@example.com", attrs: { first_name: "Salle" })
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: from, departure_date: from)
+    space_booking = SpaceBooking.create!(firstname: "Salle", group_name: "Salle seule",
+                                         from_date: from, to_date: from, status: "confirmed")
+    SpaceReservation.create!(space: space, space_booking: space_booking, date: from)
+    StayItem.create!(stay: stay, bookable: space_booking)
+
+    get "/"
+
+    expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to eq(1)
+    # Pas de double rendu : l'espace AVEC séjour ne sort plus en bloc espace legacy.
+    expect(response.body).not_to include("data-space-booking-day-entry=\"#{space_booking.id}\"")
+  end
+
+  it "rend le bloc séjour un jour où seul l'ESPACE occupe (aucune chambre ce jour-là)" do
+    from = Date.today.next_occurring(:friday)
+
+    customer = Customers::UpsertByEmail.call(email: "decale@example.com", attrs: { first_name: "Décalé" })
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: from, departure_date: from + 2)
+    booking = Booking.create!(firstname: "Décalé", group_name: "Séjour Décalé", lodging: nil,
+                              from_date: from, to_date: from + 1, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0)
+    Reservation.create!(booking: booking, room: room_a, date: from) # chambre : nuit `from` uniquement
+    StayItem.create!(stay: stay, bookable: booking)
+    space_booking = SpaceBooking.create!(firstname: "Décalé", group_name: "Séjour Décalé",
+                                         from_date: from + 2, to_date: from + 2, status: "confirmed")
+    SpaceReservation.create!(space: space, space_booking: space_booking, date: from + 2) # jour du départ
+    StayItem.create!(stay: stay, bookable: space_booking)
+
+    get "/"
+
+    # Deux jours rendus pour ce séjour : la nuit chambre ET le jour espace-seul.
+    expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to eq(2)
+    # Compteur borné (Forge F1) : le jour du départ n'affiche jamais (3/2).
+    expect(response.body).not_to include("(3/2)")
+  end
+
+  it "laisse un espace SANS séjour garder son bloc espace legacy" do
+    from = Date.today.next_occurring(:friday)
+
+    space_booking = SpaceBooking.create!(firstname: "Externe", group_name: "Salle externe",
+                                         from_date: from, to_date: from, status: "confirmed")
+    SpaceReservation.create!(space: space, space_booking: space_booking, date: from)
+    # PAS de Stay / StayItem.
+
+    get "/"
+
+    expect(response.body).to include("data-space-booking-day-entry=\"#{space_booking.id}\"")
+  end
+
   it "laisse un booking SANS séjour garder son propre bloc et son lien fiche" do
     from = Date.today.next_occurring(:friday)
 

--- a/spec/requests/calendar_unified_stay_block_spec.rb
+++ b/spec/requests/calendar_unified_stay_block_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+# Bloc SÉJOUR UNIFIÉ — sur le calendrier admin (racine), un séjour multi-composants
+# (chambres + espace + camping + van) doit produire UN SEUL bloc par séjour et par
+# jour, agrégeant ses composants en badges compacts, au lieu d'un bloc par
+# composant. Les occupations SANS séjour gardent leur bloc propre.
+RSpec.describe "Calendrier — bloc séjour unifié", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent-unified@les4sources.be", password: "password123") }
+  let(:room_a) { Room.create!(name: "Chambre A", code: "CHA", level: 1) }
+  let(:room_b) { Room.create!(name: "Chambre B", code: "CHB", level: 2) }
+  let(:space)  { Space.create!(name: "Grande Salle", code: "GS", capacity: 40) }
+
+  before { sign_in user }
+
+  def hue_for(stay_id)
+    ((stay_id * CalendarHelper::GOLDEN_ANGLE) % 360).round
+  end
+
+  it "fusionne chambres + espace + camping + van d'un même séjour en UN SEUL bloc par jour" do
+    from = Date.today.next_occurring(:friday)
+
+    customer = Customers::UpsertByEmail.call(email: "complet@example.com", attrs: { first_name: "Complet" })
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: from, departure_date: from + 1)
+
+    # Hébergement SANS gîte entier → badges chambres (2 chambres), sur la nuit `from`.
+    booking = Booking.create!(firstname: "Complet", group_name: "Séjour Complet", lodging: nil,
+                              from_date: from, to_date: from + 1, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0)
+    Reservation.create!(booking: booking, room: room_a, date: from)
+    Reservation.create!(booking: booking, room: room_b, date: from)
+    StayItem.create!(stay: stay, bookable: booking)
+
+    # Espace, camping, van rattachés AU MÊME séjour, même nuit.
+    space_booking = SpaceBooking.create!(firstname: "Complet", group_name: "Séjour Complet",
+                                         from_date: from, to_date: from, status: "confirmed")
+    SpaceReservation.create!(space: space, space_booking: space_booking, date: from)
+    StayItem.create!(stay: stay, bookable: space_booking)
+
+    camping = CampingBooking.create!(firstname: "Complet", group_name: "Séjour Complet",
+                                     from_date: from, to_date: from + 1, people: 3,
+                                     status: "confirmed", kind: "tente")
+    StayItem.create!(stay: stay, bookable: camping)
+
+    van = VanBooking.create!(firstname: "Complet", group_name: "Séjour Complet",
+                             from_date: from, to_date: from + 1, vehicles: 2, status: "confirmed")
+    StayItem.create!(stay: stay, bookable: van)
+
+    get "/"
+
+    expect(response).to have_http_status(:ok)
+
+    # UN SEUL bloc pour ce séjour ce jour-là (avant : 4 blocs distincts).
+    expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to eq(1)
+
+    # …qui agrège TOUS les composants en badges compacts sur le même bloc.
+    expect(response.body).to include("CHA")            # badge chambre A
+    expect(response.body).to include("CHB")            # badge chambre B
+    expect(response.body).to include("GS")             # badge espace
+    expect(response.body).to include("⛺ Camping · 3 pers.")
+    expect(response.body).to include("🚐 Van · 2 véh.")
+
+    # Couleur stable par séjour + câblage modale conservés.
+    expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
+    expect(response.body).to include("data-action=\"stay-details#open\"")
+    expect(response.body).to include("href=\"#{stay_path(stay)}\"")
+  end
+
+  it "laisse un booking SANS séjour garder son propre bloc et son lien fiche" do
+    from = Date.today.next_occurring(:friday)
+
+    booking = Booking.create!(firstname: "Legacy", group_name: "Sans séjour", lodging: nil,
+                              from_date: from, to_date: from + 1, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0)
+    Reservation.create!(booking: booking, room: room_a, date: from)
+    # PAS de Stay / StayItem.
+
+    get "/"
+
+    expect(response).to have_http_status(:ok)
+    # Bloc legacy conservé : son entrée par jour + le lien vers la fiche booking.
+    expect(response.body).to include("data-booking-day-entry=\"#{booking.id}\"")
+    expect(response.body).to include(booking_path(booking))
+  end
+end

--- a/spec/requests/stays_ota_spec.rb
+++ b/spec/requests/stays_ota_spec.rb
@@ -125,8 +125,10 @@ RSpec.describe "Stays — canal OTA (epic #81, Phase 4)", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("data-stay-id=\"#{stay.id}\"")
-      # 2 nuits → 2 entrées jour chambre (la représentation qui porte le veto).
-      expect(response.body.scan("data-booking-day-entry=\"#{booking.id}\"").size).to eq(2)
+      # 2 nuits → 2 cellules du jour → 2 blocs séjour unifiés (la table Reservation,
+      # qui porte le veto, reste à 2 nuits indépendamment de la fusion d'affichage).
+      expect(response.body.scan("data-stay-id=\"#{stay.id}\"").size).to eq(2)
+      expect(Reservation.where(booking: booking).count).to eq(2)
       expect(response.body).to include("hsl(#{hue_for(stay.id)}, 65%, 45%)")
     end
   end


### PR DESCRIPTION
## Quoi

Un séjour multi-composants créait un bloc PAR composant et PAR jour (chambres, camping, van, salle = 4 blocs pour « Test formulaire »). Le calendrier rend désormais **UN bloc par séjour et par jour** : nom + compteur de nuits `(n/N)` + badges compacts (chambres OU gîte, espaces, `⛺ Camping · N pers.`, `🚐 Van · N véh.`), couleur stable par séjour, clic → modale séjour. Les occupations **sans** séjour (legacy, Airbnb, événements, espaces externes) gardent leur rendu et leurs popovers historiques.

Architecture : agrégation pure d'affichage dans `Calendar::DayStayBlocks` (presenter, keyé par `stay.id`), partial unique `_day_stay_block`, les espaces avec séjour quittent `_bookings` pour le bloc unifié (aucun double rendu). Aucune logique de données/dispo/veto touchée.

## Vérifications

- **agent-browser (desktop + mobile 390px)** : séjour multi-composants créé via `/stays/new` → **1 bloc/jour au lieu de 4**, badges complets, modale OK, **mode fusion OK** (sélection ✓ sur le bloc unifié, `data-stay-id` conservé), 38 blocs legacy du mois intacts, zéro erreur console, aucun débordement mobile.
- **Revue Forge (GPT-5.4)** : PASS ; ses findings sont intégrés — compteur borné (plus de `(3/2)` quand un espace tombe le jour du départ), clé de regroupement `stay.id`, 3 specs de verrouillage supplémentaires (espaces-seuls, jour espace-seul, non-double-rendu).
- Bonus : retrait des `console.log` de debug du contrôleur calendrier (flood console à chaque clic).
- Suite complète : **823 exemples, 0 échec**.

## Anomalie découverte en passant (hors périmètre, non corrigée ici)

Le formulaire admin `/stays/new` semble **ignorer la date/période de la salle** : espace persisté « du 21 au 23 » avec « période non précisée » alors que le formulaire envoyait bien `halls[0][date]=2026-09-22` + `period=journee`. À investiguer séparément.