### PR TITLE
feat(customers): suppression gardée d'un client sans séjour vivant

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,6 +1,6 @@
 class CustomersController < BaseController
   before_action :set_accounting_view
-  before_action :get_customer, only: [:show, :edit, :update, :merge, :merge_preview, :merge_commit, :reassign]
+  before_action :get_customer, only: [:show, :edit, :update, :destroy, :merge, :merge_preview, :merge_commit, :reassign]
 
   breadcrumb "Clients", :customers_path, match: :exact
 
@@ -33,6 +33,22 @@ class CustomersController < BaseController
     else
       set_error_flash(@customer, @customer.errors.full_messages.join(", "))
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # Suppression d'un client — strictement gardée pour l'assainissement de
+  # l'historique. On ne supprime QUE les clients orphelins (aucun séjour vivant) :
+  # cf. Customer#deletable?. La suppression est un soft-delete (soft_deletion +
+  # PaperTrail), jamais un hard destroy (principe : rien ne se perd). Un client
+  # avec un séjour vivant est refusé, sa fiche listant la raison.
+  def destroy
+    if @customer.deletable?
+      name = @customer.display_name
+      @customer.soft_delete!
+      redirect_to customers_path, notice: "Le client #{name} a été supprimé."
+    else
+      redirect_to customer_path(@customer),
+                  alert: "Suppression impossible : #{@customer.deletion_blocker}. Re-ventilez ou supprimez d'abord ses séjours."
     end
   end
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -92,6 +92,28 @@ class Customer < ApplicationRecord
     email == CATCH_ALL_EMAIL
   end
 
+  # Nombre de séjours VIVANTS rattachés. `stays` porte le default_scope de
+  # soft-deletion de Stay : les séjours soft-deletés (restes d'assainissement)
+  # sont déjà exclus, donc ne comptent pas.
+  def live_stays_count
+    stays.count
+  end
+
+  # Un client n'est supprimable que s'il n'a AUCUN séjour vivant. C'est la seule
+  # garde qui compte : les `payments` sont dérivés `through: :stays` (zéro séjour
+  # vivant ⟹ zéro paiement vivant), et les Booking legacy ne sont reliés au
+  # Customer QUE via le graphe des séjours (stay_items). Aucun rattachement
+  # vivant ne subsiste donc en dehors des séjours.
+  def deletable?
+    live_stays_count.zero?
+  end
+
+  # Message expliquant pourquoi la suppression est refusée (nil si supprimable).
+  def deletion_blocker
+    return if deletable?
+    "#{live_stays_count} séjour(s) vivant(s) rattaché(s)"
+  end
+
   def name
     if organization? && organization_name.present?
       organization_name

--- a/app/views/customers/show.html.slim
+++ b/app/views/customers/show.html.slim
@@ -116,3 +116,15 @@
             | Notes internes
         .border-t.border-gray-200.px-4.py-4.prose.prose-sm
           = @customer.notes
+
+/ Zone destructive — discrète, tout en bas. N'apparaît que si le client n'a
+/ aucun séjour vivant (assainissement de l'historique). Sinon, indice grisé.
+.mt-8.pt-4.border-t.border-gray-200
+  - if @customer.deletable?
+    = button_to "Supprimer ce client", customer_path(@customer),
+                method: :delete,
+                class: "text-sm font-medium text-red-600 hover:text-red-800 hover:underline",
+                form: { data: { turbo_confirm: "Supprimer définitivement #{@customer.display_name} ? Ce client n'a aucun séjour et sera retiré de la liste." } }
+  - else
+    p.text-sm.text-gray-400
+      | Suppression impossible : #{@customer.deletion_blocker}.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,7 @@ Rails.application.routes.draw do
   end
 
   # Pôle Accueil : clients (Customer) + fusion de doublons / re-ventilation.
-  resources :customers, only: [:index, :show, :edit, :update] do
+  resources :customers, only: [:index, :show, :edit, :update, :destroy] do
     collection do
       get "search" # autocomplete JSON pour la re-ventilation
     end

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -59,6 +59,58 @@ RSpec.describe "Customers (admin Pôle Accueil)", type: :request do
     end
   end
 
+  describe "DELETE /customers/:id (suppression gardée)" do
+    it "soft-deletes a customer with no stay and redirects with a notice" do
+      orphan = Customer.create!(email: "orphan@example.com", first_name: "Orphelin", customer_type: "individual")
+
+      delete customer_path(orphan)
+
+      expect(response).to redirect_to(customers_path)
+      expect(flash[:notice]).to be_present
+      expect(Customer.find_by(id: orphan.id)).to be_nil          # soft-deleted (default scope)
+      expect(Customer.unscoped.find(orphan.id).deleted_at).to be_present # trace conservée
+    end
+
+    it "refuses to delete a customer with a live stay and leaves it intact" do
+      kept = Customer.create!(email: "hasstay@example.com", first_name: "Occupé", customer_type: "individual")
+      Stay.create!(customer: kept, arrival_date: Date.today + 1, departure_date: Date.today + 2)
+
+      delete customer_path(kept)
+
+      expect(response).to redirect_to(customer_path(kept))
+      expect(flash[:alert]).to be_present
+      expect(Customer.find_by(id: kept.id)).to be_present        # intact
+    end
+
+    it "allows deleting a customer whose only stays are soft-deleted (assainissement)" do
+      cleaned = Customer.create!(email: "cleaned@example.com", first_name: "Assaini", customer_type: "individual")
+      stay = Stay.create!(customer: cleaned, arrival_date: Date.today + 1, departure_date: Date.today + 2)
+      stay.soft_delete!
+
+      delete customer_path(cleaned)
+
+      expect(response).to redirect_to(customers_path)
+      expect(Customer.find_by(id: cleaned.id)).to be_nil
+    end
+  end
+
+  describe "delete affordance on the customer show page" do
+    it "shows the destructive button when the customer has no live stay" do
+      orphan = Customer.create!(email: "showorphan@example.com", first_name: "Sans", customer_type: "individual")
+      get customer_path(orphan)
+      expect(response.body).to include("Supprimer ce client")
+      expect(response.body).not_to include("Suppression impossible")
+    end
+
+    it "hides the button and shows a greyed hint when a live stay blocks deletion" do
+      blocked = Customer.create!(email: "showblocked@example.com", first_name: "Avec", customer_type: "individual")
+      Stay.create!(customer: blocked, arrival_date: Date.today + 1, departure_date: Date.today + 2)
+      get customer_path(blocked)
+      expect(response.body).to include("Suppression impossible")
+      expect(response.body).not_to include("Supprimer ce client")
+    end
+  end
+
   describe "GET /customers/search (autocomplete JSON)" do
     it "returns matching customers as JSON" do
       Customer.create!(email: "michael@semisto.org", first_name: "Michael", last_name: "Hulet", customer_type: "individual")


### PR DESCRIPTION
## Demande

Pouvoir supprimer un client qui n'a aucun séjour assigné (nettoyage post-fusion/re-ventilation).

## Implémentation

- `customers#destroy` **strictement gardé** : seul un client avec **zéro séjour vivant** est supprimable (les séjours soft-deletés ne bloquent pas — cas assainissement). Vérifié dans le graphe : les paiements dérivent des séjours (`through:`), les Bookings legacy n'ont aucune FK vers Customer — la garde séjours-vivants est autoritative.
- Suppression = **soft-delete** (`has_soft_deletion` + PaperTrail déjà en place — aucune migration). Jamais de hard-delete (P2).
- UI : bouton rouge discret en bas de fiche + `turbo-confirm` nominatif ; si séjours vivants → hint grisé « Suppression impossible : N séjour(s) ».

## Vérifications

- 17 specs requests clients (5 nouvelles : refus avec séjour vivant, autorisation à zéro séjour ou séjours soft-deletés, visibilité conditionnelle du bouton).
- Suite complète (agent worktree) : **831 examples, 0 failures**.
- Passe navigateur : à faire post-merge sur le serveur local (session de test Michael en cours sur main).

⚠️ À merger AVANT #<customers-index> (les deux touchent `customers_controller`/`customer.rb`/`customers_spec.rb` — je résoudrai la friction sur la seconde).