### PR TITLE
feat(payments): facturation des espaces → Payments du séjour (backfill + affichage)

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -29,6 +29,12 @@ class Payment < ApplicationRecord
   # et sont rattrapées par `rake payments:backfill_stay_from_booking`.
   belongs_to :stay
 
+  # Provenance de facturation des espaces (facturation espaces → paiements).
+  # Optionnel : seuls les Payment issus de la rake `space_bookings:billing_to_payments`
+  # le portent. Sert de trace d'audit ET de clé d'idempotence de cette rake
+  # (un seul Payment `paid` + un seul Payment `pending` par SpaceBooking).
+  belongs_to :space_booking, optional: true
+
   monetize :amount_cents, allow_nil: false
 
   # Table de versions dédiée : la PK de Payment est un UUID, incompatible avec

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -108,6 +108,29 @@ div id="stay-details-#{@stay.id}"
 
     = render "stays/activities"
 
+    / Paiements du séjour (facturation espaces → paiements, epic #26 / #55).
+    / Liste TOUS les paiements du séjour — encaissés ET en attente — avec montant,
+    / moyen, statut (badge) et date. `@stay.payments` unit le lien direct
+    / `stay_id` (espaces, Stripe, saisie manuelle) et le canal booking historique.
+    - stay_payments = @stay.payments.order(:created_at)
+    .border-t.border-gray-200.pt-4
+      h4.text-sm.font-medium.text-gray-700.mb-2 Paiements
+      - if stay_payments.any?
+        ul.divide-y.divide-gray-100
+          - stay_payments.each do |payment|
+            - p = payment.decorate
+            li.py-2.text-sm.flex.items-center.justify-between.gap-3
+              .flex.items-center.gap-2.min-w-0
+                span.text-lg.shrink-0 = p.payment_method_emoji
+                .min-w-0
+                  .text-gray-900.font-medium = p.amount
+                  .text-gray-500 = p.payment_method
+              .flex.items-center.gap-3.shrink-0
+                = p.status
+                span.text-gray-500 = p.created_at
+      - else
+        p.text-sm.text-gray-500 Aucun paiement enregistré pour ce séjour.
+
     / Notes du séjour (lecture). La note interne (texte brut, style post-it) ne
     / fuite JAMAIS côté client ; la note publique (ActionText) est celle vue par
     / le client sur /sejour/:token.

--- a/db/migrate/20260720190000_add_space_booking_to_payments.rb
+++ b/db/migrate/20260720190000_add_space_booking_to_payments.rb
@@ -1,0 +1,22 @@
+class AddSpaceBookingToPayments < ActiveRecord::Migration[7.0]
+  # Provenance de facturation des espaces (facturation espaces → paiements).
+  #
+  # Un SpaceBooking porte son moyen et son statut de paiement dans ses colonnes
+  # (`payment_method`, `payment_status`, `paid_amount_cents`, …) — mais AUCUN
+  # Payment. La rake `space_bookings:billing_to_payments` transforme ces données
+  # en Payment rattachés au Stay. Cette colonne enregistre le SpaceBooking
+  # d'origine du Payment ; elle joue deux rôles :
+  #
+  #   1. TRACE D'AUDIT — d'où vient ce paiement (quel SpaceBooking l'a généré).
+  #   2. CLÉ D'IDEMPOTENCE de la rake — on ne recrée pas un Payment pour un
+  #      (space_booking_id, status) déjà présent (voir la rake).
+  #
+  # Nullable : l'immense majorité des Payment (hébergement, Stripe, saisie
+  # manuelle) n'en portent pas. Additive et réversible — dans l'esprit de
+  # `AddStayToPayments` (issue #26). Aucune modification des colonnes existantes.
+  def change
+    add_column :payments, :space_booking_id, :bigint
+    add_index :payments, :space_booking_id
+    add_foreign_key :payments, :space_bookings, column: :space_booking_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_20_184658) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_20_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -470,8 +470,10 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_184658) do
     t.string "stripe_checkout_session_id"
     t.string "stripe_payment_intent_id"
     t.bigint "stay_id"
+    t.bigint "space_booking_id"
     t.index ["booking_id"], name: "index_payments_on_booking_id"
     t.index ["id"], name: "index_payments_on_id", unique: true
+    t.index ["space_booking_id"], name: "index_payments_on_space_booking_id"
     t.index ["stay_id"], name: "index_payments_on_stay_id"
   end
 
@@ -784,6 +786,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_184658) do
   add_foreign_key "lodging_rooms", "rooms"
   add_foreign_key "meal_orders", "stays"
   add_foreign_key "payments", "bookings"
+  add_foreign_key "payments", "space_bookings"
   add_foreign_key "payments", "stays"
   add_foreign_key "projects", "humans"
   add_foreign_key "reservations", "bookings"

--- a/lib/tasks/space_billing.rake
+++ b/lib/tasks/space_billing.rake
@@ -1,0 +1,212 @@
+namespace :space_bookings do
+  # One-shot idempotente : transforme les DONNÉES DE FACTURATION portées par les
+  # SpaceBooking (colonnes `*_amount_cents`, `payment_method`, `payment_status`)
+  # en Payment rattachés au Stay du séjour. Objectif : retrouver sur la fiche
+  # séjour TOUS les paiements (effectués ET en attente) d'un séjour « espaces ».
+  #
+  # DRY-RUN par défaut (rapport seul, ZÉRO écriture) ; APPLY=1 pour appliquer.
+  # Même esprit que `bookings:convert_parking_to_van` : transaction PAR
+  # SpaceBooking avec `requires_new: true` (savepoint) — indispensable pour que le
+  # DRY-RUN annule RÉELLEMENT ses écritures même imbriqué dans les fixtures
+  # transactionnelles des specs.
+  #
+  #   bundle exec rake space_bookings:billing_to_payments          # DRY-RUN
+  #   APPLY=1 bundle exec rake space_bookings:billing_to_payments  # RÉEL
+  #
+  # ─── SÉMANTIQUE des champs de facturation d'un SpaceBooking (vérifiée sur la
+  #     page publique `/espaces/:token` + locales `public.space_bookings.*`) ───
+  #
+  #   • price_cents          : montant TOTAL dû pour la réservation d'espace.
+  #                            (« Montant » ; 0 ⇒ « Offert »).
+  #   • paid_amount_cents    : montant RÉELLEMENT REÇU à ce jour (« Nous avons
+  #                            reçu un paiement pour un montant de X »).
+  #   • payment_status       : "paid" (reçu en intégralité) / "partially_paid" /
+  #                            (pending/nil = rien reçu).
+  #   • advance_amount_cents : ACOMPTE DEMANDÉ (« Merci de régler votre acompte de
+  #                            X ») — une CONSIGNE de paiement, PAS un encaissement
+  #                            ni le total dû. Volontairement NON utilisé comme
+  #                            montant du Payment pending : le vrai « attendu non
+  #                            encaissé » est le SOLDE (price − reçu), sinon on
+  #                            sous-estimerait la dette du séjour.
+  #   • deposit_amount_cents : CAUTION (« Votre caution: X ») — dépôt de garantie
+  #                            remboursable. Ce N'EST PAS un paiement de séjour :
+  #                            on ne crée RIEN, on le liste seulement (info).
+  #
+  # ─── RÈGLES de transformation ───
+  #
+  #   received = payment_status == "paid" ? (price>0 ? price : paid_amount)
+  #                                       : paid_amount
+  #   outstanding = price − received   (solde exigible restant)
+  #
+  #   1. received > 0                → Payment `paid` de `received` (fait historique,
+  #                                    quel que soit le statut du SpaceBooking).
+  #   2. outstanding > 0 ET price > 0 → Payment `pending` de `outstanding`, SEULEMENT
+  #      ET statut vivant                si le SpaceBooking est `confirmed` ou
+  #      (confirmed/pending)             `pending` (jamais declined/canceled : pas
+  #                                      d'attente sur un séjour mort → skipped).
+  #   3. caution                     → rien ; listée en info.
+  #
+  #   Moyen de paiement : le vocabulaire de `SpaceBooking.payment_method` et de
+  #   `Payment.payment_method` est le MÊME (cash, bank_transfer, airbnb,
+  #   bookingdotcom — cf. `stays/_form` et `payments/_form`). Le mapping est donc
+  #   l'IDENTITÉ, bornée à l'ensemble connu. Valeur vide/inconnue ⇒ on ne crée
+  #   rien (Payment exige `payment_method`) et on rapporte `skipped_unknown_method`.
+  #
+  #   Idempotence : chaque Payment créé porte `space_booking_id`. On saute la
+  #   création si un Payment VIVANT du même (space_booking_id, status) existe
+  #   déjà. Un re-run après APPLY ne crée donc rien de plus. La rake NE réconcilie
+  #   PAS un changement de montant ultérieur — c'est le rôle de la saisie « au fil
+  #   de l'eau » (chantier séparé) ; ici on ne fait que l'historique.
+  #
+  #   Aucun total de séjour n'est modifié ; on appelle `stay.set_payment_status`
+  #   après création pour recalculer le STATUT de paiement du séjour.
+
+  # Vocabulaire commun SpaceBooking.payment_method ↔ Payment.payment_method.
+  KNOWN_PAYMENT_METHODS = %w[cash bank_transfer airbnb bookingdotcom stripe card].freeze
+
+  desc "Transforme la facturation des SpaceBooking en Payment du séjour (paid + pending). DRY-RUN sauf APPLY=1"
+  task billing_to_payments: :environment do
+    apply = ENV["APPLY"] == "1"
+
+    report = {
+      scanned: [],                # SpaceBooking vivants rattachés à un Stay
+      created_paid: [],           # Payment paid créés (détail)
+      created_pending: [],        # Payment pending créés (détail)
+      skipped_already_paid: [],   # idempotence : paid déjà présent
+      skipped_already_pending: [],# idempotence : pending déjà présent
+      skipped_unknown_method: [], # argent en jeu mais moyen inconnu/absent
+      skipped_dead_status: [],    # solde dû mais SpaceBooking declined/canceled
+      skipped_no_billing: [],     # rattaché à un Stay mais aucun signal monétaire
+      deposits: [],               # cautions listées (JAMAIS transformées)
+      no_stay: 0,                  # SpaceBooking vivants sans Stay (hors périmètre)
+      failed: []                  # erreurs inattendues (détail)
+    }
+
+    SpaceBooking.find_each do |sb|
+      stay = sb.stay
+      if stay.nil?
+        report[:no_stay] += 1
+        next
+      end
+
+      report[:scanned] << sb.id
+
+      # Caution : info seule, indépendante de tout le reste. Jamais un paiement.
+      if sb.deposit_amount_cents.to_i.positive?
+        report[:deposits] << "SpaceBooking ##{sb.id} : caution #{euros(sb.deposit_amount_cents)} (non transformée)"
+      end
+
+      price     = sb.price_cents.to_i
+      received  = received_cents(sb)
+      outstanding = price - received
+      method    = KNOWN_PAYMENT_METHODS.include?(sb.payment_method) ? sb.payment_method : nil
+
+      # Aucun signal monétaire (rien reçu, aucun prix dû) → hors périmètre paiements.
+      if received <= 0 && price <= 0
+        report[:skipped_no_billing] << sb.id
+        next
+      end
+
+      # Moyen de paiement indispensable pour créer un Payment (validation modèle).
+      if method.nil?
+        report[:skipped_unknown_method] <<
+          "SpaceBooking ##{sb.id} : moyen=#{sb.payment_method.inspect} (reçu #{euros(received)}, dû #{euros(outstanding)})"
+        next
+      end
+
+      want_paid    = received.positive?
+      want_pending = outstanding.positive? && price.positive?
+
+      # Le pending n'a de sens que sur un séjour VIVANT (pas declined/canceled).
+      dead = sb.status == "declined" || sb.status == "canceled"
+      if want_pending && dead
+        report[:skipped_dead_status] << sb.id
+        want_pending = false
+      end
+
+      # Idempotence : ne pas recréer ce qui existe déjà (Payment vivant, même
+      # provenance + statut). Lecture de l'état committé, hors transaction.
+      if want_paid && Payment.exists?(space_booking_id: sb.id, status: "paid")
+        report[:skipped_already_paid] << sb.id
+        want_paid = false
+      end
+      if want_pending && Payment.exists?(space_booking_id: sb.id, status: "pending")
+        report[:skipped_already_pending] << sb.id
+        want_pending = false
+      end
+
+      next unless want_paid || want_pending
+
+      begin
+        # Savepoint PAR SpaceBooking : DRY-RUN = exécuter puis rollback (valide la
+        # création sans rien persister) ; APPLY = commit. `requires_new: true`
+        # garantit un rollback réel même sous fixtures transactionnelles.
+        ActiveRecord::Base.transaction(requires_new: true) do
+          if want_paid
+            Payment.create!(stay: stay, space_booking: sb, amount_cents: received,
+                            payment_method: method, status: "paid")
+          end
+          if want_pending
+            Payment.create!(stay: stay, space_booking: sb, amount_cents: outstanding,
+                            payment_method: method, status: "pending")
+          end
+
+          # Recalcule le STATUT de paiement du séjour (n'altère aucun total).
+          stay.set_payment_status
+
+          raise ActiveRecord::Rollback unless apply
+        end
+
+        report[:created_paid]    << "SpaceBooking ##{sb.id} → #{euros(received)} (#{method})" if want_paid
+        report[:created_pending] << "SpaceBooking ##{sb.id} → #{euros(outstanding)} (#{method})" if want_pending
+      rescue => e
+        report[:failed] << "SpaceBooking ##{sb.id} : #{e.class} #{e.message}"
+      end
+    end
+
+    print_space_billing_report(report, apply)
+    abort("ÉCHEC : #{report[:failed].size} SpaceBooking en erreur.") if report[:failed].any?
+  end
+end
+
+# Montant REÇU d'un SpaceBooking (voir en-tête pour la sémantique). Un séjour
+# marqué `paid` sans `paid_amount_cents` renseigné a bien reçu la TOTALITÉ (prix).
+def received_cents(sb)
+  if sb.payment_status == "paid"
+    price = sb.price_cents.to_i
+    price.positive? ? price : sb.paid_amount_cents.to_i
+  else
+    sb.paid_amount_cents.to_i
+  end
+end
+
+def euros(cents)
+  format("%.2f €", cents.to_i / 100.0)
+end
+
+def print_space_billing_report(report, apply)
+  puts "=== space_bookings:billing_to_payments #{apply ? '(RÉEL)' : '(DRY-RUN)'} ==="
+  puts "SpaceBooking scannés (avec séjour) : #{report[:scanned].size} #{space_billing_ids(report[:scanned])}"
+  puts "SpaceBooking sans séjour (hors périm.) : #{report[:no_stay]}"
+  puts "Payment PAID créés                : #{report[:created_paid].size}"
+  report[:created_paid].each { |l| puts "  + #{l}" }
+  puts "Payment PENDING créés             : #{report[:created_pending].size}"
+  report[:created_pending].each { |l| puts "  + #{l}" }
+  puts "Ignorés — paid déjà présent (idemp.) : #{report[:skipped_already_paid].size} #{space_billing_ids(report[:skipped_already_paid])}"
+  puts "Ignorés — pending déjà présent (idemp.) : #{report[:skipped_already_pending].size} #{space_billing_ids(report[:skipped_already_pending])}"
+  puts "Ignorés — moyen inconnu/absent    : #{report[:skipped_unknown_method].size}"
+  report[:skipped_unknown_method].each { |l| puts "  - #{l}" }
+  puts "Ignorés — solde dû mais séjour mort : #{report[:skipped_dead_status].size} #{space_billing_ids(report[:skipped_dead_status])}"
+  puts "Ignorés — aucun signal monétaire  : #{report[:skipped_no_billing].size} #{space_billing_ids(report[:skipped_no_billing])}"
+  puts "Cautions listées (NON transformées) : #{report[:deposits].size}"
+  report[:deposits].each { |l| puts "  · #{l}" }
+  unless report[:failed].empty?
+    puts "Échecs                            : #{report[:failed].size}"
+    report[:failed].each { |l| puts "  ! #{l}" }
+  end
+  puts(apply ? "OK — paiements créés." : "DRY-RUN — aucune écriture. Relancer avec APPLY=1 pour appliquer.")
+end
+
+def space_billing_ids(list)
+  list.empty? ? "" : "→ #{list.sort.join(', ')}"
+end

--- a/spec/requests/stays_show_payments_spec.rb
+++ b/spec/requests/stays_show_payments_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+# Fiche séjour (stays#show, partial `_details`) — section « Paiements ». Elle
+# liste TOUS les paiements du séjour, encaissés (`paid`) ET en attente
+# (`pending`), avec montant, moyen, statut (badge) et date. Alimentée par
+# `Stay#payments` (union du lien direct `stay_id` et du canal booking).
+RSpec.describe "Stays#show — section Paiements (epic #26 / #55)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin)    { User.create!(email: "staff-pay@les4sources.be", password: "password123") }
+  let(:customer) { Customer.create!(email: "pay@example.com", customer_type: "individual", first_name: "Ada", last_name: "Lovelace") }
+
+  let(:from) { Date.today + 30 }
+  let(:to)   { Date.today + 32 }
+
+  let(:stay) do
+    Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                 arrival_date: from, departure_date: to, total_amount_cents: 12_000)
+  end
+
+  before do
+    # Un paiement encaissé et un paiement en attente, rattachés directement au séjour.
+    Payment.create!(stay: stay, amount_cents: 5_000, payment_method: "cash", status: "paid")
+    Payment.create!(stay: stay, amount_cents: 7_000, payment_method: "bank_transfer", status: "pending")
+    sign_in admin
+    get stay_path(stay)
+  end
+
+  it "répond OK et affiche l'en-tête de la section Paiements" do
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Paiements")
+  end
+
+  it "affiche le paiement ENCAISSÉ (montant, moyen, badge Payé)" do
+    expect(response.body).to include("50,00") # 5 000 cents
+    expect(response.body).to include("Liquide")
+    expect(response.body).to include("Payé")
+  end
+
+  it "affiche le paiement EN ATTENTE (montant, moyen, badge En attente)" do
+    expect(response.body).to include("70,00") # 7 000 cents
+    expect(response.body).to include("Virement")
+    expect(response.body).to include("En attente")
+  end
+
+  context "séjour sans aucun paiement" do
+    let(:empty_stay) do
+      Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                   arrival_date: from, departure_date: to, total_amount_cents: 0)
+    end
+
+    it "affiche l'état vide de la section" do
+      get stay_path(empty_stay)
+      expect(response.body).to include("Aucun paiement enregistré pour ce séjour.")
+    end
+  end
+end

--- a/spec/tasks/space_billing_to_payments_spec.rb
+++ b/spec/tasks/space_billing_to_payments_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+require "rake"
+
+# Facturation des espaces → paiements (epic #26 / #55). La rake transforme les
+# données de facturation d'un SpaceBooking (colonnes `*_amount_cents`,
+# `payment_method`, `payment_status`) en Payment rattachés au Stay :
+#   - `paid`    du montant REÇU (paid_amount, ou prix si statut "paid") ;
+#   - `pending` du SOLDE restant dû (prix − reçu), sur séjour vivant seulement.
+# La caution (`deposit_amount_cents`) n'est JAMAIS transformée.
+RSpec.describe "space_bookings:billing_to_payments", type: :task do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("space_bookings:billing_to_payments")
+  end
+
+  def run_task(apply: false)
+    task = Rake::Task["space_bookings:billing_to_payments"]
+    task.reenable
+    previous_apply = ENV["APPLY"]
+    ENV["APPLY"] = apply ? "1" : nil
+    original = $stdout
+    buffer = StringIO.new
+    $stdout = buffer
+    task.invoke
+    buffer.string
+  ensure
+    $stdout = original
+    ENV["APPLY"] = previous_apply
+  end
+
+  let(:customer) do
+    Customer.create!(email: "billing@example.com", customer_type: "individual",
+                     first_name: "Ada", last_name: "Lovelace")
+  end
+
+  let(:from) { Date.today + 30 }
+  let(:to)   { Date.today + 31 }
+
+  # Crée un séjour + un SpaceBooking rattaché, avec les données de facturation
+  # voulues. Le total du séjour est aligné sur le prix de l'espace par défaut.
+  def build_stay_with_space(total_cents: nil, status: "confirmed", **sb_attrs)
+    price = sb_attrs[:price_cents].to_i
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: from, departure_date: to,
+                        total_amount_cents: total_cents || price)
+    sb = SpaceBooking.create!({
+      firstname: "Ada", group_name: "Les Analytiques",
+      from_date: from, to_date: to, status: status
+    }.merge(sb_attrs))
+    stay.stay_items.create!(bookable: sb)
+    [stay, sb]
+  end
+
+  context "DRY-RUN (par défaut)" do
+    it "n'écrit aucun Payment" do
+      build_stay_with_space(price_cents: 12_000, paid_amount_cents: 5_000,
+                            payment_method: "cash", payment_status: "partially_paid")
+
+      expect { run_task(apply: false) }.not_to change(Payment, :count)
+    end
+  end
+
+  context "APPLY — paiement partiel (partially_paid)" do
+    it "crée un Payment paid du reçu ET un Payment pending du solde" do
+      stay, sb = build_stay_with_space(price_cents: 12_000, paid_amount_cents: 5_000,
+                                       payment_method: "cash", payment_status: "partially_paid")
+
+      expect { run_task(apply: true) }.to change(Payment, :count).by(2)
+
+      paid = Payment.find_by(space_booking_id: sb.id, status: "paid")
+      pending = Payment.find_by(space_booking_id: sb.id, status: "pending")
+
+      expect(paid.amount_cents).to eq(5_000)
+      expect(paid.payment_method).to eq("cash")
+      expect(paid.stay).to eq(stay)
+
+      expect(pending.amount_cents).to eq(7_000) # 12 000 − 5 000
+      expect(pending.payment_method).to eq("cash")
+      expect(pending.stay).to eq(stay)
+
+      # Le statut de paiement du séjour est recalculé (encaissé partiel).
+      expect(stay.reload.payment_status).to eq("partially_paid")
+      # Aucun total de séjour modifié.
+      expect(stay.total_amount_cents).to eq(12_000)
+    end
+  end
+
+  context "APPLY — payé en intégralité (paid) sans paid_amount renseigné" do
+    it "crée un Payment paid du PRIX total, aucun pending, séjour soldé" do
+      stay, sb = build_stay_with_space(price_cents: 12_000, paid_amount_cents: nil,
+                                       payment_method: "bank_transfer", payment_status: "paid")
+
+      expect { run_task(apply: true) }.to change(Payment, :count).by(1)
+
+      paid = Payment.find_by(space_booking_id: sb.id, status: "paid")
+      expect(paid.amount_cents).to eq(12_000)
+      expect(paid.payment_method).to eq("bank_transfer")
+      expect(Payment.exists?(space_booking_id: sb.id, status: "pending")).to be(false)
+      expect(stay.reload.payment_status).to eq("paid")
+    end
+  end
+
+  context "mapping du moyen de paiement" do
+    it "conserve un moyen connu (bookingdotcom) à l'identique" do
+      _stay, sb = build_stay_with_space(price_cents: 8_000, paid_amount_cents: 8_000,
+                                        payment_method: "bookingdotcom", payment_status: "paid")
+
+      run_task(apply: true)
+
+      expect(Payment.find_by(space_booking_id: sb.id, status: "paid").payment_method).to eq("bookingdotcom")
+    end
+
+    it "ne crée rien et rapporte skipped_unknown_method pour un moyen inconnu" do
+      _stay, sb = build_stay_with_space(price_cents: 8_000, paid_amount_cents: 8_000,
+                                        payment_method: "paypal", payment_status: "paid")
+
+      output = nil
+      expect { output = run_task(apply: true) }.not_to change(Payment, :count)
+      expect(output).to match(/moyen inconnu.*1/m)
+      expect(output).to match(/SpaceBooking ##{sb.id}.*"paypal"/)
+    end
+  end
+
+  context "caution (deposit)" do
+    it "ne transforme JAMAIS la caution en paiement, mais la liste" do
+      _stay, sb = build_stay_with_space(total_cents: 0, price_cents: 0,
+                                        deposit_amount_cents: 30_000,
+                                        payment_method: "bank_transfer", payment_status: "pending")
+
+      output = nil
+      expect { output = run_task(apply: true) }.not_to change(Payment, :count)
+      expect(output).to match(/Cautions listées.*1/)
+      expect(output).to match(/SpaceBooking ##{sb.id} : caution 300\.00 €/)
+    end
+  end
+
+  context "séjour mort (declined/canceled) avec solde dû" do
+    it "ne crée pas de pending et le rapporte en skipped_dead_status" do
+      _stay, sb = build_stay_with_space(price_cents: 12_000, paid_amount_cents: 0,
+                                        payment_method: "cash", payment_status: "pending",
+                                        status: "canceled")
+
+      output = nil
+      expect { output = run_task(apply: true) }.not_to change(Payment, :count)
+      expect(output).to match(/séjour mort.*#{sb.id}/)
+    end
+  end
+
+  context "idempotence" do
+    it "un second passage APPLY ne crée aucun Payment supplémentaire" do
+      build_stay_with_space(price_cents: 12_000, paid_amount_cents: 5_000,
+                            payment_method: "cash", payment_status: "partially_paid")
+
+      run_task(apply: true)
+
+      output = nil
+      expect { output = run_task(apply: true) }.not_to change(Payment, :count)
+      expect(output).to match(/Payment PAID créés\s+:\s+0/)
+      expect(output).to match(/Payment PENDING créés\s+:\s+0/)
+    end
+  end
+end


### PR DESCRIPTION
## Demande Michael

Un SpaceBooking porte moyen et statut de paiement — à transformer en Payment(s) du séjour ; la fiche séjour doit montrer tous les paiements effectués et en attente.

## Sémantique découverte (vérifiée sur la page publique + locales)

`price_cents` = total dû · `paid_amount_cents` = reçu · `advance_amount_cents` = acompte DEMANDÉ (consigne, pas un encaissement — volontairement non utilisé pour le pending, qui vaut le solde `price − reçu`) · `deposit_amount_cents` = caution (jamais transformée, listée au rapport).

## Livré

- **Rake `space_bookings:billing_to_payments`** (dry-run / APPLY=1, idempotente) : Payment `paid` du reçu + Payment `pending` du solde (séjours vivants uniquement) ; mapping payment_method identité borné (vocabulaires identiques), inconnu → skipped.
- **Idempotence + audit** : nouvelle colonne `payments.space_booking_id` (migration, nullable + FK) — clé d'idempotence et provenance ; préparera la synchronisation « au fil de l'eau » (chantier suivant).
- **Fiche séjour** : section « Paiements » (montant, moyen, badge statut, date).

## Dry-run sur la copie prod (0 échec)

**166 paid + 30 pending** seraient créés · **2 à corriger avant APPLY** (#82 : 930 € reçus sans moyen ; #686 : 1230 € dus sans moyen) · 22 séjours morts avec solde → pas de pending (voulu ?) · 7 cautions listées non transformées · 362 sans signal monétaire ignorés · quelques 0,01 € placeholder à vérifier.

## Vérifications

Suite complète sur la branche : **877 examples, 0 failures** (12 nouveaux).