### PR TITLE
feat(bookings): rake convert_tent_spaces_to_camping — espaces Bois/Pâtures → tentes

### DIFF
--- a/lib/tasks/bookings.rake
+++ b/lib/tasks/bookings.rake
@@ -165,6 +165,164 @@ namespace :bookings do
     print_parking_van_report(report, apply)
     abort("ÉCHEC : #{report[:failed_total_drift].size} séjour(s) en dérive de total.") if report[:failed_total_drift].any?
   end
+
+  # One-shot idempotente : convertit les réservations d'ESPACE « tentes » (Bois,
+  # Pâture ouest, Pâture est) en réservations de CAMPING (CampingBooking kind
+  # "tente", epic #66). Décision Michael : toute résa de ces espaces était en
+  # réalité un camping tente ; le nombre de PERSONNES se DÉDUIT du prix
+  # (people = prix / (nuits × 7,50 €/pers/nuit)). On PRÉSERVE le montant du séjour
+  # (on ne refacture pas le passé). Sœur de convert_parking_to_van (même famille).
+  #
+  # DRY-RUN par défaut (rapport seul, aucune écriture) ; APPLY=1 pour appliquer.
+  #
+  #   bundle exec rake bookings:convert_tent_spaces_to_camping          # DRY-RUN
+  #   APPLY=1 bundle exec rake bookings:convert_tent_spaces_to_camping  # RÉEL
+  #
+  # Sémantique nuits : une SpaceReservation porte une DATE (un jour réservé).
+  # from_date = min(dates), to_date = max(dates) + 1 ([from, to)) ; nuits = nombre
+  # de dates réservées DISTINCTES. `people` se déduit du prix conservé :
+  #   people = price_cents / (nuits × 750)
+  # Si la division ne tombe PAS juste (reste ≠ 0) ou donne 0 → on NE convertit PAS
+  # (skipped_price_ambiguous, avec le détail) : Michael tranche à la main.
+  desc "Convertit les SpaceBooking 100 % espaces tentes (Bois/Pâtures) en CampingBooking tente (people déduit du prix). DRY-RUN sauf APPLY=1"
+  task convert_tent_spaces_to_camping: :environment do
+    apply = ENV["APPLY"] == "1"
+    rate = Pricing::Catalog::CAMPING_PER_PERSON_NIGHT_CENTS.fetch("tente") # 750 cts
+
+    # Espaces « tentes » : Bois + pâtures, résolus par CODE ou NOM (jamais par id
+    # en dur). Codes prod : "Bois", "OUEST", "EST" ; noms : "Bois", "Pature ouest",
+    # "Pature est". Regex insensible à la casse et à l'accent de « pâture ».
+    tent_space_ids = Space.where(
+      "code ~* :codes OR name ~* :names",
+      codes: '^(bois|ouest|est)$',
+      names: 'bois|p[aâ]ture'
+    ).pluck(:id)
+
+    report = {
+      scanned: [],
+      converted: [],
+      skipped_mixed: [],
+      skipped_empty: [],
+      skipped_no_stay: [],
+      skipped_price_ambiguous: [],
+      failed_total_drift: []
+    }
+
+    if tent_space_ids.empty?
+      puts "=== bookings:convert_tent_spaces_to_camping #{apply ? '(RÉEL)' : '(DRY-RUN)'} ==="
+      puts "Aucun espace tente (Bois / Pâture ouest / Pâture est) trouvé — rien à convertir."
+      next
+    end
+
+    # CANDIDATS = SpaceBooking VIVANTS portant ≥1 SpaceReservation VIVANTE
+    # (deleted_at IS NULL — ce modèle n'a pas de soft-deletion, on filtre la
+    # colonne) pointant un espace tente. Idempotence : après conversion les
+    # réservations sont détruites → plus candidat.
+    candidate_ids = SpaceReservation
+      .where(deleted_at: nil, space_id: tent_space_ids)
+      .distinct
+      .pluck(:space_booking_id)
+
+    SpaceBooking.where(id: candidate_ids).find_each do |space_booking|
+      report[:scanned] << space_booking.id
+
+      living_reservations = space_booking.space_reservations.where(deleted_at: nil).to_a
+
+      if living_reservations.empty?
+        report[:skipped_empty] << space_booking.id
+        next
+      end
+
+      # Mixte : au moins une réservation vivante pointe un espace NON tente (une
+      # salle) → on ne touche pas.
+      unless living_reservations.all? { |r| tent_space_ids.include?(r.space_id) }
+        report[:skipped_mixed] << space_booking.id
+        next
+      end
+
+      stay = space_booking.stay
+      if stay.nil?
+        report[:skipped_no_stay] << space_booking.id
+        next
+      end
+
+      # `people` déduit du prix : nuits = nombre de dates DISTINCTES réservées.
+      dates = living_reservations.map(&:date).compact.uniq
+      nights = dates.size
+      price_cents = space_booking.price_cents
+      denom = nights * rate
+
+      if price_cents.nil? || denom.zero?
+        report[:skipped_price_ambiguous] <<
+          "space_booking #{space_booking.id} : prix=#{price_cents.inspect}, nuits=#{nights} (indéterminable)"
+        next
+      end
+
+      people, remainder = price_cents.divmod(denom)
+      # La division DOIT tomber juste (reste 0) et donner ≥1 personne, sinon on ne
+      # devine pas : Michael tranchera (people ≥ 1 est aussi la validation modèle).
+      if remainder != 0 || people <= 0
+        report[:skipped_price_ambiguous] <<
+          "space_booking #{space_booking.id} : prix=#{price_cents} cts, nuits=#{nights}, #{price_cents}/#{denom}=#{(price_cents.to_f / denom).round(2)} pers (non entier)"
+        next
+      end
+
+      total_before = stay.total_amount_cents
+      outcome = nil
+
+      # Transaction PAR SpaceBooking, `requires_new: true` (rollback réel du
+      # DRY-RUN et sous fixtures transactionnelles — cf. convert_parking_to_van).
+      ActiveRecord::Base.transaction(requires_new: true) do
+        from_date = dates.min
+        to_date   = dates.max + 1 # sémantique nuits [from, to)
+
+        camping = CampingBooking.new(
+          firstname: space_booking.firstname,
+          lastname: space_booking.lastname,
+          email: space_booking.email,
+          phone: space_booking.phone,
+          group_name: space_booking.group_name,
+          status: space_booking.status,
+          kind: "tente",
+          people: people,
+          from_date: from_date,
+          to_date: to_date,
+          # INVARIANT : le montant du séjour ne change pas — prix conservé tel quel.
+          price_cents: price_cents
+        )
+        camping.notes = space_booking.notes if camping.respond_to?(:notes) && space_booking.respond_to?(:notes)
+        camping.save!
+
+        StayItem.create!(stay: stay, bookable: camping)
+
+        # SpaceReservation : pas de soft-deletion et pas de cascade depuis le
+        # SpaceBooking → on retire les lignes explicitement (pattern
+        # Stays::DestroyService). Rend l'occupation/veto des espaces tentes.
+        space_booking.space_reservations.destroy_all
+        StayItem.find_by(bookable: space_booking)&.soft_delete!(validate: false)
+        space_booking.soft_delete!(validate: false)
+
+        stay.reload
+        stay.recompute_aggregates!
+
+        if stay.total_amount_cents != total_before
+          outcome = :drift
+          raise ActiveRecord::Rollback
+        end
+
+        outcome = :converted
+        raise ActiveRecord::Rollback unless apply # DRY-RUN : on annule tout
+      end
+
+      case outcome
+      when :converted then report[:converted] << space_booking.id
+      when :drift     then report[:failed_total_drift] << space_booking.id
+      end
+    end
+
+    print_tent_camping_report(report, apply)
+    abort("ÉCHEC : #{report[:failed_total_drift].size} séjour(s) en dérive de total.") if report[:failed_total_drift].any?
+  end
 end
 
 def print_parking_van_report(report, apply)
@@ -184,4 +342,19 @@ end
 
 def parking_ids(list)
   list.empty? ? "" : "→ #{list.sort.join(', ')}"
+end
+
+def print_tent_camping_report(report, apply)
+  puts "=== bookings:convert_tent_spaces_to_camping #{apply ? '(RÉEL)' : '(DRY-RUN)'} ==="
+  puts "Scannés (candidats tentes)         : #{report[:scanned].size} #{parking_ids(report[:scanned])}"
+  puts "Convertis en camping (tente)       : #{report[:converted].size} #{parking_ids(report[:converted])}"
+  puts "Ignorés — mixtes (tente + salle)   : #{report[:skipped_mixed].size} #{parking_ids(report[:skipped_mixed])}"
+  puts "Ignorés — sans réservation         : #{report[:skipped_empty].size} #{parking_ids(report[:skipped_empty])}"
+  puts "Ignorés — sans séjour              : #{report[:skipped_no_stay].size} #{parking_ids(report[:skipped_no_stay])}"
+  puts "Échecs — dérive de total           : #{report[:failed_total_drift].size} #{parking_ids(report[:failed_total_drift])}"
+  unless report[:skipped_price_ambiguous].empty?
+    puts "Ignorés — prix ambigu (à trancher) : #{report[:skipped_price_ambiguous].size}"
+    report[:skipped_price_ambiguous].each { |line| puts "  - #{line}" }
+  end
+  puts(apply ? "OK — conversions appliquées." : "DRY-RUN — aucune écriture. Relancer avec APPLY=1 pour appliquer.")
 end

--- a/spec/tasks/bookings_convert_tent_spaces_to_camping_spec.rb
+++ b/spec/tasks/bookings_convert_tent_spaces_to_camping_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "bookings:convert_tent_spaces_to_camping", type: :task do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("bookings:convert_tent_spaces_to_camping")
+  end
+
+  # Exécute la tâche et renvoie sa sortie (rapport ventilé), silençée du flux de
+  # test. `apply: true` pose APPLY=1 le temps de l'invocation.
+  def run_task(apply: false)
+    task = Rake::Task["bookings:convert_tent_spaces_to_camping"]
+    task.reenable
+    previous_apply = ENV["APPLY"]
+    ENV["APPLY"] = apply ? "1" : nil
+    original = $stdout
+    buffer = StringIO.new
+    $stdout = buffer
+    task.invoke
+    buffer.string
+  ensure
+    $stdout = original
+    ENV["APPLY"] = previous_apply
+  end
+
+  let(:d1) { Date.new(2026, 8, 1) }
+  let(:d2) { Date.new(2026, 8, 2) }
+
+  # Espace « tente » : le Bois (capacité 3 personnes/groupes).
+  let(:bois) { Space.create!(code: "Bois", name: "Bois", capacity: 3) }
+
+  # SpaceBooking VIVANT + son Stay (via le service courant), sans réservation.
+  def build_space_booking(price_cents: 3_000, status: "confirmed", **attrs)
+    sb = SpaceBooking.create!({
+      firstname: "Tente",
+      lastname: "Camper",
+      email: "tente@example.com",
+      from_date: d1,
+      to_date: d2,
+      status: status,
+      price_cents: price_cents
+    }.merge(attrs))
+    Stays::EnsureForSpaceBooking.call(sb)
+    sb
+  end
+
+  def reserve(space_booking, space, date)
+    SpaceReservation.create!(space_booking: space_booking, space: space, date: date)
+  end
+
+  context "SpaceBooking 100 % espace tente, 2 nuits à 30 € (people déduit = 2)" do
+    it "le convertit en CampingBooking tente 2 personnes, nuits/prix/total conservés" do
+      sb = build_space_booking(price_cents: 3_000) # 30 € = 2 nuits × 2 pers × 7,50 €
+      reserve(sb, bois, d1)
+      reserve(sb, bois, d2)
+      stay = sb.stay
+      total_before = stay.total_amount_cents
+
+      expect(SpaceReservation.where(space: bois, deleted_at: nil).count).to eq(2)
+
+      expect { run_task(apply: true) }.to change(CampingBooking, :count).by(1)
+
+      camping = CampingBooking.last
+      expect(camping.kind).to eq("tente")
+      expect(camping.people).to eq(2) # 3000 / (2 × 750)
+      # 2 jours consécutifs → [d1, d2+1) = 2 nuits.
+      expect(camping.from_date).to eq(d1)
+      expect(camping.to_date).to eq(d2 + 1)
+      expect(camping.price_cents).to eq(3_000) # prix historique conservé tel quel
+      expect(camping.firstname).to eq("Tente")
+      expect(camping.status).to eq("confirmed")
+
+      # Camping rattaché au MÊME séjour ; total du séjour INCHANGÉ.
+      expect(camping.stay).to eq(stay)
+      expect(stay.reload.total_amount_cents).to eq(total_before)
+
+      # SpaceBooking soft-deleté, plus aucune SpaceReservation vivante.
+      expect(SpaceBooking.find_by(id: sb.id)).to be_nil
+      expect(SpaceBooking.with_deleted { SpaceBooking.unscoped.find(sb.id).deleted_at }).to be_present
+      expect(SpaceReservation.where(space_booking_id: sb.id, deleted_at: nil)).to be_empty
+      expect(SpaceReservation.where(space: bois, deleted_at: nil).count).to eq(0)
+
+      # StayItem du camping vivant, StayItem du SpaceBooking retiré.
+      expect(StayItem.where(bookable: camping).count).to eq(1)
+      expect(StayItem.where(bookable_type: "SpaceBooking", bookable_id: sb.id).count).to eq(0)
+    end
+  end
+
+  context "prix qui ne tombe pas juste (20 € / 2 nuits → 1,33 pers)" do
+    it "ne convertit pas et le rapporte en prix ambigu" do
+      sb = build_space_booking(price_cents: 2_000) # 2000 / 1500 = 1,33 → non entier
+      reserve(sb, bois, d1)
+      reserve(sb, bois, d2)
+
+      output = nil
+      expect { output = run_task(apply: true) }.not_to change(CampingBooking, :count)
+
+      # Intact.
+      expect(SpaceBooking.find_by(id: sb.id)).to be_present
+      expect(SpaceReservation.where(space_booking_id: sb.id, deleted_at: nil).count).to eq(2)
+
+      expect(output).to match(/prix ambigu/i)
+      expect(output).to match(/space_booking #{sb.id}/)
+    end
+  end
+
+  context "SpaceBooking mixte (tente + salle)" do
+    it "n'y touche pas et le rapporte en skipped_mixed" do
+      grande_salle = Space.create!(code: "GS", name: "Grande Salle", capacity: 1)
+      sb = build_space_booking(price_cents: 3_000)
+      reserve(sb, bois, d1)
+      reserve(sb, grande_salle, d1)
+
+      output = nil
+      expect { output = run_task(apply: true) }.not_to change(CampingBooking, :count)
+
+      expect(SpaceBooking.find_by(id: sb.id)).to be_present
+      expect(SpaceReservation.where(space_booking_id: sb.id, deleted_at: nil).count).to eq(2)
+      expect(output).to match(/mixtes.*#{sb.id}/)
+    end
+  end
+
+  context "DRY-RUN (par défaut)" do
+    it "n'écrit rien" do
+      sb = build_space_booking(price_cents: 3_000)
+      reserve(sb, bois, d1)
+      reserve(sb, bois, d2)
+
+      expect { run_task(apply: false) }.not_to change(CampingBooking, :count)
+      expect(StayItem.where(bookable_type: "CampingBooking").count).to eq(0)
+      expect(SpaceBooking.find_by(id: sb.id)).to be_present
+      expect(SpaceReservation.where(space_booking_id: sb.id, deleted_at: nil).count).to eq(2)
+    end
+  end
+
+  context "idempotence" do
+    it "un second passage après APPLY ne convertit plus rien" do
+      sb = build_space_booking(price_cents: 3_000)
+      reserve(sb, bois, d1)
+      reserve(sb, bois, d2)
+
+      run_task(apply: true)
+
+      output = nil
+      expect { output = run_task(apply: true) }.not_to change(CampingBooking, :count)
+      expect(output).to match(/Convertis en camping \(tente\)\s+:\s+0/)
+    end
+  end
+end


### PR DESCRIPTION
## Décision Michael

Les réservations d'espace « Bois » / « Pâture ouest » / « Pâture est » sont en réalité des réservations de **tentes** — à convertir en CampingBooking `kind: tente`, le nombre de personnes dérivé du prix (7,50 €/pers/nuit).

## La task (`bookings:convert_tent_spaces_to_camping`)

- Espaces résolus par code/nom (regex, jamais d'id) ; SpaceBookings dont TOUTES les réservations vivantes sont sur ces espaces.
- `people = price_cents / (nuits × 750)` — division exacte exigée : reste ≠ 0 ou people = 0 → **`skipped_price_ambiguous`** avec détail, non converti (arbitrage manuel).
- Prix conservé (totaux invariants, assertion + rollback sinon), StayItem sur le même séjour, SpaceBooking soft-deleté, réservations retirées.
- Dry-run par défaut / APPLY=1, idempotente, rapport ventilé.

## Vérifications

- 5 specs (conversion 30 €/2 nuits → 2 pers, ambigu 20 €/2 nuits rapporté, mixte intact, dry-run sans écriture, idempotence).
- Suite complète sur la branche : **873 examples, 0 failures**.
- Dry-run sur la copie prod locale posté après merge.

Note : la branche initiale `feat/tent-spaces-to-camping` a été polluée par une collision de checkout partagé (supprimée) — celle-ci est propre : un commit, 2 fichiers.