### PR TITLE
feat(merge): carte survivant enrichie (email, statut, canal, notes) + notes du calendrier masquées en mode fusion

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -275,9 +275,28 @@ class StaysController < BaseController
   # Séjours candidats à la fusion, préchargés pour éviter les N+1 des aperçus.
   def load_merge_stays
     ids = Array(params[:stay_ids]).map(&:to_i).uniq.reject(&:zero?)
-    Stay.where(id: ids)
-        .includes(:customer, :meal_orders, experience_bookings: { experience_availability: :experience }, stay_items: :bookable)
-        .to_a
+    stays = Stay.where(id: ids)
+                .includes(:customer, :meal_orders, experience_bookings: { experience_availability: :experience }, stay_items: :bookable)
+                .to_a
+    preload_public_notes(stays)
+    stays
+  end
+
+  # `public_notes` est de l'ActionText (`has_rich_text`) porté par Booking et
+  # SpaceBooking UNIQUEMENT. Le `bookable` étant polymorphe (types mixtes —
+  # Camping/Van n'ont pas de rich text), on ne peut pas l'`includes` dans la
+  # requête ci-dessus sans lever une erreur ; on précharge donc le rich text sur
+  # le seul sous-ensemble concerné, pour que la carte de désignation puisse tester
+  # la présence d'une note publique sans N+1.
+  def preload_public_notes(stays)
+    notable = stays.flat_map(&:stay_items)
+                   .map(&:bookable)
+                   .select { |b| b.is_a?(Booking) || b.is_a?(SpaceBooking) }
+    return if notable.empty?
+
+    ActiveRecord::Associations::Preloader.new(
+      records: notable, associations: :rich_text_public_notes
+    ).call
   end
 
   # Résout le survivant STRICTEMENT parmi les séjours postés : un `target_id`

--- a/app/frontend/controllers/stay_merge_controller.js
+++ b/app/frontend/controllers/stay_merge_controller.js
@@ -92,6 +92,27 @@ export default class extends Controller {
       activeClasses.forEach((c) => this.toggleButtonTarget.classList.toggle(c, on))
       baseClasses.forEach((c) => this.toggleButtonTarget.classList.toggle(c, !on))
     }
+    // Les blocs notes du jour ajoutent du bruit en mode fusion (on désigne des
+    // séjours, pas des notes). Le masquage est accroché ICI — la routine d'état
+    // visuel du mode — et non dans le handler du clic : ainsi il suit AUSSI la
+    // restauration au connect() (navigation de mois, sélection persistée en
+    // sessionStorage) et la sortie du mode, sans duplication.
+    this.toggleCalendarNotes(on)
+  }
+
+  // Masque (on=true) ou réaffiche (on=false) les blocs notes du calendrier. Ils
+  // vivent hors du fragment de sélection, dans les cellules jour du template ERB
+  // (data-calendar-notes). Un simple `hidden` suffit — au rechargement d'un mois,
+  // l'état est reposé par applyModeChrome selon le mode restauré.
+  toggleCalendarNotes(hidden) {
+    document.querySelectorAll("[data-calendar-notes]").forEach((el) => {
+      el.classList.toggle("hidden", hidden)
+      if (hidden) {
+        el.setAttribute("aria-hidden", "true")
+      } else {
+        el.removeAttribute("aria-hidden")
+      }
+    })
   }
 
   // --- Sélection d'un séjour entier -----------------------------------------

--- a/app/helpers/stays_merge_helper.rb
+++ b/app/helpers/stays_merge_helper.rb
@@ -61,6 +61,41 @@ module StaysMergeHelper
     "#{pluralize_fr(count, 'paiement')} · #{humanized_money_with_symbol(Money.new(stay.amount_paid_cents))} encaissé#{'s' if count > 1}"
   end
 
+  # Canal d'attribution d'un séjour, en libellé COURT pour la carte de fusion.
+  # Distinct de `StaysHelper#stay_source_label` (libellés verbeux du form/index) :
+  # ici la carte est une comparaison rapide, donc on abrège. Le nom de l'OTA
+  # (Airbnb / Booking.com) est affiché à part par `platform_badge` (décorateur).
+  MERGE_SOURCE_LABELS = {
+    "reservation"  => "Funnel",
+    "manual"       => "Manuel",
+    "ota"          => "OTA",
+    "tally_legacy" => "Import"
+  }.freeze
+
+  def merge_source_label(stay)
+    MERGE_SOURCE_LABELS.fetch(stay.source, stay.source.to_s.humanize.presence || "—")
+  end
+
+  # Le séjour porte-t-il une note INTERNE quelque part ? (note du séjour lui-même
+  # OU note d'un de ses bookables). Itère sur les `stay_items` PRÉCHARGÉS — pas de
+  # requête supplémentaire (le contrôleur précharge `stay_items: :bookable`).
+  def stay_has_internal_note?(stay)
+    return true if stay.notes.present?
+
+    stay.stay_items.any? { |item| item.bookable&.try(:notes).present? }
+  end
+
+  # Le séjour porte-t-il une note PUBLIQUE (ActionText) sur un de ses bookables ?
+  # Seuls Booking et SpaceBooking exposent `public_notes` (has_rich_text) ; le
+  # rich text est préchargé côté contrôleur (`preload_public_notes`) pour éviter
+  # le N+1 sur cet accès.
+  def stay_has_public_note?(stay)
+    stay.stay_items.any? do |item|
+      bookable = item.bookable
+      bookable.respond_to?(:public_notes) && bookable.public_notes.body.present?
+    end
+  end
+
   # Libellé français d'une catégorie de composition (titre de section d'aperçu).
   MERGE_TYPE_LABELS = {
     lodging:  "Hébergements",

--- a/app/views/simple_calendar/_dashboard_calendar.html.erb
+++ b/app/views/simple_calendar/_dashboard_calendar.html.erb
@@ -136,7 +136,7 @@
                   <%= render partial: "pages/calendar/day_bookings", locals: { date: day } %>
                 </div>
 
-                <div id="notes-<%= day %>" class="<%= day < Date.today ? "opacity-75" : nil %>">
+                <div id="notes-<%= day %>" data-calendar-notes class="<%= day < Date.today ? "opacity-75" : nil %>">
                   <%= render Note.where(date: day).order(id: :desc) %>
                 </div>
 

--- a/app/views/stays/_merge_setup.html.slim
+++ b/app/views/stays/_merge_setup.html.slim
@@ -27,8 +27,24 @@
             - if stay.id == suggested_id
               span.inline-flex.items-center.rounded-full.bg-indigo-50.px-2.text-xs.font-medium.text-indigo-700(class="py-0.5" title="Présélection : #{merge_suggestion_reason(suggested_reason)}")
                 | suggéré · #{merge_suggestion_reason(suggested_reason)}
+          - if stay.customer&.email.present?
+            .truncate.text-xs.text-gray-500 = stay.customer.email
           .text-sm.text-gray-500(class="mt-0.5") = decorated.date_range
+          .mt-1.flex.items-center.flex-wrap.gap-x-2.gap-y-1
+            = decorated.status_badge
+            span.inline-flex.items-center.rounded-full.bg-gray-100.text-gray-600(class="px-2 py-0.5 text-xs font-medium") = merge_source_label(stay)
+            = decorated.platform_badge
+            span.text-xs.text-gray-400
+              | saisi le #{l(stay.created_at.to_date)}
           .mt-1.text-sm.text-gray-600 = stay_composition_summary(stay)
+          - internal_note = stay_has_internal_note?(stay)
+          - public_note = stay_has_public_note?(stay)
+          - if internal_note || public_note
+            .mt-1.flex.items-center.flex-wrap.gap-y-1(class="gap-x-1.5")
+              - if internal_note
+                span.inline-flex.items-center.rounded.bg-amber-50.text-amber-700(class="px-1.5 py-0.5 text-xs") 📝 note interne
+              - if public_note
+                span.inline-flex.items-center.rounded.bg-sky-50.text-sky-700(class="px-1.5 py-0.5 text-xs") 📝 note publique
           .mt-1.flex.items-center.flex-wrap.gap-x-3.gap-y-1.text-sm
             span.font-medium.text-gray-900 = humanized_money_with_symbol(stay.total_amount)
             span.text-gray-500 = stay_payments_summary(stay)

--- a/spec/requests/stays_merge_setup_spec.rb
+++ b/spec/requests/stays_merge_setup_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+# Étape A de la fusion (POST /stays/merge_setup) — la carte de désignation du
+# séjour survivant est enrichie pour aider l'admin à choisir : email du client,
+# badge statut, canal d'attribution, date de saisie et chips de présence de notes.
+RSpec.describe "Fusion — carte de désignation enrichie (merge_setup)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user)    { User.create!(email: "agent@les4sources.be", password: "password123") }
+  let(:lodging) { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+
+  before { sign_in user }
+
+  # Un séjour = un hébergement rattaché (StayItem), avec un client identifiable.
+  def stay_with_booking(email:, status:, source:, from:, to:,
+                        booking_notes: nil, public_notes: nil, stay_notes: nil)
+    customer = Customer.create!(email: email, first_name: "Client", customer_type: "individual")
+    booking = Booking.create!(firstname: "Client", group_name: "Groupe", lodging: lodging,
+                              from_date: from, to_date: to, adults: 2, children: 0, babies: 0,
+                              status: "confirmed", booking_type: "lodging", price_cents: 0,
+                              notes: booking_notes, public_notes: public_notes)
+    stay = Stay.create!(customer: customer, source: source, status: status,
+                        arrival_date: from, departure_date: to, notes: stay_notes)
+    StayItem.create!(stay: stay, bookable: booking)
+    stay
+  end
+
+  it "rend email, badge statut, canal, date de saisie et la chip note interne" do
+    from = Date.today.next_occurring(:friday)
+    stay_a = stay_with_booking(email: "alice@example.com", status: "confirmed",
+                               source: "reservation", from: from, to: from + 1,
+                               booking_notes: "Note interne booking")
+    stay_b = stay_with_booking(email: "bob@example.com", status: "pending",
+                               source: "manual", from: from, to: from + 2)
+
+    post "/stays/merge_setup", params: { stay_ids: [stay_a.id, stay_b.id] }
+
+    expect(response).to have_http_status(:ok)
+    # Email du client sur chaque carte.
+    expect(response.body).to include("alice@example.com")
+    expect(response.body).to include("bob@example.com")
+    # Badge statut (décorateur StayDecorator#status_badge).
+    expect(response.body).to include("Confirmé")
+    expect(response.body).to include("En attente")
+    # Canal / source.
+    expect(response.body).to include("Funnel")
+    expect(response.body).to include("Manuel")
+    # Date de saisie (repère original vs doublon).
+    expect(response.body).to include("saisi le")
+    # Chip note interne : stay_a porte une note sur son booking.
+    expect(response.body).to include("note interne")
+  end
+
+  it "affiche la chip « note publique » quand un bookable porte une note publique ActionText" do
+    from = Date.today.next_occurring(:friday)
+    stay_a = stay_with_booking(email: "carol@example.com", status: "confirmed",
+                               source: "manual", from: from, to: from + 1,
+                               public_notes: "Bienvenue chez nous !")
+    stay_b = stay_with_booking(email: "dave@example.com", status: "confirmed",
+                               source: "manual", from: from, to: from + 1)
+
+    post "/stays/merge_setup", params: { stay_ids: [stay_a.id, stay_b.id] }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("note publique")
+  end
+end


### PR DESCRIPTION
## Demandes

1. La modale de fusion doit montrer l'**email du client** + les infos utiles au choix du survivant.
2. En mode « Fusionner les séjours », **masquer les notes** du calendrier.

## Implémentation

- **Carte de désignation** : email (tronqué proprement), badge statut (décorateur existant), canal court (Funnel/Manuel/OTA/Import — helper `merge_source_label`, renommé pour éviter une collision avec `stay_source_label` qui cassait 159 specs), badge plateforme OTA, « saisi le {date} » (repérer l'original du doublon), chips « 📝 note interne / note publique » (présence sur le séjour OU ses bookables — aide à choisir en sachant où vivent les notes).
- **Anti-N+1** : `Preloader` ciblé pour les `public_notes` ActionText (bookable polymorphe → preload sur le seul sous-ensemble Booking/SpaceBooking).
- **Masquage notes** : `data-calendar-notes` sur les blocs + toggle accroché à la routine d'état du mode (`applyModeChrome`) — couvre l'entrée, la **restauration inter-mois** (sessionStorage) et la sortie.

## Vérifications

- Nouvelle request spec `stays_merge_setup_spec` (email, badges, canal, « saisi le », chips notes interne/publique).
- Suite complète (agent worktree) : **828 examples, 0 failures**.
- Passe navigateur (masquage réel + lisibilité mobile de la carte) : post-merge sur le serveur local.