### PR TITLE
feat(stays): notes interne + publique — lecture, édition, consolidation à la fusion

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -54,6 +54,10 @@ class StaysController < BaseController
     )
 
     if builder.run
+      # Notes admin appliquées APRÈS la création : la note interne saisie est
+      # CONCATÉNÉE avec l'éventuelle note auto du Builder (avertissement
+      # multi-chiens) — on ne l'écrase jamais. La note publique est posée telle quelle.
+      apply_admin_notes(builder.stay, merge_auto: true)
       flash[:notice] = "Séjour créé."
       flash[:alert]  = combined_warning(builder)
       redirect_to recent_stays_path
@@ -85,6 +89,9 @@ class StaysController < BaseController
     )
 
     if updater.run
+      # À l'édition, le form préremplit les notes courantes : simple écrasement
+      # (note interne texte brut + note publique ActionText), pas de concaténation.
+      apply_admin_notes(@stay, merge_auto: false)
       flash[:notice] = "Séjour mis à jour."
       flash[:alert]  = combined_warning(updater)
       redirect_to recent_stays_path
@@ -308,6 +315,25 @@ class StaysController < BaseController
 
   def set_stay
     @stay = Stay.find(params[:id])
+  end
+
+  # Applique la note interne (colonne `notes`, texte brut) et la note publique
+  # (`public_notes`, ActionText) saisies au form. `merge_auto` distingue les deux
+  # canaux : à la CRÉATION, on concatène la note interne saisie avec l'éventuelle
+  # note auto déjà posée par le Builder (multi-chiens) ; à l'ÉDITION, on écrase.
+  def apply_admin_notes(stay, merge_auto:)
+    return if stay.nil?
+
+    admin_internal = stay_params[:notes].to_s.strip.presence
+    stay.notes =
+      if merge_auto
+        [admin_internal, stay.notes.to_s.strip.presence].compact.uniq.join("\n\n").presence
+      else
+        admin_internal
+      end
+
+    stay.public_notes = stay_params[:public_notes] if stay_params.key?(:public_notes)
+    stay.save!
   end
 
   # Concatène l'avertissement de disponibilité (force-dispo) et celui des espaces

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -42,6 +42,10 @@ class Stay < ApplicationRecord
   belongs_to :customer
   has_many :stay_items, dependent: :destroy
   has_many :experience_bookings, dependent: :destroy
+  # Note publique du séjour (visible client) — ActionText, PAS de colonne. Consolide
+  # à la fusion les `public_notes` des bookables + des stays sources (epic notes).
+  # La note INTERNE reste la colonne `stays.notes` (texte brut, jamais publique).
+  has_rich_text :public_notes
   # Repas (epic #66, Phase 3) : rattachés en direct (pas d'occupation calendrier),
   # sur le modèle d'`experience_bookings`.
   has_many :meal_orders, dependent: :destroy

--- a/app/services/stays/merge_service.rb
+++ b/app/services/stays/merge_service.rb
@@ -46,6 +46,11 @@ module Stays
           # Les associations de la cible ont changé en base : on recharge avant de
           # recalculer, sinon `recompute_aggregates!` lirait un cache périmé.
           target.reload
+          # Consolidation ADDITIVE des notes (principe P2 : rien ne se perd). On
+          # rassemble sur le survivant les notes internes ET publiques de la cible,
+          # des sources et de TOUS les bookables migrés, en une seule note interne
+          # et une seule note publique. Les colonnes des bookables ne sont PAS vidées.
+          consolidate_notes!
           target.recompute_aggregates!
           # `set_payment_status` est non-bang (partagé avec le webhook Stripe) :
           # ici, un échec silencieux violerait le tout-ou-rien de la fusion.
@@ -143,5 +148,102 @@ module Stays
     def soft_deleted?(stay)
       stay.deleted_at.present?
     end
+
+    # --- Consolidation des notes (fusion) -----------------------------------
+    # Réunit sur le survivant les notes éparpillées, sans jamais rien perdre ni
+    # vider les colonnes d'origine des bookables. Écrit uniquement si le résultat
+    # change quelque chose (aucune note nulle part → survivant inchangé).
+    def consolidate_notes!
+      consolidate_internal_notes!
+      consolidate_public_notes!
+    end
+
+    # Note interne : texte brut. Ordre : note du séjour cible, notes des séjours
+    # sources, PUIS notes internes de tous les bookables (cible + migrés). Ignore
+    # les blancs, déduplique les contenus strictement identiques. Une seule note
+    # → contenu tel quel ; plusieurs → en-têtes de provenance courts + jointure.
+    def consolidate_internal_notes!
+      entries = []
+      entries << internal_entry("séjour ##{target.id}", target.notes)
+      sources.each { |source| entries << internal_entry("séjour ##{source.id}", source.notes) }
+      target.bookables.each do |bookable|
+        entries << internal_entry(bookable_provenance(bookable), bookable_notes(bookable))
+      end
+
+      entries = dedup_internal(entries)
+      return if entries.empty?
+
+      consolidated =
+        if entries.size == 1
+          entries.first[:content]
+        else
+          entries.map { |e| "— Note de #{e[:label]} —\n#{e[:content]}" }.join("\n\n")
+        end
+
+      target.update!(notes: consolidated) if consolidated != target.notes
+    end
+
+    # Note publique : HTML ActionText. Rassemble les `public_notes` de la cible,
+    # des sources et des bookables qui en portent (Booking, SpaceBooking). Une
+    # seule → telle quelle ; plusieurs → concaténées, séparées par `<hr>`.
+    # Déduplique les contenus HTML identiques.
+    def consolidate_public_notes!
+      htmls = []
+      htmls << public_html(target)
+      sources.each { |source| htmls << public_html(source) }
+      target.bookables.each { |bookable| htmls << public_html(bookable) }
+
+      htmls = htmls.compact.uniq
+      return if htmls.empty?
+
+      consolidated = htmls.size == 1 ? htmls.first : htmls.join("<hr>")
+      target.public_notes = consolidated if consolidated != current_public_html(target)
+    end
+
+    # {label:, content:} d'une note interne, ou nil si le contenu est blanc.
+    def internal_entry(label, content)
+      text = content.to_s.strip
+      return nil if text.blank?
+      { label: label, content: text }
+    end
+
+    # Retire les nil et déduplique sur le CONTENU strict (garde la 1re provenance).
+    def dedup_internal(entries)
+      seen = {}
+      entries.compact.each { |e| seen[e[:content]] ||= e }
+      seen.values
+    end
+
+    # Provenance courte d'un bookable, p.ex. « La Hulotte (résa #345) ».
+    def bookable_provenance(bookable)
+      "#{bookable_label(bookable)} (résa ##{bookable.id})"
+    end
+
+    def bookable_label(bookable)
+      case bookable
+      when Booking      then bookable.lodging&.name.presence || "Hébergement"
+      when SpaceBooking then bookable.spaces.map(&:name).compact_blank.join(", ").presence || "Espace"
+      when CampingBooking then "Camping"
+      when VanBooking     then "Van"
+      else bookable.class.model_name.human
+      end
+    end
+
+    # Colonne `notes` texte brut d'un bookable (Booking/SpaceBooking/Camping/Van).
+    def bookable_notes(bookable)
+      bookable.respond_to?(:notes) ? bookable.notes : nil
+    end
+
+    # HTML de la note publique d'un enregistrement (Stay/Booking/SpaceBooking) qui
+    # porte `public_notes` (ActionText), ou nil si absent/vide.
+    def public_html(record)
+      return nil unless record.respond_to?(:public_notes)
+      rich = record.public_notes
+      return nil if rich.nil?
+      body = rich.body
+      return nil if body.nil? || body.to_plain_text.blank?
+      body.to_html
+    end
+    alias current_public_html public_html
   end
 end

--- a/app/services/stays/merge_service.rb
+++ b/app/services/stays/merge_service.rb
@@ -197,7 +197,15 @@ module Stays
       return if htmls.empty?
 
       consolidated = htmls.size == 1 ? htmls.first : htmls.join("<hr>")
-      target.public_notes = consolidated if consolidated != current_public_html(target)
+      return if consolidated == current_public_html(target)
+
+      target.public_notes = consolidated
+      # Persistance EXPLICITE (revue Forge F1) : sans ce save, l'écriture
+      # ActionText ne tenait que par l'autosave du `update!` de
+      # `recompute_aggregates!` appelé juste après — un couplage invisible
+      # qu'un réordonnancement ou un `update_columns` ferait disparaître en
+      # silence. La consolidation se suffit à elle-même, par contrat.
+      target.save!
     end
 
     # {label:, content:} d'une note interne, ou nil si le contenu est blanc.

--- a/app/views/public/stays/show.html.slim
+++ b/app/views/public/stays/show.html.slim
@@ -42,6 +42,11 @@
         p.text-base.font-semibold.text-gray-900 = t(".total")
         p.text-lg.font-bold.text-gray-900 = @stay.formatted_total
 
+    / Note publique du séjour (visible client). JAMAIS la note interne.
+    - if @stay.public_notes.present?
+      .mt-8.bg-slate-50.rounded-lg.px-4.py-5.sm:px-6
+        .content.text-base.text-gray-800.space-y-4 == @stay.public_notes
+
     = render "public/stays/balance"
 
     = render "public/stays/payments"

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -108,6 +108,20 @@ div id="stay-details-#{@stay.id}"
 
     = render "stays/activities"
 
+    / Notes du séjour (lecture). La note interne (texte brut, style post-it) ne
+    / fuite JAMAIS côté client ; la note publique (ActionText) est celle vue par
+    / le client sur /sejour/:token.
+    - if @stay.notes.present? || @stay.public_notes.present?
+      .border-t.border-gray-200.pt-4.space-y-3
+        - if @stay.notes.present?
+          .rounded-md.bg-yellow-50.ring-1.ring-yellow-200.px-4.py-3
+            h4.text-sm.font-medium.text-yellow-900.mb-1 Note interne
+            .text-sm.text-yellow-800.space-y-2 = simple_format @stay.notes
+        - if @stay.public_notes.present?
+          .rounded-md.bg-gray-50.ring-1.ring-gray-200.px-4.py-3
+            h4.text-sm.font-medium.text-gray-700.mb-1 Note publique (visible client)
+            .content.text-sm.text-gray-800.space-y-2 == @stay.public_notes
+
     - bk = @stay.primary_bookable
     - group = bk&.try(:group_name).presence
     .border-t.border-gray-200.pt-4

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -247,6 +247,19 @@
         = number_field_tag "stay[price_override]", override_prefill, id: "stay_price_override", step: "0.01", min: 0, placeholder: "—", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
         p.text-xs.text-gray-500 Laisser vide pour appliquer le devis B2C. Un montant remplace le total du devis.
 
+    / --- Notes --------------------------------------------------------------
+    / Note interne (texte brut, jamais visible du client) + note publique
+    / (ActionText, affichée sur /sejour/:token). À la création, la note interne
+    / saisie est concaténée avec l'éventuelle note auto (multi-chiens).
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Notes
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 for="stay_notes" Note interne (jamais visible du client)
+        = text_area_tag "stay[notes]", @stay&.notes, id: "stay_notes", rows: 3, class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+      .space-y-1
+        label.block.text-sm.font-medium.text-gray-700 Note publique (visible par le client)
+        = rich_text_area_tag "stay[public_notes]", @stay&.public_notes&.to_trix_html, class: "trix-content"
+
     .flex.justify-end.gap-3
       = link_to "Annuler", recent_stays_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
       = submit_tag submit_label, class: "inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700"

--- a/spec/requests/public/stays_spec.rb
+++ b/spec/requests/public/stays_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe "Public::Stays (/sejour/:token)", type: :request do
       get "/sejour/inconnu"
       expect(response).to have_http_status(:not_found)
     end
+
+    it "affiche la note PUBLIQUE du séjour et JAMAIS la note interne" do
+      stay.update!(notes: "SECRET INTERNE À NE PAS DIVULGUER")
+      stay.public_notes = "<div>Bon séjour à vous et à bientôt</div>"
+      stay.save!
+
+      get "/sejour/#{stay.token}"
+
+      expect(response.body).to include("Bon séjour à vous et à bientôt")
+      expect(response.body).not_to include("SECRET INTERNE")
+    end
   end
 
   # Epic #55, Phase 3 — ventilation exigible + bouton « Payer le solde ».

--- a/spec/requests/stays_admin_crud_spec.rb
+++ b/spec/requests/stays_admin_crud_spec.rb
@@ -123,6 +123,45 @@ RSpec.describe "Stays — CRUD admin (epic #66)", type: :request do
     end
   end
 
+  describe "notes du séjour" do
+    def update_params(stay, overrides = {})
+      {
+        stay: {
+          customer_mode: "existing", customer_id: stay.customer_id, new_customer: {},
+          arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+          adults: 2, children: 0, dogs_count: 0,
+          lodging_id: lodging.id, status: "pending"
+        }.merge(overrides)
+      }
+    end
+
+    it "CRÉATION avec multi-chiens : la note saisie COEXISTE avec l'avertissement auto" do
+      post stays_path, params: base_params(dogs_count: 3, notes: "Client VIP", public_notes: "<div>Merci de votre visite</div>")
+      stay = Stay.order(:created_at).last
+
+      # Les DEUX textes internes coexistent (concaténation, pas d'écrasement).
+      expect(stay.notes).to include("Client VIP")
+      expect(stay.notes).to include("multi-chiens")
+      # Note publique posée telle quelle.
+      expect(stay.public_notes.body.to_plain_text).to include("Merci de votre visite")
+    end
+
+    it "ÉDITION : persiste la note interne + publique, puis les préremplit au re-edit" do
+      stay = create_admin_stay
+      patch stay_path(stay), params: update_params(stay, notes: "Note interne éditée",
+                                                         public_notes: "<div>Note publique éditée</div>")
+      expect(response).to redirect_to(recent_stays_path)
+
+      stay.reload
+      expect(stay.notes).to eq("Note interne éditée")
+      expect(stay.public_notes.body.to_plain_text).to include("Note publique éditée")
+
+      get edit_stay_path(stay)
+      expect(response.body).to include("Note interne éditée")
+      expect(response.body).to include("Note publique éditée")
+    end
+  end
+
   describe "PATCH /stays/:id (update)" do
     let!(:cheveche) { Lodging.create!(name: "La Chevêche", summary: "gîte") }
 

--- a/spec/services/stays/merge_service_spec.rb
+++ b/spec/services/stays/merge_service_spec.rb
@@ -225,6 +225,71 @@ RSpec.describe Stays::MergeService, type: :service do
     end
   end
 
+  describe "consolidation des notes" do
+    let(:customer) { make_customer("notes@example.com") }
+    let!(:lodging) { Lodging.create!(name: "La Hulotte", summary: "gîte") }
+
+    it "réunit UNE note interne et UNE note publique consolidées sur le survivant, sans vider les bookables" do
+      target = make_stay(customer: customer, notes: "Note du séjour cible")
+      source = make_stay(customer: customer, notes: "Note du séjour source",
+                         arrival_date: Date.new(2026, 8, 4), departure_date: Date.new(2026, 8, 6))
+
+      booking = make_booking(notes: "Note interne hébergement", lodging: lodging)
+      booking.public_notes = "<div>Bienvenue à La Hulotte</div>"
+      booking.save!
+
+      space_booking = make_space_booking(notes: "Note interne espace")
+      space_booking.public_notes = "<div>Salle prête dès 14h</div>"
+      space_booking.save!
+
+      attach(target, booking)
+      attach(source, space_booking)
+
+      expect(described_class.new(target: target, sources: [source]).run).to be_truthy
+      target.reload
+
+      # Note interne consolidée : tous les contenus + provenance.
+      expect(target.notes).to include("Note du séjour cible")
+      expect(target.notes).to include("Note du séjour source")
+      expect(target.notes).to include("Note interne hébergement")
+      expect(target.notes).to include("Note interne espace")
+      expect(target.notes).to include("La Hulotte") # provenance du bookable
+
+      # Note publique consolidée (HTML des deux bookables).
+      html = target.public_notes.body.to_html
+      expect(html).to include("Bienvenue à La Hulotte")
+      expect(html).to include("Salle prête dès 14h")
+
+      # Les bookables GARDENT leurs notes (rien ne se perd — principe P2).
+      expect(booking.reload.notes).to eq("Note interne hébergement")
+      expect(space_booking.reload.notes).to eq("Note interne espace")
+      expect(space_booking.public_notes.body.to_plain_text).to include("Salle prête dès 14h")
+    end
+
+    it "laisse les notes du survivant inchangées quand il n'y a AUCUNE note nulle part" do
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer,
+                         arrival_date: Date.new(2026, 8, 4), departure_date: Date.new(2026, 8, 6))
+      attach(target, make_booking)
+      attach(source, make_space_booking)
+
+      expect(described_class.new(target: target, sources: [source]).run).to be_truthy
+      expect(target.reload.notes).to be_blank
+      expect(target.public_notes.body).to be_blank
+    end
+
+    it "déduplique les contenus internes strictement identiques" do
+      target = make_stay(customer: customer, notes: "Même note")
+      source = make_stay(customer: customer, notes: "Même note",
+                         arrival_date: Date.new(2026, 8, 4), departure_date: Date.new(2026, 8, 6))
+      attach(target, make_booking(notes: "Même note", lodging: lodging))
+      attach(source, make_space_booking)
+
+      expect(described_class.new(target: target, sources: [source]).run).to be_truthy
+      expect(target.reload.notes.scan("Même note").size).to eq(1)
+    end
+  end
+
   describe "intégrité transactionnelle" do
     it "ne modifie rien si une étape échoue en cours de route" do
       customer = make_customer("tx@example.com")

--- a/spec/services/stays/merge_service_spec.rb
+++ b/spec/services/stays/merge_service_spec.rb
@@ -266,6 +266,25 @@ RSpec.describe Stays::MergeService, type: :service do
       expect(space_booking.public_notes.body.to_plain_text).to include("Salle prête dès 14h")
     end
 
+    # Revue Forge F5 — le scénario réel de l'assainissement : un séjour SOURCE
+    # (qui sera soft-deleté par la fusion) porte SA PROPRE note publique. Elle
+    # doit survivre dans la consolidation, lue APRÈS le soft_delete! de la source.
+    it "conserve la note PUBLIQUE d'un séjour source soft-deleté par la fusion" do
+      target = make_stay(customer: customer)
+      source = make_stay(customer: customer,
+                         arrival_date: Date.new(2026, 8, 4), departure_date: Date.new(2026, 8, 6))
+      source.public_notes = "<div>Arrivée possible dès 15h, clés dans le boîtier</div>"
+      source.save!
+      attach(target, make_booking)
+      attach(source, make_space_booking)
+
+      expect(described_class.new(target: target, sources: [source]).run).to be_truthy
+
+      expect(source.reload.deleted_at).to be_present
+      expect(target.reload.public_notes.body.to_plain_text)
+        .to include("Arrivée possible dès 15h")
+    end
+
     it "laisse les notes du survivant inchangées quand il n'y a AUCUNE note nulle part" do
       target = make_stay(customer: customer)
       source = make_stay(customer: customer,


### PR DESCRIPTION
## Demandes

1. Lire les notes internes dans la modale séjour (elles n'apparaissaient plus nulle part).
2. Éditer note interne + note publique dans le formulaire séjour.
3. À la fusion : **les notes de tous les composants absolument conservées**, réunies en une note interne et une note publique sur le survivant.

## Implémentation

- `Stay` : `has_rich_text :public_notes` (ActionText, zéro migration) ; l'interne reste `stays.notes`.
- **Fusion** : consolidation ADDITIVE dans la transaction (après migration des bookables) — notes internes (séjours + tous bookables) réunies avec en-têtes de provenance (`— Note de La Hulotte (résa #345) —`), notes publiques rich text jointes par `<hr>`, dédup des contenus identiques, **jamais de colonne vidée** (P2).
- **Lecture** : `stays/_details` (modale calendrier + fiche) — interne en post-it jaune, publique étiquetée « visible client » ; page publique `/sejour/:token` : publique uniquement.
- **Édition** : formulaire séjour (textarea + éditeur Trix) ; création = concat avec la note auto multi-chiens du Builder (jamais écrasée) ; édition = écrasement (form prérempli).

## Revue Forge (GPT-5.4) : concerns → corrigés

- **F1** : la note publique consolidée se sauvegarde désormais explicitement (elle ne tenait que par l'autosave du `recompute_aggregates!` voisin — couplage invisible).
- **F5** : spec ajouté — note publique d'un séjour source soft-deleté par la fusion → survit dans la consolidation (le scénario exact de l'assainissement).
- XSS vérifié sûr (interne échappée + jamais publique ; publique re-sanitisée par ActionText à l'assignation), fuite interne→public couverte par spec, ordre reload/recompute sûr.

## Vérifications

- Specs fusion (consolidation, provenance, dédup, source soft-deletée, no-op sans notes, bookables intacts), CRUD admin (coexistence note saisie + auto, persistance édition), page publique (note publique affichée, interne jamais).
- Passe navigateur post-merge (Trix dans le form, post-it en modale) sur le serveur local.