### PR TITLE
feat(stays): « Séjours » au menu + table de gestion /stays paginée

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -2,6 +2,32 @@ class StaysController < BaseController
   before_action :set_accounting_view, only: :show
   before_action :set_stay, only: %i[edit update destroy update_status]
 
+  # Index admin des séjours (epic #81) — le séjour devient le point d'entrée
+  # unique. Tableau paginé (30/page) orienté GESTION des réservations et
+  # paiements : contact, canal, dates + statut, composition compacte, et surtout
+  # total / encaissé / reste dû exigible + statut de paiement.
+  #
+  # Filtres légers : « Tous » (défaut), « À venir » (current_and_future),
+  # « Passés » (past). Les montants agrégés (encaissé, reste dû) sont calculés
+  # EN LOT par `Stays::IndexAmounts` (aucun N+1 — voir le service).
+  def index
+    @filter = params[:filter].presence_in(%w[upcoming past]) # nil = tous
+    @stays  = index_scope
+              .includes(
+                :customer,
+                :meal_orders,
+                { stay_items: :bookable },
+                { experience_bookings: { experience_availability: :experience } }
+              )
+              .paginate(page: params[:page], per_page: 30)
+
+    # Agrégats monétaires de la page (encaissé + reste dû exigible) — calculés
+    # AVANT décoration, sur les enregistrements préchargés, en une requête de
+    # paiements pour toute la page.
+    @amounts = Stays::IndexAmounts.new(@stays).call
+    @stays   = StayDecorator.decorate_collection(@stays)
+  end
+
   # Rendu sans layout : le fragment HTML est injecté dans la modale de détails
   # par le contrôleur Stimulus stay-details (fetch + innerHTML). [tranche 1]
   def show
@@ -240,6 +266,19 @@ class StaysController < BaseController
   end
 
   private
+
+  # Relation de base de l'index selon le filtre actif. « À venir » / « Passés »
+  # réutilisent les scopes du modèle (qui portent DÉJÀ leur propre tri utile :
+  # arrivée asc pour l'à-venir, arrivée desc pour le passé). « Tous » (défaut) :
+  # arrivée la plus récente/future d'abord — les séjours sans date d'arrivée
+  # (activités/repas seuls) rejetés en fin de liste, tri stable sur l'id.
+  def index_scope
+    case @filter
+    when "upcoming" then Stay.current_and_future
+    when "past"     then Stay.past
+    else Stay.order(Arel.sql("arrival_date DESC NULLS LAST, id DESC"))
+    end
+  end
 
   # Draft de préremplissage du form NEW (epic #81, Phase 7). Trois cas, dans
   # l'ordre de priorité : duplication d'un séjour, saisie datée d'un espace,

--- a/app/decorators/stay_decorator.rb
+++ b/app/decorators/stay_decorator.rb
@@ -1,6 +1,16 @@
 class StayDecorator < ApplicationDecorator
   delegate_all
 
+  # Collection paginée (index Séjours) : préserve les méthodes will_paginate sur
+  # la collection décorée — même pattern que CustomerDecorator.
+  def self.collection_decorator_class
+    PaginatingDecorator
+  end
+
+  # Statuts d'activité écartés de la composition « active » (miroir du scope
+  # `ExperienceBooking.active`), filtrés EN MÉMOIRE pour éviter tout N+1.
+  DEAD_EXPERIENCE_STATUSES = %w[cancelled refused].freeze
+
   STATUS_STYLES = {
     "confirmed" => { label: "Confirmé", classes: "bg-green-100 text-green-800" },
     "pending"   => { label: "En attente", classes: "bg-amber-100 text-amber-800" },
@@ -51,6 +61,23 @@ class StayDecorator < ApplicationDecorator
       van_bookings.any? || meals.any? || object.experience_bookings.active.any?
   end
 
+  # Résumé compact de la composition pour l'index Séjours : « 1 gîte · 2 espaces
+  # · 3 activités ». N'affiche que les catégories présentes. Tout est lu sur des
+  # associations PRÉCHARGÉES (stay_items, experience_bookings, meal_orders) —
+  # aucun accès base, contrairement à `stay_composition_summary` (helper de
+  # fusion) qui interroge `experience_bookings.active` / `meal_orders`.
+  def composition_summary
+    parts = [
+      compo_part(lodging_bookings.size, "gîte", "gîtes"),
+      compo_part(space_bookings.size, "espace", "espaces"),
+      compo_part(camping_bookings.size, "camping", "campings"),
+      compo_part(van_bookings.size, "van", "vans"),
+      compo_part(active_experiences_count, "activité", "activités"),
+      compo_part(object.meal_orders.size, "repas", "repas")
+    ].compact
+    parts.any? ? parts.join(" · ") : "—"
+  end
+
   # Montant formaté d'un bookable (Booking/SpaceBooking/Camping/Van) ou d'un repas.
   def formatted_item_amount(record)
     money(record.try(:price_cents))
@@ -62,6 +89,20 @@ class StayDecorator < ApplicationDecorator
   def bookables_of(type)
     object.stay_items.select { |item| item.bookable_type == type }
           .map(&:bookable).compact
+  end
+
+  # Nombre d'activités actives, filtré EN MÉMOIRE (association préchargée) —
+  # jamais `experience_bookings.active` (scope = requête).
+  def active_experiences_count
+    object.experience_bookings.reject { |eb| DEAD_EXPERIENCE_STATUSES.include?(eb.status) }.size
+  end
+
+  # Fragment « N mot » de la composition ; nil quand la catégorie est absente
+  # (pour être filtré). Pluriel FR simple.
+  def compo_part(count, singular, plural)
+    return nil if count.to_i.zero?
+
+    "#{count} #{count.to_i > 1 ? plural : singular}"
   end
 
   public

--- a/app/services/stays/index_amounts.rb
+++ b/app/services/stays/index_amounts.rb
@@ -1,0 +1,97 @@
+module Stays
+  # Agrégats monétaires de l'index Séjours (epic #81) — encaissé + reste dû
+  # exigible, calculés EN LOT pour la page courante (≤ 30 séjours) afin d'éviter
+  # tout N+1.
+  #
+  # Le point dur : `Stay#payments` n'est PAS une association mais une requête
+  # construite à la volée (union `payments.stay_id` ∪ `payments.booking_id` des
+  # items Booking). Aucun preload ne peut donc l'aplatir — on reconstitue ici la
+  # MÊME union en UNE seule requête pour toute la page, puis on ventile en Ruby.
+  #
+  # Le reste (total, activités `pending`, prix imposé) se lit sur des
+  # associations DÉJÀ préchargées par le contrôleur (`experience_bookings` +
+  # `experience_availability` + `experience` pour le calcul `price_cents`),
+  # donc sans requête supplémentaire.
+  class IndexAmounts
+    # Statuts d'activité écartés du total exigible (miroir de `ExperienceBooking`).
+    Result = Struct.new(:paid_cents, :balance_due_cents, keyword_init: true)
+
+    def initialize(stays)
+      @stays = stays.to_a
+    end
+
+    # => { stay_id => Result(paid_cents:, balance_due_cents:) }
+    def call
+      paid = paid_by_stay
+      @stays.each_with_object({}) do |stay, acc|
+        paid_cents = paid[stay.id].to_i
+        acc[stay.id] = Result.new(
+          paid_cents:       paid_cents,
+          balance_due_cents: payable_cents(stay) - paid_cents
+        )
+      end
+    end
+
+    private
+
+    # Assiette exigible d'un séjour, dérivée du total (source unique de vérité,
+    # cf. `Stay#payable_amount_cents`) : sous prix imposé le total est ferme ;
+    # sinon on retranche les activités encore `pending` (non facturables).
+    def payable_cents(stay)
+      return stay.total_amount_cents.to_i if stay.price_overridden?
+
+      stay.total_amount_cents.to_i - pending_experiences_cents(stay)
+    end
+
+    # Somme des activités `pending` LUES en mémoire (association préchargée) —
+    # jamais `experience_bookings.pending` (scope = requête). `price_cents`
+    # délègue à `experience` (préchargé) : aucun accès base.
+    def pending_experiences_cents(stay)
+      stay.experience_bookings
+          .select { |eb| eb.status == "pending" }
+          .sum(&:price_cents)
+    end
+
+    # Encaissé (paiements `paid`) par séjour, reconstituant l'union du modèle en
+    # une requête. Chaque paiement est attribué UNE fois : d'abord par son
+    # `stay_id` direct, à défaut via le `booking_id` de l'un de ses items.
+    def paid_by_stay
+      return {} if @stays.empty?
+
+      stay_ids     = @stays.map(&:id)
+      booking2stay = booking_to_stay
+      booking_ids  = booking2stay.keys
+
+      totals = Hash.new(0)
+      paid_payments(stay_ids, booking_ids).each do |payment|
+        stay_id =
+          if payment.stay_id && stay_ids.include?(payment.stay_id)
+            payment.stay_id
+          else
+            booking2stay[payment.booking_id]
+          end
+        next unless stay_id
+
+        totals[stay_id] += payment.amount_cents.to_i
+      end
+      totals
+    end
+
+    # Carte bookable(Booking)#id => stay_id, lue sur les `stay_items` préchargés.
+    def booking_to_stay
+      @stays.each_with_object({}) do |stay, map|
+        stay.stay_items.each do |item|
+          map[item.bookable_id] = stay.id if item.bookable_type == "Booking"
+        end
+      end
+    end
+
+    # Union `stay_id ∈ page` ∪ `booking_id ∈ items Booking de la page`, restreinte
+    # aux paiements encaissés (le default_scope soft-deletion exclut les supprimés).
+    def paid_payments(stay_ids, booking_ids)
+      relation = Payment.paid.where(stay_id: stay_ids)
+      relation = relation.or(Payment.paid.where(booking_id: booking_ids)) if booking_ids.any?
+      relation.select(:id, :amount_cents, :stay_id, :booking_id)
+    end
+  end
+end

--- a/app/views/layouts/components/_navbar.html.slim
+++ b/app/views/layouts/components/_navbar.html.slim
@@ -31,7 +31,7 @@ nav.bg-white.shadow-sm.lg:px-6
 
         / Accueil dropdown (Hébergements + Espaces + Reporting + Comptabilité)
         li.relative
-          button.flex.items-center.gap-1.5.px-4.py-2.rounded-lg.text-sm.font-medium.transition-all.duration-150[id="accueilDropdownButton" data-controller="dropdown" data-action="click->dropdown#toggle click@window->dropdown#hideOnClickOutside" data-dropdown-toggle-value="accueilDropdown" type="button" class="#{ (controller_name == 'bookings' || controller_name == 'space_bookings' || controller_name == 'reports' || !@accounting_view.nil?) ? 'text-4s-main bg-teal-50' : 'text-gray-600 hover:text-4s-main hover:bg-teal-50/60'}"]
+          button.flex.items-center.gap-1.5.px-4.py-2.rounded-lg.text-sm.font-medium.transition-all.duration-150[id="accueilDropdownButton" data-controller="dropdown" data-action="click->dropdown#toggle click@window->dropdown#hideOnClickOutside" data-dropdown-toggle-value="accueilDropdown" type="button" class="#{ (controller_name == 'stays' || controller_name == 'bookings' || controller_name == 'space_bookings' || controller_name == 'reports' || !@accounting_view.nil?) ? 'text-4s-main bg-teal-50' : 'text-gray-600 hover:text-4s-main hover:bg-teal-50/60'}"]
             svg.w-4.h-4[xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"]
               path[d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"]
               polyline[points="9 22 9 12 15 12 15 22"]
@@ -40,26 +40,19 @@ nav.bg-white.shadow-sm.lg:px-6
               polyline[points="6 9 12 15 18 9"]
           #accueilDropdown.absolute.left-0.mt-1.z-10.hidden.bg-white.divide-y.divide-gray-50.rounded-xl.shadow-lg.shadow-gray-200/80.border.border-gray-100.w-52
             ul.py-1.5[aria-labelledby="accueilDropdownButton"]
+              / Épic #81 — le séjour est le point d'entrée unique. Les entrées
+              / « Hébergements » (bookings) et « Espaces » (space_bookings) sont
+              / retirées du menu ; leurs anciennes vues restent accessibles via
+              / les boutons de transition en tête de l'index Séjours.
               li
-                = link_to bookings_path,
-                          class: "flex items-center gap-2.5 px-4 py-2.5 text-sm transition-colors #{controller_name == 'bookings' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-600 hover:bg-teal-50/60 hover:text-4s-main'}" do
+                = link_to stays_path,
+                          class: "flex items-center gap-2.5 px-4 py-2.5 text-sm transition-colors #{controller_name == 'stays' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-600 hover:bg-teal-50/60 hover:text-4s-main'}" do
                   svg.w-4.h-4.opacity-70[xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"]
                     path[d="M2 20v-8a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v8"]
                     path[d="M4 10V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"]
                     path[d="M12 4v6"]
                     path[d="M2 18h20"]
-                  span Hébergements
-              li
-                = link_to space_bookings_path,
-                          class: "flex items-center gap-2.5 px-4 py-2.5 text-sm transition-colors #{controller_name == 'space_bookings' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-600 hover:bg-teal-50/60 hover:text-4s-main'}" do
-                  svg.w-4.h-4.opacity-70[xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"]
-                    path[d="M3 7V5a2 2 0 0 1 2-2h2"]
-                    path[d="M17 3h2a2 2 0 0 1 2 2v2"]
-                    path[d="M21 17v2a2 2 0 0 1-2 2h-2"]
-                    path[d="M7 21H5a2 2 0 0 1-2-2v-2"]
-                    rect[width="7" height="5" x="7" y="7" rx="1"]
-                    rect[width="7" height="5" x="10" y="12" rx="1"]
-                  span Espaces
+                  span Séjours
               li
                 = link_to reports_path,
                           class: "flex items-center gap-2.5 px-4 py-2.5 text-sm transition-colors #{controller_name == 'reports' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-600 hover:bg-teal-50/60 hover:text-4s-main'}" do

--- a/app/views/stays/index.html.slim
+++ b/app/views/stays/index.html.slim
@@ -35,7 +35,9 @@
           - amount = @amounts[stay.id]
           tr.hover:bg-gray-50
             td.px-4.py-2.text-sm.whitespace-nowrap
-              = link_to "##{stay.id}", stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 font-medium hover:underline"
+              / stays#show rend un fragment sans layout (réservé à la modale du
+                calendrier) — la navigation directe pointe donc vers l'édition.
+              = link_to "##{stay.id}", edit_stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 font-medium hover:underline"
             td.px-4.py-2.text-sm
               - if stay.customer
                 = link_to stay.customer.name, customer_path(stay.customer), class: "text-indigo-600 hover:text-indigo-800 font-medium hover:underline"

--- a/app/views/stays/index.html.slim
+++ b/app/views/stays/index.html.slim
@@ -1,0 +1,78 @@
+.px-4.sm:px-6.lg:px-8.py-6
+  / En-tête + boutons de transition vers les anciennes vues (epic #81).
+  .sm:flex.sm:items-center.sm:justify-between.mb-4
+    .sm:flex-auto
+      h1.text-xl.font-semibold.text-gray-900 Séjours
+      p.mt-1.text-sm.text-gray-600 Tous les séjours — gestion des réservations et des paiements.
+    .mt-4.sm:mt-0.sm:ml-4.flex.flex-wrap.items-center.gap-2
+      = link_to "Hébergements (ancienne vue)", bookings_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50"
+      = link_to "Espaces (ancienne vue)", space_bookings_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50"
+      = link_to "Nouveau séjour", new_stay_path, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"
+
+  / Filtres légers (pills) : Tous · À venir · Passés.
+  - pill_active = "bg-indigo-600 text-white"
+  - pill_idle = "bg-white text-gray-600 border border-gray-300 hover:bg-gray-50"
+  nav.mb-4.flex.flex-wrap.gap-2
+    = link_to "Tous", stays_path, class: "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium #{@filter.nil? ? pill_active : pill_idle}"
+    = link_to "À venir", stays_path(filter: "upcoming"), class: "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium #{@filter == 'upcoming' ? pill_active : pill_idle}"
+    = link_to "Passés", stays_path(filter: "past"), class: "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium #{@filter == 'past' ? pill_active : pill_idle}"
+
+  .overflow-x-auto.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg
+    table.min-w-full.divide-y.divide-gray-300
+      thead.bg-gray-50
+        tr
+          th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase #
+          th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Client
+          th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Dates
+          th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Composition
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Total
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Encaissé
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Reste dû
+          th.px-4.py-2.text-left.text-xs.font-medium.text-gray-500.uppercase Paiement
+          th.px-4.py-2.text-right.text-xs.font-medium.text-gray-500.uppercase Actions
+      tbody.divide-y.divide-gray-200.bg-white
+        - @stays.each do |stay|
+          - amount = @amounts[stay.id]
+          tr.hover:bg-gray-50
+            td.px-4.py-2.text-sm.whitespace-nowrap
+              = link_to "##{stay.id}", stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 font-medium hover:underline"
+            td.px-4.py-2.text-sm
+              - if stay.customer
+                = link_to stay.customer.name, customer_path(stay.customer), class: "text-indigo-600 hover:text-indigo-800 font-medium hover:underline"
+                .text-xs.text-gray-500 = stay.customer.email
+              - else
+                span.text-gray-400 —
+              .mt-1.flex.flex-wrap.items-center.gap-1
+                span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.text-xs.font-medium.text-gray-700(class="py-0.5") = stay_source_label(stay.source)
+                = stay.platform_badge
+            td.px-4.py-2.text-sm
+              .text-gray-900.whitespace-nowrap = stay.date_range
+              .mt-1 = stay.status_badge
+            td.px-4.py-2.text-sm.text-gray-600 = stay.composition_summary
+            td.px-4.py-2.text-sm.text-right.whitespace-nowrap
+              span.font-medium.text-gray-900 = humanized_money_with_symbol(stay.total_amount)
+              - if stay.price_overridden?
+                span.ml-1.text-xs.text-amber-700(title="Prix total imposé par l'admin") imposé
+            td.px-4.py-2.text-sm.text-right.whitespace-nowrap.text-gray-700
+              = humanized_money_with_symbol(Money.new(amount.paid_cents))
+            td.px-4.py-2.text-sm.text-right.whitespace-nowrap
+              - if amount.balance_due_cents.positive?
+                span.font-medium.text-red-600 = humanized_money_with_symbol(Money.new(amount.balance_due_cents))
+              - else
+                span.text-gray-400 = humanized_money_with_symbol(Money.new(amount.balance_due_cents))
+            td.px-4.py-2.text-sm = stay.payment_status_badge
+            td.px-4.py-2.text-sm.text-right.whitespace-nowrap
+              = link_to "Éditer", edit_stay_path(stay), class: "text-indigo-600 hover:text-indigo-800 hover:underline"
+        - if @stays.empty?
+          tr
+            td.px-4.py-6.text-center.text-sm.text-gray-400 colspan="9" Aucun séjour.
+
+  / Pagination (30/page) + « X–Y sur N ».
+  - if @stays.total_entries.positive?
+    .mt-4.flex.flex-col.gap-2.sm:flex-row.sm:items-center.sm:justify-between
+      p.text-sm.text-gray-600
+        - page_count = @stays.to_a.size
+        - first = @stays.offset + 1
+        - last = @stays.offset + page_count
+        = "#{first}–#{last} sur #{@stays.total_entries}"
+      = will_paginate @stays

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,7 @@ Rails.application.routes.draw do
   # `show` reste rendu sans layout (fragment de modale) ; new/edit sont des pages
   # pleines. La route `stays/recents` ci-dessus est déclarée AVANT pour ne pas
   # être captée par `/stays/:id`.
-  resources :stays, only: [:show, :new, :create, :edit, :update, :destroy] do
+  resources :stays, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
     collection do
       # Vérification de disponibilité en temps réel dans le form de composition
       # (issue #77) : lodging_id + dates → JSON { available: bool }. Informe sans

--- a/spec/requests/admin_nav_stays_spec.rb
+++ b/spec/requests/admin_nav_stays_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+# Menu principal admin (epic #81) — le séjour devient le point d'entrée unique :
+# l'entrée « Séjours » remplace « Hébergements » / « Espaces » dans la nav.
+RSpec.describe "Nav admin — entrée Séjours", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent-nav@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  # On rend une page admin quelconque servie AVEC le layout (donc la navbar) :
+  # /stays/recents. Son propre contenu ne mentionne pas « Hébergements », ce qui
+  # isole l'assertion à la navigation.
+  it "expose « Séjours » et retire « Hébergements » du menu principal" do
+    get recent_stays_path
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Séjours")
+    expect(response.body).to include(%(href="#{stays_path}"))
+    expect(response.body).not_to include("Hébergements")
+  end
+end

--- a/spec/requests/stays_index_spec.rb
+++ b/spec/requests/stays_index_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+# Index admin des séjours (epic #81) — le séjour est le point d'entrée unique :
+# tableau paginé (30/page) orienté gestion des réservations et paiements, avec
+# filtres légers et boutons de transition vers les anciennes vues.
+RSpec.describe "Index Séjours (/stays)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent-index@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  # Crée un séjour daté rattaché à un client distinct (email unique obligatoire).
+  def create_stay(email:, arrival:, departure:, total_cents: 0, first: "Jean", last: "Test")
+    customer = Customer.create!(email: email, first_name: first, last_name: last)
+    Stay.create!(
+      customer:           customer,
+      source:             "manual",
+      status:             "pending",
+      arrival_date:       arrival,
+      departure_date:     departure,
+      total_amount_cents: total_cents
+    )
+  end
+
+  describe "garde Devise" do
+    it "redirige un visiteur non authentifié vers sign_in" do
+      sign_out user
+      get stays_path
+      expect(response).to redirect_to("/users/sign_in")
+    end
+  end
+
+  describe "rendu et contenu de gestion" do
+    let!(:stay) do
+      create_stay(email: "cliente@example.com", first: "Alice", last: "Durand",
+                  arrival: Date.today + 5, departure: Date.today + 7, total_cents: 12_345)
+    end
+
+    it "répond 200 et affiche client, total et badge de paiement" do
+      get stays_path
+      expect(response).to have_http_status(:ok)
+      # Client (nom + email)
+      expect(response.body).to include("Alice Durand")
+      expect(response.body).to include("cliente@example.com")
+      # Total formaté (même helper que la vue → indépendant de la locale de test)
+      expected_total = ApplicationController.helpers.humanized_money_with_symbol(Money.new(12_345))
+      expect(response.body).to include(expected_total)
+      # Badge de statut de paiement (défaut « pending »)
+      expect(response.body).to include(I18n.t("public.stays.payment_status.pending"))
+    end
+
+    it "affiche les boutons vers les anciennes vues (transition)" do
+      get stays_path
+      expect(response.body).to include("Hébergements (ancienne vue)")
+      expect(response.body).to include("Espaces (ancienne vue)")
+      expect(response.body).to include(%(href="#{bookings_path}"))
+      expect(response.body).to include(%(href="#{space_bookings_path}"))
+    end
+  end
+
+  describe "pagination 30/page" do
+    before do
+      31.times do |i|
+        create_stay(email: "p#{i}@example.com",
+                    arrival: Date.today + 1 + i, departure: Date.today + 2 + i)
+      end
+    end
+
+    it "affiche 30 séjours sur la première page (« 1–30 sur 31 »)" do
+      get stays_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("1–30 sur 31")
+    end
+
+    it "affiche le 31e séjour sur la seconde page (« 31–31 sur 31 »)" do
+      get stays_path(page: 2)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("31–31 sur 31")
+    end
+  end
+
+  describe "filtre « À venir »" do
+    let!(:future_stay) do
+      create_stay(email: "future@example.com", first: "Futur", last: "Client",
+                  arrival: Date.today + 10, departure: Date.today + 12)
+    end
+    let!(:past_stay) do
+      create_stay(email: "passe@example.com", first: "Passe", last: "Client",
+                  arrival: Date.today - 12, departure: Date.today - 10)
+    end
+
+    it "n'affiche pas un séjour passé" do
+      get stays_path(filter: "upcoming")
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Futur Client")
+      expect(response.body).not_to include("Passe Client")
+    end
+  end
+end


### PR DESCRIPTION
## Demande

Menu principal : masquer « Hébergements » et « Espaces », afficher « Séjours » → `/stays` : table paginée (30/page) utile à la gestion des réservations et paiements, avec boutons d'accès aux anciennes vues pendant la transition.

## Implémentation

- `stays#index` : tri `arrival_date DESC NULLS LAST` (l'actualité de gestion d'abord, séjours sans dates en fin), pills **Tous · À venir · Passés** (scopes existants), pagination `will_paginate` 30/page.
- Colonnes : # (→ édition), client (nom + email), badge canal + plateforme OTA, dates + badge statut, composition compacte, **total · encaissé · reste dû exigible en rouge** + badge statut de paiement, bouton Éditer.
- **Zéro N+1** : `Stays::IndexAmounts` (query object) reconstitue l'union paiements (`stay_id` ∪ `booking_id`) en UNE requête pour toute la page et ventile en Ruby (sémantique identique à `Stay#payments`) ; préchargements pour composition/activités.
- Filtre « À encaisser » abandonné (non exprimable en SQL bon marché — le reste dû rouge par ligne couvre le besoin) — comme autorisé dans le brief.
- Nav : « Séjours » remplace les deux entrées dans le dropdown (desktop + mobile, même partial) ; `/stays/recents` intact ; boutons « anciennes vues » en tête de page.

## Vérifications

- Suite complète (sur la branche) : **833 examples, 0 failures** + patch lien de ligne → édition (stays#show est un fragment `layout: false` pour la modale).
- Passe navigateur post-merge sur le serveur local (session Michael en cours).