### PR TITLE
feat(customers): liste triable par séjours, filtre type, séjours à venir, 100/page

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -4,9 +4,29 @@ class CustomersController < BaseController
 
   breadcrumb "Clients", :customers_path, match: :exact
 
+  PER_PAGE = 100
+
   def index
-    scope = Customer.search(params[:q]).order(created_at: :desc)
-    @customers = CustomerDecorator.decorate_collection(scope.paginate(page: params[:page], per_page: 30))
+    @type = params[:type].presence_in(Customer::CUSTOMER_TYPES)
+    @sort = params[:sort]
+    @direction = params[:direction] == "asc" ? "asc" : "desc"
+
+    # Compteur total (scalaire) calculé sur la relation NON groupée : la relation
+    # `with_stay_counts` porte un GROUP BY dont le `.count` renverrait un hash et
+    # casserait will_paginate. On l'injecte donc via `total_entries:`.
+    filtered = Customer.search(params[:q])
+    filtered = filtered.where(customer_type: @type) if @type
+    total = filtered.count
+
+    scope = filtered.with_stay_counts
+    scope = if @sort == "stays"
+      scope.order(Arel.sql("stays_count #{@direction.upcase}, customers.created_at DESC"))
+    else
+      scope.order(created_at: :desc)
+    end
+
+    paginated = scope.paginate(page: params[:page], per_page: PER_PAGE, total_entries: total)
+    @customers = CustomerDecorator.decorate_collection(paginated)
   end
 
   # Autocomplete JSON pour la re-ventilation (recherche dynamique de client cible).

--- a/app/decorators/customer_decorator.rb
+++ b/app/decorators/customer_decorator.rb
@@ -35,6 +35,25 @@ class CustomerDecorator < ApplicationDecorator
     stays.current_and_future
   end
 
+  # Compteurs de la liste : lus depuis les colonnes calculées par
+  # `Customer.with_stay_counts` (aucun N+1). Repli sur une requête si le
+  # décorateur est utilisé hors de ce scope (ex. page show).
+  def stays_count
+    if object.has_attribute?(:stays_count)
+      object.stays_count.to_i
+    else
+      object.stays.count
+    end
+  end
+
+  def upcoming_stays_count
+    if object.has_attribute?(:upcoming_stays_count)
+      object.upcoming_stays_count.to_i
+    else
+      object.stays.current_and_future.count
+    end
+  end
+
   def past_stays
     stays.past
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -64,6 +64,24 @@ class Customer < ApplicationRecord
     where("email ILIKE :q OR first_name ILIKE :q OR last_name ILIKE :q OR organization_name ILIKE :q", q: q)
   }
 
+  # Compteurs de séjours calculés EN SQL (aucun N+1) pour la liste admin :
+  #   - `stays_count`          : nombre de séjours VIVANTS (soft-delete exclu) ;
+  #   - `upcoming_stays_count` : séjours vivants à venir, même sémantique que le
+  #     scope `Stay.current_and_future` (`departure_date >= aujourd'hui`).
+  # Le LEFT JOIN porte lui-même le filtre `stays.deleted_at IS NULL` (le
+  # default_scope de Stay ne s'applique pas à une jointure manuelle). GROUP BY
+  # sur la PK ⇒ `customers.*` est sélectionnable (dépendance fonctionnelle PG).
+  scope :with_stay_counts, -> {
+    today = connection.quote(Date.current)
+    select(
+      "customers.*",
+      "COUNT(stays.id) AS stays_count",
+      "COUNT(stays.id) FILTER (WHERE stays.departure_date >= #{today}) AS upcoming_stays_count"
+    )
+      .joins("LEFT JOIN stays ON stays.customer_id = customers.id AND stays.deleted_at IS NULL")
+      .group("customers.id")
+  }
+
   # Single point of email normalization, reused by the legacy migration.
   def self.normalize_email(raw)
     return nil if raw.nil?

--- a/app/views/customers/index.html.slim
+++ b/app/views/customers/index.html.slim
@@ -2,14 +2,34 @@
   = render "layouts/components/page_header",
            title: "Clients"
 
+/ Recherche — les filtres/tri actifs sont conservés via des champs cachés pour
+/ que la recherche se combine avec eux plutôt que de les réinitialiser.
 .mb-4
   = form_with url: customers_path, method: :get do
+    - if @type
+      = hidden_field_tag :type, @type
+    - if @sort.present?
+      = hidden_field_tag :sort, @sort
+      = hidden_field_tag :direction, @direction
     .flex.gap-2
       = text_field_tag :q, params[:q],
                        placeholder: "Rechercher par email, nom ou organisation…",
                        class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
       = submit_tag "Rechercher",
                    class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+
+/ Filtre par type de client (param `type`), combinable avec la recherche et le tri.
+- pill_base = "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium"
+- pill_active = "bg-indigo-600 text-white"
+- pill_idle = "bg-gray-100 text-gray-700 hover:bg-gray-200"
+nav.mb-4.flex.gap-2
+  = link_to "Tous", customers_path(request.query_parameters.except("type", "page")), class: "#{pill_base} #{@type.nil? ? pill_active : pill_idle}"
+  = link_to "Particuliers", customers_path(request.query_parameters.merge("type" => "individual").except("page")), class: "#{pill_base} #{@type == 'individual' ? pill_active : pill_idle}"
+  = link_to "Organisations", customers_path(request.query_parameters.merge("type" => "organization").except("page")), class: "#{pill_base} #{@type == 'organization' ? pill_active : pill_idle}"
+
+/ Tri par nombre de séjours : 1er clic → desc, 2e clic → asc. Conserve les autres params.
+- next_dir = (@sort == "stays" && @direction == "desc") ? "asc" : "desc"
+- sort_url = customers_path(request.query_parameters.merge("sort" => "stays", "direction" => next_dir).except("page"))
 
 .overflow-x-auto.relative
   table.w-full.text-sm.text-left.text-gray-500
@@ -22,14 +42,19 @@
         th.py-3.px-6[scope="col"]
           | Type
         th.py-3.px-6.text-center[scope="col"]
-          | Séjours
+          = link_to sort_url, class: "inline-flex items-center gap-1 hover:text-gray-900" do
+            | Séjours
+            - if @sort == "stays"
+              span.text-gray-400 = @direction == "desc" ? "▼" : "▲"
+        th.py-3.px-6.text-center[scope="col"]
+          | À venir
     tbody
       - if @customers.empty?
         tr.border-b.bg-white
-          td.py-4.px-6.text-gray-500[colspan="4"]
+          td.py-4.px-6.text-gray-500[colspan="5"]
             | Aucun client.
       - @customers.each do |customer|
-        tr.border-b.bg-white
+        tr.border-b.bg-white id="customer_#{customer.id}"
           td.py-4.px-6.font-medium.text-gray-900.whitespace-nowrap[scope="row"]
             = link_to customer.display_name,
                       customer_path(customer),
@@ -40,6 +65,8 @@
           td.py-4.px-6
             = customer.type_badge
           td.py-4.px-6.text-center
-            = customer.stays.count
+            span.font-medium.text-gray-900 data-role="total-stays" = customer.stays_count
+          td.py-4.px-6.text-center
+            span.text-gray-700 data-role="upcoming-stays" = customer.upcoming_stays_count
 
 = will_paginate @customers

--- a/spec/requests/customers_spec.rb
+++ b/spec/requests/customers_spec.rb
@@ -20,6 +20,95 @@ RSpec.describe "Customers (admin Pôle Accueil)", type: :request do
     end
   end
 
+  # Assainissement de l'historique clients (epic « liste des clients ») :
+  # tri par nombre de séjours, filtre par type, colonne « séjours à venir »,
+  # pagination à 100. Les compteurs se calculent en SQL (LEFT JOIN + COUNT +
+  # FILTER), séjours soft-deletés exclus, sans N+1.
+  describe "GET /customers — tri, filtre, compteurs, pagination" do
+    def customer_row(customer_id)
+      Nokogiri::HTML(response.body).at_css("#customer_#{customer_id}")
+    end
+
+    describe "tri par nombre de séjours vivants" do
+      let!(:few) { Customer.create!(email: "few@example.com", customer_type: "individual") }
+      let!(:many) { Customer.create!(email: "many@example.com", customer_type: "individual") }
+
+      before do
+        Stay.create!(customer: few, arrival_date: Date.today + 1, departure_date: Date.today + 2)
+        2.times do |i|
+          Stay.create!(customer: many, arrival_date: Date.today + i + 1, departure_date: Date.today + i + 2)
+        end
+        # Un séjour soft-deleté sur `few` ne doit PAS gonfler son compteur.
+        dead = Stay.create!(customer: few, arrival_date: Date.today + 5, departure_date: Date.today + 6)
+        dead.destroy
+      end
+
+      it "ordonne desc par défaut quand le tri est actif, séjours soft-deletés exclus" do
+        get customers_path, params: { sort: "stays", direction: "desc" }
+        expect(response).to have_http_status(:ok)
+        # `many` (2 séjours) avant `few` (1 séjour vivant, le soft-deleté ne compte pas).
+        expect(response.body.index("many@example.com")).to be < response.body.index("few@example.com")
+        expect(customer_row(few.id).at_css("[data-role=total-stays]").text.strip).to eq("1")
+      end
+
+      it "inverse en ordre asc au 2e clic" do
+        get customers_path, params: { sort: "stays", direction: "asc" }
+        expect(response.body.index("few@example.com")).to be < response.body.index("many@example.com")
+      end
+    end
+
+    describe "filtre par type de client" do
+      let!(:org) do
+        Customer.create!(email: "org@example.com", customer_type: "organization", organization_name: "ACME")
+      end
+
+      it "n'affiche que les organisations quand type=organization" do
+        get customers_path, params: { type: "organization" }
+        expect(response.body).to include("org@example.com")
+        expect(response.body).not_to include("admin@example.com") # individual masqué
+      end
+
+      it "n'affiche que les particuliers quand type=individual" do
+        get customers_path, params: { type: "individual" }
+        expect(response.body).to include("admin@example.com")
+        expect(response.body).not_to include("org@example.com")
+      end
+    end
+
+    describe "colonne séjours à venir" do
+      let!(:mix) { Customer.create!(email: "mix@example.com", customer_type: "individual") }
+
+      before do
+        Stay.create!(customer: mix, arrival_date: Date.today - 5, departure_date: Date.today - 3) # passé
+        Stay.create!(customer: mix, arrival_date: Date.today + 3, departure_date: Date.today + 5) # à venir
+      end
+
+      it "compte 1 séjour à venir et 2 séjours au total (un passé + un futur)" do
+        get customers_path
+        row = customer_row(mix.id)
+        expect(row.at_css("[data-role=total-stays]").text.strip).to eq("2")
+        expect(row.at_css("[data-role=upcoming-stays]").text.strip).to eq("1")
+      end
+    end
+
+    describe "pagination à 100 par page" do
+      before do
+        # `customer` (admin) existe déjà ⇒ 1 + 100 = 101 clients au total.
+        100.times { |i| Customer.create!(email: "p#{i}@example.com", customer_type: "individual") }
+      end
+
+      it "affiche 100 lignes en page 1 et 1 ligne en page 2" do
+        get customers_path
+        page1 = Nokogiri::HTML(response.body).css("tbody tr[id^='customer_']")
+        expect(page1.size).to eq(100)
+
+        get customers_path, params: { page: 2 }
+        page2 = Nokogiri::HTML(response.body).css("tbody tr[id^='customer_']")
+        expect(page2.size).to eq(1)
+      end
+    end
+  end
+
   describe "GET /customers/:id" do
     it "renders the customer page" do
       get customer_path(customer)


### PR DESCRIPTION
## Demande

Liste clients : tri par nombre de séjours, filtre particulier/organisation, nombre de séjours à venir, 100 par page.

## Implémentation

- `Customer.with_stay_counts` : une seule requête SQL — `LEFT JOIN stays` (avec `deleted_at IS NULL` DANS la jointure), `COUNT` + `COUNT FILTER (WHERE departure_date >= aujourd'hui)` (même sémantique que `Stay.current_and_future`), tri SQL borné asc/desc.
- Pills « Tous · Particuliers · Organisations » (`customer_type`), combinables avec recherche + tri (params préservés partout).
- Pagination `will_paginate` (déjà dans le Gemfile, déjà utilisé ici) passée à **100/page**, `total_entries` injecté pour contourner le `.count` groupé.
- Colonne « À venir » à côté du total de séjours.

## Vérifications

- 18 specs requests clients (7 nouvelles : ordre de tri, exclusion des soft-deletés du compte, filtre type, compteur à venir, pagination 101→100+1).
- Suite complète (agent worktree) : **832 examples, 0 failures**.
- Passe navigateur : post-merge sur le serveur local.

⚠️ À merger APRÈS la PR customer-destroy (fichiers partagés — friction résolue au merge).