### PR TITLE
feat(stays): confirmation en deux clics sur les boutons de statut

### DIFF
--- a/app/frontend/controllers/confirm_click_controller.js
+++ b/app/frontend/controllers/confirm_click_controller.js
@@ -1,0 +1,128 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Two-click confirmation for a form submit button (generic, reusable).
+//
+// `button_to` renders a <form> wrapping a <button>, so we hook the controller
+// on the FORM and intercept its `submit` event (more reliable than the click):
+// the first submit is prevented and the button morphs into a confirmation
+// label with an alert (red) style, keeping its size stable to avoid layout
+// shift. A second submit within the window lets the real submission proceed.
+// Escape, a click/focus outside the form, or a timeout restores the button.
+//
+// Usage (Slim / button_to):
+//   = button_to "Confirmer le séjour", path, method: :patch,
+//       form: { data: { controller: "confirm-click",
+//                       action: "submit->confirm-click#confirm",
+//                       "confirm-click-label-value": "Êtes-vous sûr·e ?" } },
+//       data: { "confirm-click-target": "button" }
+//
+// All state is instance-scoped (no globals), so multiple instances — including
+// one injected dynamically into the calendar modal — coexist safely.
+export default class extends Controller {
+  static targets = ["button"]
+  static values = {
+    label: { type: String, default: "Confirmer ?" },
+    delay: { type: Number, default: 4000 }
+  }
+
+  connect() {
+    this.armed = false
+    this.timer = null
+    this.onKeydown = null
+    this.onOutside = null
+  }
+
+  disconnect() {
+    this.restore()
+  }
+
+  // Intercepts the form submit. First submit arms the confirmation; a second
+  // submit while armed is allowed through untouched.
+  confirm(event) {
+    if (this.armed) {
+      this.clearTimer()
+      this.detachOutsideListeners()
+      this.armed = false
+      return
+    }
+
+    event.preventDefault()
+    this.arm()
+  }
+
+  arm() {
+    const button = this.buttonElement()
+    if (!button) return
+
+    this.armed = true
+    this.originalHtml = button.innerHTML
+    // Freeze the current width so the shorter confirm label doesn't shrink the
+    // button and shift the surrounding layout.
+    button.style.minWidth = `${button.offsetWidth}px`
+    button.style.textAlign = "center"
+    button.textContent = this.labelValue
+    this.applyAlertStyle(button)
+
+    this.timer = setTimeout(() => this.restore(), this.delayValue)
+
+    this.onKeydown = (event) => {
+      if (event.key === "Escape") this.restore()
+    }
+    this.onOutside = (event) => {
+      if (!this.element.contains(event.target)) this.restore()
+    }
+    document.addEventListener("keydown", this.onKeydown)
+    // Capture phase so an outside click restores before it does anything else.
+    document.addEventListener("click", this.onOutside, true)
+  }
+
+  // Restores the button to its initial label and style.
+  restore() {
+    this.clearTimer()
+    this.detachOutsideListeners()
+
+    if (this.armed) {
+      const button = this.buttonElement()
+      if (button) {
+        button.innerHTML = this.originalHtml
+        button.style.minWidth = ""
+        button.style.textAlign = ""
+        this.removeAlertStyle(button)
+      }
+    }
+    this.armed = false
+  }
+
+  // Inline styles (not Tailwind classes) so the alert look is guaranteed
+  // regardless of JIT purging, and overrides the button's own bg/border.
+  applyAlertStyle(button) {
+    button.style.backgroundColor = "#dc2626" // red-600
+    button.style.borderColor = "#dc2626"
+    button.style.color = "#ffffff"
+  }
+
+  removeAlertStyle(button) {
+    button.style.backgroundColor = ""
+    button.style.borderColor = ""
+    button.style.color = ""
+  }
+
+  buttonElement() {
+    if (this.hasButtonTarget) return this.buttonTarget
+    return this.element.querySelector("button")
+  }
+
+  clearTimer() {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  detachOutsideListeners() {
+    if (this.onKeydown) document.removeEventListener("keydown", this.onKeydown)
+    if (this.onOutside) document.removeEventListener("click", this.onOutside, true)
+    this.onKeydown = null
+    this.onOutside = null
+  }
+}

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -17,9 +17,9 @@ div id="stay-details-#{@stay.id}"
     / le form d'édition. Le changement de statut propage aux réservables (veto).
     .flex.flex-wrap.items-center.gap-2.border-t.border-gray-200.pt-3
       - if @stay.status == "confirmed"
-        = button_to "Repasser en attente", update_status_stay_path(@stay, status: "pending"), method: :patch, class: "inline-flex items-center rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm font-medium text-amber-800 hover:bg-amber-100"
+        = button_to "Repasser en attente", update_status_stay_path(@stay, status: "pending"), method: :patch, form: { data: { controller: "confirm-click", action: "submit->confirm-click#confirm", "confirm-click-label-value": "Êtes-vous sûr·e ?" } }, data: { "confirm-click-target": "button" }, class: "inline-flex items-center rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm font-medium text-amber-800 hover:bg-amber-100"
       - else
-        = button_to "Confirmer le séjour", update_status_stay_path(@stay, status: "confirmed"), method: :patch, class: "inline-flex items-center rounded-md border border-transparent bg-green-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-green-700"
+        = button_to "Confirmer le séjour", update_status_stay_path(@stay, status: "confirmed"), method: :patch, form: { data: { controller: "confirm-click", action: "submit->confirm-click#confirm", "confirm-click-label-value": "Êtes-vous sûr·e ?" } }, data: { "confirm-click-target": "button" }, class: "inline-flex items-center rounded-md border border-transparent bg-green-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-green-700"
       - if @stay.token.present?
         = link_to "Solde / paiement client ↗", public_stay_path(@stay.token), target: "_blank", rel: "noopener", class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
 

--- a/spec/requests/stays_status_confirm_click_spec.rb
+++ b/spec/requests/stays_status_confirm_click_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+# Confirmation en deux clics sur les boutons de changement de statut d'un séjour
+# (fiche + modale calendrier). Le comportement JS (morphing du bouton) est
+# vérifié au navigateur ; ici on garantit seulement que les deux boutons
+# portent bien les data-attributes du contrôleur Stimulus `confirm-click`.
+RSpec.describe "Stays — confirmation deux clics sur le statut", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "admin-confirmclick@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  let(:arrival)   { Date.today + 60 }
+  let(:departure) { Date.today + 62 }
+
+  def create_pending_stay
+    draft = Reservations::Draft.new(
+      lodging_id: hulotte.id, arrival_date: arrival, departure_date: departure,
+      adults: 2, dogs_count: 0, first_name: "Alice", last_name: "Martin",
+      email: "alice@example.com", phone: "0470111222"
+    )
+    Reservations::Builder.new(draft: draft, admin: true, source: "manual", status: "pending").tap(&:run!).stay
+  end
+
+  it "arme le bouton « Confirmer le séjour » avec le contrôleur confirm-click" do
+    stay = create_pending_stay
+
+    get stay_path(stay)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Confirmer le séjour")
+    # Le contrôleur est accroché au form généré par button_to, sur son submit.
+    expect(response.body).to include('data-controller="confirm-click"')
+    expect(response.body).to include("submit-&gt;confirm-click#confirm")
+    expect(response.body).to include('data-confirm-click-label-value="Êtes-vous sûr·e ?"')
+    # La cible button permet au contrôleur de morpher le libellé.
+    expect(response.body).to include('data-confirm-click-target="button"')
+  end
+
+  it "arme le bouton « Repasser en attente » avec le contrôleur confirm-click" do
+    stay = create_pending_stay
+    patch update_status_stay_path(stay), params: { status: "confirmed" }
+
+    get stay_path(stay)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Repasser en attente")
+    expect(response.body).to include('data-controller="confirm-click"')
+    expect(response.body).to include("submit-&gt;confirm-click#confirm")
+    expect(response.body).to include('data-confirm-click-label-value="Êtes-vous sûr·e ?"')
+    expect(response.body).to include('data-confirm-click-target="button"')
+  end
+end


### PR DESCRIPTION
## Demande

« Repasser en attente » / « Confirmer le séjour » : le premier clic transforme le bouton en **« Êtes-vous sûr·e ? »**, seul un second clic exécute le changement de statut.

## Implémentation

Contrôleur Stimulus générique `confirm-click` (valeurs `label`/`delay` configurables, réutilisable) : interception du **submit** du form `button_to` (couvre souris + clavier), morphing avec largeur figée (pas de saut de layout), style d'alerte en inline (immunisé du purge JIT), restauration par timer 4 s / Échap / clic ailleurs / `disconnect()` (le partial est ré-injecté en Turbo Stream après l'action). Aucun état global — fonctionne en modale calendrier ET sur la fiche.

## Vérifications

- Request spec : les deux boutons portent les data-attributes du contrôleur (pending → « Confirmer le séjour », confirmed → « Repasser en attente »).
- Suite complète sur la branche : **865 examples, 0 failures**.
- Comportement JS : vérifié au navigateur post-merge (passe groupée avec les chantiers en cours).