### PR TITLE
feat(customers): fiche client — total du séjour + icônes de composition

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -40,6 +40,10 @@ class CustomersController < BaseController
     # Cibles possibles pour la re-ventilation des séjours (tout client sauf celui-ci).
     @reassign_targets = Customer.where.not(id: @customer.id).order(:first_name, :last_name, :email)
     @customer = CustomerDecorator.decorate(@customer)
+    # Séjours préchargés pour l'affichage du total + des icônes de composition
+    # (StaysCompositionHelper), sans N+1 sur la liste.
+    @upcoming_stays = preload_stays_composition(@customer.upcoming_stays)
+    @past_stays     = preload_stays_composition(@customer.past_stays)
   end
 
   def edit
@@ -128,6 +132,26 @@ class CustomersController < BaseController
   end
 
   private
+
+  # Précharge tout ce dont la liste des séjours a besoin pour afficher le total et
+  # les icônes de composition SANS N+1 : items→bookable (polymorphe) + activités,
+  # puis — pour les seuls SpaceBooking — leurs espaces (classés salle/cuisine dans
+  # `StaysCompositionHelper`). Le préchargement des espaces est fait à part car il
+  # ne concerne qu'un type de bookable polymorphe (Booking/Camping/Van n'ont pas
+  # d'espaces). Retourne un Array de Stay prêt à décorer.
+  def preload_stays_composition(relation)
+    stays = relation.includes(:experience_bookings, stay_items: :bookable).to_a
+    space_bookings = stays.flat_map(&:stay_items)
+                          .select { |item| item.bookable_type == "SpaceBooking" }
+                          .filter_map(&:bookable)
+    if space_bookings.any?
+      ActiveRecord::Associations::Preloader.new(
+        records: space_bookings,
+        associations: { space_reservations: :space }
+      ).call
+    end
+    stays
+  end
 
   # Returns [target_customer, nil] on success or [nil, error_message] on failure.
   def resolve_reassign_target

--- a/app/helpers/stays_composition_helper.rb
+++ b/app/helpers/stays_composition_helper.rb
@@ -1,0 +1,89 @@
+module StaysCompositionHelper
+  # Une icône emoji PAR TYPE de ressource composant un séjour, dans un ordre fixe
+  # et stable : hébergement, salle, cuisine, van, tente, activité. Jamais une
+  # icône par occurrence — une seule par type présent. Chaque icône porte un
+  # `title` (tooltip natif) nommant la ressource.
+  #
+  # HAMAC : aucune icône. Les hamacs ne sont PAS persistés côté séjour — ils
+  # n'existent que dans le devis B2C (`Reservations::Draft#hamacs`, pour le
+  # prix) ; `CampingBooking` ne persiste jamais que `kind: "tente"` et
+  # `RentalItem` n'est qu'un catalogue d'objets physiques (jamais rattaché à un
+  # Stay). Dès qu'un stockage hamac côté séjour existera, ajouter 🛌 ici.
+  #
+  # PERFORMANCE : ne déclenche AUCUNE requête. S'appuie sur les associations
+  # préchargées par `CustomersController#show` (stay_items→bookable,
+  # space_reservations→space, experience_bookings). Tout le filtrage se fait en
+  # mémoire Ruby — pas de N+1 dans la liste des séjours.
+  def stay_composition_icons(stay)
+    icons = []
+    icons << composition_icon("🏠", "Hébergement") if stay_has_lodging?(stay)
+    icons << composition_icon("🏛️", "Salle")       if stay_has_hall?(stay)
+    icons << composition_icon("🍳", "Cuisine")      if stay_has_kitchen?(stay)
+    icons << composition_icon("🚐", "Van")          if stay_has_van?(stay)
+    icons << composition_icon("⛺", "Tente")        if stay_has_tent?(stay)
+    icons << composition_icon("🎯", "Activité")     if stay_has_activity?(stay)
+    return if icons.empty?
+
+    tag.span(safe_join(icons, " "), class: "inline-flex items-center gap-1")
+  end
+
+  private
+
+  def composition_icon(emoji, label)
+    tag.span(emoji, title: label, role: "img", aria: { label: label },
+                    class: "text-base leading-none")
+  end
+
+  # StayItems du type polymorphe demandé (les soft-deleted sont déjà exclus par
+  # le default_scope au moment du préchargement).
+  def stay_items_of(stay, bookable_type)
+    stay.stay_items.select { |item| item.bookable_type == bookable_type }
+  end
+
+  def stay_has_lodging?(stay)
+    stay_items_of(stay, "Booking").any?
+  end
+
+  def stay_has_van?(stay)
+    stay_items_of(stay, "VanBooking").any?
+  end
+
+  # Camping = tente (seul `kind` persisté aujourd'hui — cf. note hamac ci-dessus).
+  def stay_has_tent?(stay)
+    stay_items_of(stay, "CampingBooking").any?
+  end
+
+  # Activité = au moins un ExperienceBooking ACTIF (ni annulé, ni refusé — même
+  # définition que le scope `ExperienceBooking.active`, appliquée en mémoire pour
+  # rester sans requête sur une association préchargée).
+  def stay_has_activity?(stay)
+    stay.experience_bookings.any? { |eb| !(eb.cancelled? || eb.refused?) }
+  end
+
+  # Tous les espaces occupés par les SpaceBooking du séjour.
+  def stay_spaces(stay)
+    stay_items_of(stay, "SpaceBooking")
+      .filter_map(&:bookable)
+      .flat_map(&:space_reservations)
+      .filter_map(&:space)
+  end
+
+  # Distinction salle vs cuisine par MOTIF sur code + nom (les codes réels de prod
+  # — « Cuisine », « Grande salle », « Coworking », « Bois », « OUEST »… — varient
+  # et ne suivent pas les codes des seeds : on résout par pattern, pas par liste
+  # figée). Un espace « Cuisine » → 🍳 ; tout le reste (salles, coworking, bois,
+  # pâtures/extérieur) → icône salle générique 🏛️.
+  KITCHEN_SPACE_PATTERN = /cuisine/i
+
+  def kitchen_space?(space)
+    "#{space.code} #{space.name}".match?(KITCHEN_SPACE_PATTERN)
+  end
+
+  def stay_has_kitchen?(stay)
+    stay_spaces(stay).any? { |space| kitchen_space?(space) }
+  end
+
+  def stay_has_hall?(stay)
+    stay_spaces(stay).any? { |space| !kitchen_space?(space) }
+  end
+end

--- a/app/views/customers/show.html.slim
+++ b/app/views/customers/show.html.slim
@@ -43,7 +43,7 @@
                 = @customer.language_label
 
       = form_with url: reassign_customer_path(@customer), method: :post, data: { controller: "reventilation-modal" } do
-        - [["Séjours à venir", @customer.upcoming_stays, "Aucun séjour à venir."], ["Séjours passés", @customer.past_stays, "Aucun séjour passé."]].each do |title, stays, empty_label|
+        - [["Séjours à venir", @upcoming_stays, "Aucun séjour à venir."], ["Séjours passés", @past_stays, "Aucun séjour passé."]].each do |title, stays, empty_label|
           .overflow-hidden.bg-white.shadow.sm:rounded-lg
             .px-4.py-5.sm:px-6
               h3.text-lg.font-medium.leading-6.text-gray-900
@@ -63,6 +63,9 @@
                           = stay.status_badge
                           = stay.platform_badge
                         .text-gray-500.truncate = stay.contact_line
+                        .mt-1.flex.items-center.gap-2.flex-wrap
+                          span.font-medium.text-gray-900 = humanized_money_with_symbol(stay.total_amount)
+                          = stay_composition_icons(stay)
                       = link_to "Détails", stay_path(stay),
                                 data: { action: "stay-details#open" },
                                 class: "shrink-0 text-indigo-600 hover:underline"

--- a/spec/requests/customers_show_composition_spec.rb
+++ b/spec/requests/customers_show_composition_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+
+# Fiche client (customers#show) — la liste des séjours affiche, pour chaque
+# séjour, LE MONTANT TOTAL et UNE ICÔNE PAR TYPE DE RESSOURCE qui le compose
+# (hébergement, salle, cuisine, van, tente, activité). Une icône par TYPE présent,
+# jamais par occurrence. Le hamac n'est pas persisté côté séjour → jamais d'icône.
+RSpec.describe "Customers#show — total + icônes de composition des séjours", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin)    { User.create!(email: "compo-fiche@les4sources.be", password: "password123") }
+  let(:customer) { Customer.create!(email: "compo-client@example.com", customer_type: "individual", first_name: "Ada", last_name: "Lovelace") }
+  let(:lodging)  { Lodging.create!(name: "La Hulotte", price_night_cents: 48_500) }
+  # Codes réels de prod (pas les codes des seeds) : salle vs cuisine résolus par
+  # motif sur code + nom.
+  let(:hall)     { Space.create!(name: "Grande salle", code: "Grande salle", capacity: 40) }
+  let(:kitchen)  { Space.create!(name: "Cuisine", code: "Cuisine", capacity: 1) }
+
+  let(:from) { Date.today + 30 }
+  let(:to)   { Date.today + 32 }
+
+  let(:porteur)      { Human.create!(name: "Porteuse", email: "porteuse-compo@example.com") }
+  let(:experience)   { Experience.create!(name: "Balade ânes", human: porteur, fixed_price_cents: 4000, price_cents: 1500) }
+  let(:availability) { ExperienceAvailability.create!(experience: experience, available_on: from + 1, starts_at: "10:00") }
+
+  # Un séjour composite : hébergement + salle + cuisine + tente + van + activité.
+  let!(:composite) do
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: from, departure_date: to, total_amount_cents: 137_500)
+
+    booking = Booking.create!(firstname: "Ada", lastname: "Lovelace", group_name: "Les Analytiques",
+                              lodging: lodging, from_date: from, to_date: to,
+                              adults: 3, status: "confirmed", booking_type: "lodging", price_cents: 97_000)
+    stay.stay_items.create!(bookable: booking)
+
+    hall_booking = SpaceBooking.create!(firstname: "Ada", group_name: "Les Analytiques",
+                                        from_date: from, to_date: from, status: "confirmed", price_cents: 12_000)
+    SpaceReservation.create!(space: hall, space_booking: hall_booking, date: from)
+    stay.stay_items.create!(bookable: hall_booking)
+
+    kitchen_booking = SpaceBooking.create!(firstname: "Ada", group_name: "Les Analytiques",
+                                           from_date: from, to_date: from, status: "confirmed", price_cents: 5_000)
+    SpaceReservation.create!(space: kitchen, space_booking: kitchen_booking, date: from)
+    stay.stay_items.create!(bookable: kitchen_booking)
+
+    camping = CampingBooking.create!(firstname: "Ada", group_name: "Les Analytiques",
+                                     from_date: from, to_date: to, people: 5, kind: "tente",
+                                     status: "confirmed", price_cents: 9_000)
+    stay.stay_items.create!(bookable: camping)
+
+    van = VanBooking.create!(firstname: "Ada", group_name: "Les Analytiques",
+                             from_date: from, to_date: to, vehicles: 2, status: "confirmed", price_cents: 6_000)
+    stay.stay_items.create!(bookable: van)
+
+    ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 4, status: "confirmed")
+    stay
+  end
+
+  # Un séjour hébergement-seul : uniquement l'icône 🏠.
+  let!(:lodging_only) do
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: from + 10, departure_date: from + 12, total_amount_cents: 48_500)
+    booking = Booking.create!(firstname: "Ada", lastname: "Lovelace", group_name: "Solo",
+                              lodging: lodging, from_date: from + 10, to_date: from + 12,
+                              adults: 2, status: "confirmed", booking_type: "lodging", price_cents: 48_500)
+    stay.stay_items.create!(bookable: booking)
+    stay
+  end
+
+  before { sign_in admin }
+
+  def money(cents)
+    ApplicationController.helpers.humanized_money_with_symbol(Money.new(cents))
+  end
+
+  describe "GET /customers/:id" do
+    before { get customer_path(customer) }
+
+    it "répond OK" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "affiche le montant total formaté de chaque séjour" do
+      expect(response.body).to include(money(137_500)) # séjour composite
+      expect(response.body).to include(money(48_500))  # séjour hébergement-seul
+    end
+
+    it "affiche une icône par type de ressource du séjour composite" do
+      expect(response.body).to include('title="Hébergement"')
+      expect(response.body).to include('title="Salle"')
+      expect(response.body).to include('title="Cuisine"')
+      expect(response.body).to include('title="Van"')
+      expect(response.body).to include('title="Tente"')
+      expect(response.body).to include('title="Activité"')
+      # Les emojis attendus sont bien rendus.
+      expect(response.body).to include("🏠", "🏛️", "🍳", "🚐", "⛺", "🎯")
+    end
+
+    it "n'affiche jamais d'icône hamac (non persisté côté séjour)" do
+      expect(response.body).not_to include("🛌")
+      expect(response.body).not_to include('title="Hamac"')
+    end
+  end
+
+  describe "séjour hébergement-seul" do
+    it "n'affiche que l'icône hébergement (aucune autre ressource)" do
+      lodging_only # matérialise le séjour hébergement-seul
+      # Isole ce client sur son seul séjour hébergement-seul.
+      solo = Customer.create!(email: "solo-lodging@example.com", customer_type: "individual", first_name: "Grace")
+      stay = Stay.create!(customer: solo, source: "manual", status: "confirmed",
+                          arrival_date: from, departure_date: to, total_amount_cents: 48_500)
+      booking = Booking.create!(firstname: "Grace", lastname: "Hopper", group_name: "Solo",
+                                lodging: lodging, from_date: from, to_date: to,
+                                adults: 2, status: "confirmed", booking_type: "lodging", price_cents: 48_500)
+      stay.stay_items.create!(bookable: booking)
+
+      get customer_path(solo)
+
+      expect(response.body).to include('title="Hébergement"')
+      expect(response.body).to include("🏠")
+      expect(response.body).not_to include('title="Salle"')
+      expect(response.body).not_to include('title="Cuisine"')
+      expect(response.body).not_to include('title="Van"')
+      expect(response.body).not_to include('title="Tente"')
+      expect(response.body).not_to include('title="Activité"')
+    end
+  end
+
+  describe "activité annulée / refusée" do
+    it "n'affiche pas l'icône activité si la seule activité est annulée" do
+      dead = Customer.create!(email: "dead-activity@example.com", customer_type: "individual", first_name: "Nulle")
+      stay = Stay.create!(customer: dead, source: "manual", status: "confirmed",
+                          arrival_date: from, departure_date: to, total_amount_cents: 48_500)
+      booking = Booking.create!(firstname: "N", lastname: "N", group_name: "N", lodging: lodging,
+                                from_date: from, to_date: to, adults: 1, status: "confirmed",
+                                booking_type: "lodging", price_cents: 48_500)
+      stay.stay_items.create!(bookable: booking)
+      ExperienceBooking.create!(experience_availability: availability, stay: stay, participants: 2, status: "cancelled")
+
+      get customer_path(dead)
+
+      expect(response.body).to include('title="Hébergement"')
+      expect(response.body).not_to include('title="Activité"')
+    end
+  end
+end


### PR DESCRIPTION
## Demande

Fiche client, liste des séjours : montant total + une icône par type de ressource (hébergement, salle, cuisine, van, tente, hamac, activité).

## Implémentation

- Helper `stay_composition_icons(stay)` : une icône par TYPE présent — 🏠 hébergement · 🏛️ salle (et espaces génériques : coworking, bois, pâtures) · 🍳 cuisine (motif `/cuisine/i` sur code+nom, robuste aux codes prod réels) · 🚐 van · ⛺ tente · 🎯 activités actives — chacune avec `title` + `aria-label`.
- **Hamac : omis à raison** — aucun stockage hamac n'existe côté Stay (les hamacs ne vivent que dans le devis ; `CampingBooking` ne persiste que `kind: "tente"`). Documenté dans le helper, spec anti-fuite ajoutée ; l'icône 🛌 s'ajoutera quand un stockage existera.
- Total : `humanized_money_with_symbol` (pattern repo). Zéro N+1 (préchargements + Preloader ciblé pour le polymorphe).

## Vérifications

- 6 specs (rendu réel de la vue : icônes, titles, totaux ; hébergement-seul → 🏠 seul).
- Suite complète sur la branche : **845 examples, 0 failures**.
- Coup d'œil visuel post-merge sur le serveur local.