### PR TITLE
fix(spaces): dates réelles + vocabulaire canonique de durée pour les espaces composés

### DIFF
--- a/app/services/concerns/space_composition.rb
+++ b/app/services/concerns/space_composition.rb
@@ -45,6 +45,19 @@ module SpaceComposition
     "cuisine_pro"  => "Cuisine professionnelle"
   }.freeze
 
+  # Période de PRICING (funnel/admin : "journee"…) → durée CANONIQUE de
+  # `SpaceReservation#duration` (vocabulaire tranche 1 : "day"/"evening"/
+  # "fullday"/"2h"/"see_notes", celui que lit `SpaceBookingDecorator#duration`).
+  # Sans ce mapping, la composition persistait "journee" → affiché « période
+  # non précisée » partout (bug repéré le 2026-07-20). L'inverse vit dans
+  # `Stays::DraftReconstructor` (édition → clés de pricing).
+  DURATION_BY_PERIOD = {
+    "journee"           => "day",
+    "soiree"            => "evening",
+    "journee_et_soiree" => "fullday"
+  }.freeze
+  PERIOD_BY_DURATION = DURATION_BY_PERIOD.invert.freeze
+
   private
 
   # Avertissement (String) listant les espaces DEVISÉS mais NON persistables
@@ -93,8 +106,10 @@ module SpaceComposition
 
   # Crée un `SpaceBooking` + ses `SpaceReservation` à partir de specs résolues,
   # et le rattache au séjour via un `StayItem`. Retourne le `SpaceBooking`.
-  # `window` = [arrival_date, departure_date] du draft, pour fixer from/to_date
-  # sur la fenêtre du séjour (cohérent avec `Stay#recompute_aggregates!`).
+  # `from/to_date` = les dates RÉELLEMENT occupées (min/max des specs) — pas la
+  # fenêtre du séjour : une salle louée le seul 22 ne doit pas s'afficher
+  # « du 21 au 23 » (bug repéré le 2026-07-20). Repli sur la fenêtre du draft
+  # si les specs n'ont pas de dates (défensif).
   def persist_space_booking!(stay:, draft:, specs:, status:, price_cents:)
     space_booking = build_space_booking(draft: draft, specs: specs, status: status, price_cents: price_cents)
     space_booking.save!
@@ -110,8 +125,8 @@ module SpaceComposition
       email:          Customer.normalize_email(draft.email),
       phone:          draft.phone,
       group_name:     draft.group_name,
-      from_date:      draft.arrival_date || dates.min,
-      to_date:        draft.departure_date || dates.max,
+      from_date:      dates.min || draft.arrival_date,
+      to_date:        dates.max || draft.departure_date,
       status:         status,
       payment_status: "pending",
       price_cents:    price_cents
@@ -162,7 +177,7 @@ module SpaceComposition
         next unless SPACE_NAMES_BY_KEY.key?(key.to_s)
         Array(periods).each_with_index do |period, night_idx|
           next if period.blank?
-          entries << { key: key.to_s, date: arrival + night_idx, duration: period.to_s }
+          entries << { key: key.to_s, date: arrival + night_idx, duration: canonical_duration(period) }
         end
       end
     end
@@ -175,10 +190,16 @@ module SpaceComposition
       next if period.blank?
       date = parse_space_date(hall[:date])
       next if date.nil?
-      entries << { key: key, date: date, duration: period }
+      entries << { key: key, date: date, duration: canonical_duration(period) }
     end
 
     entries
+  end
+
+  # Toujours persister le vocabulaire canonique ; une valeur déjà canonique
+  # (réédition d'un séjour, donnée historique) passe inchangée.
+  def canonical_duration(period)
+    DURATION_BY_PERIOD.fetch(period.to_s, period.to_s)
   end
 
   def space_for_key(key)

--- a/app/services/stays/draft_reconstructor.rb
+++ b/app/services/stays/draft_reconstructor.rb
@@ -113,7 +113,11 @@ module Stays
       sb.space_reservations.map do |res|
         key = space_key_for(res.space)
         next if key.nil?
-        { kind: key, date: res.date&.iso8601, period: res.duration }
+        # Durée canonique persistée ("day"…) → clé de PRICING ("journee"…),
+        # sinon le devis d'édition ne retrouverait pas son tarif. Une valeur
+        # historique déjà en vocabulaire pricing passe inchangée.
+        period = SpaceComposition::PERIOD_BY_DURATION.fetch(res.duration.to_s, res.duration)
+        { kind: key, date: res.date&.iso8601, period: period }
       end.compact
     end
 

--- a/db/migrate/20260720184658_normalize_space_reservation_durations.rb
+++ b/db/migrate/20260720184658_normalize_space_reservation_durations.rb
@@ -1,0 +1,51 @@
+class NormalizeSpaceReservationDurations < ActiveRecord::Migration[7.0]
+  # La composition de séjour (funnel + admin) persistait les périodes de PRICING
+  # ("journee"/"soiree"/"journee_et_soiree") dans `space_reservations.duration`,
+  # alors que tout l'affichage lit le vocabulaire canonique tranche 1
+  # ("day"/"evening"/"fullday") → « période non précisée » partout. Le code
+  # persiste désormais le canonique ; on normalise l'existant. Idempotent,
+  # inclut les lignes soft-deleted (données d'affichage historiques).
+  MAPPING = {
+    "journee"           => "day",
+    "soiree"            => "evening",
+    "journee_et_soiree" => "fullday"
+  }.freeze
+
+  def up
+    MAPPING.each do |period, duration|
+      execute <<~SQL
+        UPDATE space_reservations SET duration = #{quote(duration)} WHERE duration = #{quote(period)}
+      SQL
+    end
+
+    # Même bug, volet dates : la composition posait from/to_date sur la fenêtre
+    # du séjour au lieu des dates réellement réservées (« du 21 au 23 » pour une
+    # salle du seul 22). On réaligne sur min/max des SpaceReservation VIVANTES,
+    # uniquement là où ça diverge — les données historiques cohérentes (canal
+    # direct tranche 1, from/to == bornes des réservations) ne bougent pas.
+    execute <<~SQL
+      UPDATE space_bookings sb
+      SET from_date = bounds.min_date, to_date = bounds.max_date
+      FROM (
+        SELECT space_booking_id, MIN(date) AS min_date, MAX(date) AS max_date
+        FROM space_reservations
+        WHERE deleted_at IS NULL
+        GROUP BY space_booking_id
+      ) bounds
+      WHERE bounds.space_booking_id = sb.id
+        AND (sb.from_date IS DISTINCT FROM bounds.min_date
+          OR sb.to_date   IS DISTINCT FROM bounds.max_date)
+    SQL
+  end
+
+  def down
+    # Volontairement irréversible : on ne sait pas distinguer un "day" historique
+    # d'un "day" normalisé. Le vocabulaire canonique reste valide dans les deux mondes.
+  end
+
+  private
+
+  def quote(value)
+    ActiveRecord::Base.connection.quote(value)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_19_190000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_20_184658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"

--- a/spec/requests/stays_admin_spaces_spec.rb
+++ b/spec/requests/stays_admin_spaces_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Stays — espaces (epic #66, Phase 2)", type: :request do
 
       stay.reload
       sb = stay.stay_items.where(bookable_type: "SpaceBooking").first.bookable
-      expect(sb.space_reservations.first.duration).to eq("journee_et_soiree")
+      expect(sb.space_reservations.first.duration).to eq("fullday") # durée canonique (fix 2026-07-20)
       expect(stay.total_amount_cents).to eq(38_000)
     end
 

--- a/spec/services/reservations/builder_spaces_spec.rb
+++ b/spec/services/reservations/builder_spaces_spec.rb
@@ -53,6 +53,50 @@ RSpec.describe Reservations::Builder, "espaces (epic #66, Phase 2)" do
     end
   end
 
+  # Bug 2026-07-20 : la salle demandée « le 22, journée » était persistée sur la
+  # fenêtre du séjour (21→23) avec la période de PRICING brute ("journee"), que
+  # l'affichage (vocabulaire tranche 1) traduit… « période non précisée ».
+  describe "dates réelles + vocabulaire canonique de durée" do
+    it "persiste la durée CANONIQUE (day/evening/fullday), jamais la clé de pricing" do
+      builder = described_class.new(
+        draft: draft(halls: [hall(period: "journee"),
+                             hall(date: arrival + 1, period: "soiree"),
+                             hall(date: arrival + 2, period: "journee_et_soiree")]),
+        admin: true, source: "manual"
+      )
+      expect(builder.run).to be(true)
+
+      durations = builder.space_booking.space_reservations.order(:date).map(&:duration)
+      expect(durations).to eq(%w[day evening fullday])
+      # Le décorateur (source des libellés partout) sait donc les afficher.
+      decorated = SpaceBookingDecorator.new(builder.space_booking)
+      expect(decorated.duration).not_to include("non précisée")
+    end
+
+    it "borne from/to_date aux dates RÉELLEMENT occupées, pas à la fenêtre du séjour" do
+      middle_day = arrival + 1
+      builder = described_class.new(
+        draft: draft(halls: [hall(date: middle_day)]), admin: true, source: "manual"
+      )
+      expect(builder.run).to be(true)
+
+      sb = builder.space_booking
+      expect(sb.from_date).to eq(middle_day)
+      expect(sb.to_date).to eq(middle_day)
+    end
+
+    it "aller-retour édition : le DraftReconstructor re-mappe la durée en clé de pricing" do
+      builder = described_class.new(draft: draft(halls: [hall(period: "journee")]),
+                                    admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      rebuilt = Stays::DraftReconstructor.new(builder.stay.reload).to_draft
+      expect(rebuilt.halls.first[:period]).to eq("journee")
+      # …et le devis d'édition retrouve son tarif (290 € — pas un 0 silencieux).
+      expect(rebuilt.quote.spaces_cents).to eq(grande_salle_journee_cents)
+    end
+  end
+
   describe "séjour « espaces seuls » (sans hébergement)" do
     let(:spaces_only) { draft(lodging_id: nil, halls: [hall]) }
 
@@ -77,8 +121,11 @@ RSpec.describe Reservations::Builder, "espaces (epic #66, Phase 2)" do
       stay.recompute_aggregates!
       stay.reload
       expect(stay.total_amount_cents).to eq(grande_salle_journee_cents)
+      # Depuis le fix 2026-07-20, le SpaceBooking porte ses dates RÉELLES (le
+      # seul jour de salle réservé), plus la fenêtre saisie du séjour : le
+      # recompute d'un séjour espaces-seuls s'aligne donc sur la salle.
       expect(stay.arrival_date).to eq(arrival)
-      expect(stay.departure_date).to eq(departure)
+      expect(stay.departure_date).to eq(arrival)
     end
   end
 


### PR DESCRIPTION
## Bug (repéré lors de la vérification du calendrier unifié)

Une salle demandée « le 22 septembre, journée » via la composition de séjour (`/stays/new` admin **ou** funnel public) était persistée et affichée **« du 21 au 23, période non précisée »**.

## Deux causes

1. **Vocabulaire** : la composition stockait la clé de PRICING brute (`journee` / `soiree` / `journee_et_soiree`) dans `space_reservations.duration`, alors que tout l'affichage lit le vocabulaire canonique de la tranche 1 (`day` / `evening` / `fullday`) → repli « période non précisée » partout. Fix au point d'ingestion (`SpaceComposition::DURATION_BY_PERIOD`), avec le mapping inverse dans `DraftReconstructor` — sans lui, le devis d'édition ne retrouvait plus son tarif (0 € silencieux, couvert par spec).
2. **Dates** : `build_space_booking` posait `from/to_date` sur la fenêtre du séjour au lieu des dates réellement réservées. Ils portent désormais min/max des réservations réelles. Conséquence assumée (documentée en spec) : le recompute d'un séjour espaces-seuls s'aligne sur les dates réelles de la salle.

## Migration de données (incluse)

Normalise les `duration` existantes et réaligne `from/to_date` sur les bornes des `SpaceReservation` vivantes — **uniquement là où ça diverge** ; l'historique cohérent du canal direct tranche 1 ne bouge pas. Idempotente ; down volontairement no-op.

## Vérifications

- 3 specs Builder (durée canonique + décorateur lisible, dates réelles, aller-retour édition avec tarif retrouvé) ; 2 specs existantes réalignées sur le nouveau contrat (documentées).
- Suite complète : **821 exemples, 0 échec**.
- Probe sur le séjour même du bug (après migration locale) : `22/09 → 22/09, "day"` → affiché « journée ».

⚠️ Après merge + deploy : `rails db:migrate` tourne au deploy Hatchbox — vérifier ensuite dans la modale du séjour test que la salle affiche « le 22 septembre · journée ».