### PR TITLE
feat(humans): gestion des rôles activable, statut membre, blocage inactifs, accès restreint porteurs

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -4,9 +4,21 @@ class BaseController < ActionController::Base
   layout "application"
 
   before_action :authenticate_user!
+  before_action :enforce_active_member
+  before_action :restrict_experience_carriers
   before_action :set_paper_trail_whodunnit
 
   helper_method :current_human
+
+  # Contrôleurs/actions accessibles à un utilisateur « restreint à ses
+  # activités » (porteur cloisonné). Tout le reste de l'app le renvoie vers son
+  # planning d'activités. La déconnexion (Devise::SessionsController) n'hérite
+  # PAS de BaseController, elle reste donc toujours disponible.
+  RESTRICTED_ALLOWLIST = {
+    "experiences" => %w[index show],
+    "experience_availabilities" => %w[create destroy],
+    "experience_bookings" => %w[index update confirm new_refusal refuse]
+  }.freeze
 
   # breadcrumb "Calendrier", :root_path
 
@@ -16,6 +28,28 @@ class BaseController < ActionController::Base
   end
 
   private
+
+  # Coupe la session d'un compte dont le membre d'équipe a été désactivé — même
+  # si la session était déjà ouverte avant la désactivation. Le refus au moment
+  # du sign-in est géré par `User#active_for_authentication?`.
+  def enforce_active_member
+    return unless current_user&.member_deactivated?
+
+    sign_out(current_user)
+    redirect_to new_user_session_path,
+                alert: I18n.t("devise.failure.account_deactivated")
+  end
+
+  # Cloisonne un utilisateur « restreint » sur son planning d'activités : toute
+  # page hors allowlist le renvoie vers la liste de SES activités.
+  def restrict_experience_carriers
+    return unless current_user&.restricted_to_experiences?
+
+    allowed = RESTRICTED_ALLOWLIST[controller_name]&.include?(action_name)
+    return if allowed
+
+    redirect_to experiences_path
+  end
 
   # Identifie l'humain (porteur d'activité, membre de l'équipe…) lié à
   # l'utilisateur connecté. Centralisé ici pour rester cohérent partout —

--- a/app/controllers/experience_availabilities_controller.rb
+++ b/app/controllers/experience_availabilities_controller.rb
@@ -37,6 +37,13 @@ class ExperienceAvailabilitiesController < ApplicationController
 
   def set_experience
     @experience = Experience.find(params[:experience_id])
+    # Ce contrôleur n'hérite pas de BaseController : on applique ici le même
+    # cloisonnement qu'ailleurs pour un porteur restreint (il ne pose/retire de
+    # créneaux que sur SES propres activités).
+    if current_user&.restricted_to_experiences? &&
+       @experience.human_id != current_user.human_id
+      redirect_to experiences_path and return
+    end
   end
 
   # Grille du mois que le porteur regardait (pas le mois courant) : sans ça,

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -4,14 +4,21 @@ class ExperiencesController < BaseController
   breadcrumb "Activités", :experiences_path, match: :exact
 
   def index
-    # Calendrier global MENSUEL des créneaux, toutes activités confondues
-    # (2026-07-20) — `?month=YYYY-MM` navigue.
-    @global_calendar = Experiences::GlobalMonthCalendar.new(month: params[:month])
+    # Un porteur restreint ne voit QUE ses propres activités (son planning) ;
+    # l'admin global voit tout (comportement inchangé).
+    scope = restricted_human_id ? Experience.where(human_id: restricted_human_id) : Experience.all
+    # Calendrier global MENSUEL des créneaux — borné aux activités du porteur
+    # restreint le cas échéant (`?month=YYYY-MM` navigue).
+    @global_calendar = Experiences::GlobalMonthCalendar.new(
+      month: params[:month],
+      human_id: restricted_human_id
+    )
     @experiences = ExperienceDecorator
-      .decorate_collection(Experience.all.order(name: :asc))
+      .decorate_collection(scope.order(name: :asc))
     # Créneaux FUTURS par activité (une requête pour toute la liste).
     @future_slot_counts = ExperienceAvailability
       .where("available_on >= ?", Date.today)
+      .where(experience_id: scope.select(:id))
       .group(:experience_id)
       .count
   end
@@ -75,8 +82,19 @@ class ExperiencesController < BaseController
 
   private
 
+  # `human_id` de cloisonnement quand le porteur est restreint à ses activités,
+  # sinon `nil` (pas de restriction). Fail-closed : un porteur restreint sans
+  # `human_id` ne verra aucune activité plutôt que toutes.
+  def restricted_human_id
+    current_user&.restricted_to_experiences? ? current_user.human_id : nil
+  end
+
   def get_experience
     @experience = Experience.find(params[:id])
+    # Un porteur restreint ne peut consulter qu'une de SES activités.
+    if restricted_human_id && @experience.human_id != restricted_human_id
+      redirect_to experiences_path
+    end
   end
 
   def set_presenters

--- a/app/controllers/organisation_controller.rb
+++ b/app/controllers/organisation_controller.rb
@@ -4,7 +4,7 @@ class OrganisationController < BaseController
   breadcrumb "Organisation", :organisation_path, match: :exact
 
   def index
-    humans = Human.cycle_active.order(:name).to_a
+    humans = Human.cycle_active.roles_enabled.order(:name).to_a
     @current_cycle = Cycle.covering_date(Date.today).first
     @cycles = Cycle.chronological
 
@@ -71,7 +71,7 @@ class OrganisationController < BaseController
     @total_hours = @human.cycle_actions.not_archived.active.where.not(category: :reportee).sum(:hours) || 0
     @current_cycle = Cycle.covering_date(Date.today).first
     @archives_count = @human.cycle_actions.archived.count
-    @cycle_active_humans = Human.cycle_active.where.not(id: @human.id).order(:name)
+    @cycle_active_humans = Human.cycle_active.roles_enabled.where.not(id: @human.id).order(:name)
     @gathering_actions = @human.gathering_actions
                                 .includes(:gathering)
                                 .order(:completed, created_at: :desc)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -71,7 +71,9 @@ class PagesController < BaseController
         .where(date: @date, space_booking: { status: "confirmed" })
     )
     @roles = Role.all
-    @humans = Human.all
+    # Écran d'assignation des rôles (veilleur, nourrissage…) : on n'y liste que
+    # les membres dont la gestion des rôles est activée.
+    @humans = Human.roles_enabled
     @human_roles = HumanRole.where(date: @date)
     @lodgings = LodgingDecorator.decorate_collection(Lodging.all)
     render layout: !turbo_frame_request?
@@ -119,8 +121,9 @@ class PagesController < BaseController
       .count
 
     # Créer la liste avec tous les humains actifs (même ceux avec 0 veilles)
-    # Le default_scope de Human filtre déjà par status: 'active'
-    all_active_humans = Human.all.pluck(:id, :name).to_h
+    # Le default_scope de Human filtre déjà par status: 'active' ; on restreint
+    # en plus aux membres dont la gestion des rôles est activée.
+    all_active_humans = Human.roles_enabled.pluck(:id, :name).to_h
     @watchman_stats = all_active_humans.map do |human_id, human_name|
       {
         human: Human.find(human_id),

--- a/app/models/human.rb
+++ b/app/models/human.rb
@@ -27,6 +27,10 @@ class Human < ApplicationRecord
   has_many :carried_agenda_items, class_name: "AgendaItem", foreign_key: :carrier_id, dependent: :nullify
 
   scope :cycle_active, -> { where(cycle_active: true) }
+  # Membres pour lesquels la gestion des rôles (veilleur, nourrissage…) est
+  # activée. Un membre avec `roles_enabled: false` reste dans l'équipe mais
+  # n'apparaît plus dans les écrans d'assignation de rôles.
+  scope :roles_enabled, -> { where(roles_enabled: true) }
   # Personnes pouvant recevoir un compte d'accès (un email est requis pour
   # créer le User Devise). Cf. epic #25 — Phase 2 (comptes porteurs).
   scope :with_email, -> { where.not(email: [nil, ""]) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,4 +36,32 @@ class User < ApplicationRecord
   def global_admin?
     human_id.blank?
   end
+
+  # Membre d'équipe (Human) lié, sans le `default_scope` de Human (qui masque les
+  # membres inactifs / soft-deleted) : indispensable pour détecter qu'un compte
+  # est rattaché à un membre désactivé — l'association `user.human` renverrait
+  # `nil` dans ce cas et laisserait passer la connexion.
+  def linked_human
+    return nil if human_id.blank?
+
+    @linked_human ||= Human.unscoped.find_by(id: human_id)
+  end
+
+  # Un compte rattaché à un membre d'équipe INACTIF (statut ≠ "active") ne peut
+  # plus se connecter, même si le User Devise est par ailleurs valide. Les
+  # comptes purement admin (sans `human`) ne sont jamais concernés.
+  def member_deactivated?
+    h = linked_human
+    h.present? && h.status != "active"
+  end
+
+  # Hook Devise : refuse l'authentification d'un compte dont le membre est
+  # désactivé (contrôlé aussi à chaque requête via BaseController).
+  def active_for_authentication?
+    super && !member_deactivated?
+  end
+
+  def inactive_message
+    member_deactivated? ? :account_deactivated : super
+  end
 end

--- a/app/services/experiences/global_month_calendar.rb
+++ b/app/services/experiences/global_month_calendar.rb
@@ -6,7 +6,8 @@ module Experiences
   class GlobalMonthCalendar
     attr_reader :month
 
-    def initialize(month: nil)
+    def initialize(month: nil, human_id: nil)
+      @human_id = human_id
       base = case month
              when Date then month
              when /\A\d{4}-\d{2}\z/ then (Date.parse("#{month}-01") rescue Date.today)
@@ -31,8 +32,13 @@ module Experiences
     # activités qui ont au moins un créneau dans le mois affiché.
     def rows
       @rows ||= begin
-        counts = ExperienceAvailability
-                 .where(available_on: days.first..days.last)
+        availabilities = ExperienceAvailability.where(available_on: days.first..days.last)
+        # Cloisonnement porteur restreint : ne compter que ses propres activités.
+        if @human_id
+          availabilities = availabilities.joins(:experience)
+                                         .where(experiences: { human_id: @human_id })
+        end
+        counts = availabilities
                  .group(:experience_id, :available_on)
                  .count
         by_experience = {}

--- a/app/services/humans/create_service.rb
+++ b/app/services/humans/create_service.rb
@@ -34,7 +34,9 @@ module Humans
           :summary,
           :description,
           :photo,
-          :photo_cache
+          :photo_cache,
+          :roles_enabled,
+          :status
         )
     end
   end

--- a/app/services/humans/update_service.rb
+++ b/app/services/humans/update_service.rb
@@ -20,8 +20,21 @@ module Humans
     end
 
     def run!(params = {})
-      human.attributes = human_params(params)
+      attrs = human_params(params)
+      # `restricted_to_experiences` appartient au compte User lié, pas au Human :
+      # on l'extrait avant l'assignation des attributs du Human.
+      restricted = attrs.key?(:restricted_to_experiences) ? attrs.delete(:restricted_to_experiences) : nil
+
+      human.attributes = attrs
       human.save!
+
+      unless restricted.nil?
+        user = human.user
+        user&.update!(
+          restricted_to_experiences: ActiveModel::Type::Boolean.new.cast(restricted)
+        )
+      end
+
       true
     end
 
@@ -37,7 +50,10 @@ module Humans
           :description,
           :photo,
           :photo_cache,
-          :cycle_active
+          :cycle_active,
+          :roles_enabled,
+          :status,
+          :restricted_to_experiences
         )
     end
   end

--- a/app/views/humans/_form.html.slim
+++ b/app/views/humans/_form.html.slim
@@ -26,8 +26,43 @@
                        hint: "Un fichier au format JPG, PNG ou GIF"
         = f.hidden_field :photo_cache
 
-    = f.label :description, 
+    = f.label :description,
               "Présentation complète"
     = f.rich_text_area :description
 
 hr
+
+.border-l-8.border-indigo-700.-ml-4.pl-4.md:p-0.md:m-0.md:border-0.grid.grid-cols-1.md:grid-cols-3.md:gap-4
+  .md:border-r-8.md:border-indigo-700.md:pr-4.md:text-right
+    = section_heading_tw heading: "Accès & rôles"
+
+  .col-span-2.mb-4.space-y-6.sm:space-y-5
+    / Statut du membre — un membre inactif reste dans l'équipe mais ne peut plus
+    / se connecter (même si son compte existe).
+    .space-y-1
+      = f.hidden_field :status, value: "inactive"
+      label class="inline-flex items-center gap-3 cursor-pointer"
+        input type="checkbox" name="human[status]" value="active" checked=(@human.status == "active") role="switch" aria-label="Membre actif" class="sr-only peer"
+        span.ui-switch aria-hidden="true"
+        span.ui-switch-label-off class="text-sm font-medium text-gray-500" Membre inactif
+        span.ui-switch-label-on class="text-sm font-medium text-emerald-700" Membre actif
+
+    / Gestion des rôles — quand elle est désactivée, le membre n'apparaît plus
+    / dans les écrans d'assignation de rôles (veilleur, nourrissage…).
+    .space-y-1
+      = f.hidden_field :roles_enabled, value: "0"
+      label class="inline-flex items-center gap-3 cursor-pointer"
+        input type="checkbox" name="human[roles_enabled]" value="1" checked=f.object.roles_enabled role="switch" aria-label="Gestion des rôles" class="sr-only peer"
+        span.ui-switch aria-hidden="true"
+        span.ui-switch-label-off class="text-sm font-medium text-gray-500" Rôles désactivés
+        span.ui-switch-label-on class="text-sm font-medium text-emerald-700" Gestion des rôles
+
+    - if @human.user
+      / Accès restreint — l'utilisateur ne voit QUE son planning d'activités.
+      .space-y-1
+        input type="hidden" name="human[restricted_to_experiences]" value="0"
+        label class="inline-flex items-center gap-3 cursor-pointer"
+          input type="checkbox" name="human[restricted_to_experiences]" value="1" checked=@human.user.restricted_to_experiences? role="switch" aria-label="Accès restreint aux activités" class="sr-only peer"
+          span.ui-switch aria-hidden="true"
+          span.ui-switch-label-off class="text-sm font-medium text-gray-500" Accès complet
+          span.ui-switch-label-on class="text-sm font-medium text-emerald-700" Restreint à ses activités

--- a/app/views/layouts/components/_navbar.html.slim
+++ b/app/views/layouts/components/_navbar.html.slim
@@ -230,7 +230,7 @@ nav.bg-white.shadow-sm.lg:px-6
             = link_to "Cycles",
                       cycles_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'cycles' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
-          - Human.cycle_active.each do |human|
+          - Human.cycle_active.roles_enabled.each do |human|
             li
               = link_to human.name,
                         organisation_member_path(human.id),

--- a/app/views/roles/_form.html.slim
+++ b/app/views/roles/_form.html.slim
@@ -11,8 +11,8 @@
     .space-y-2
       = f.label :role_team,
                 "Ce rôle est assignable à"
-      = f.collection_check_boxes :role_team, 
-                                 Human.all.order(:name),
+      = f.collection_check_boxes :role_team,
+                                 Human.roles_enabled.order(:name),
                                  :id, :name do |cb|
         .relative.flex.items-start
           .flex.h-5.items-center

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,6 +7,7 @@ en:
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
+      account_deactivated: "Your account has been deactivated. Please contact an administrator."
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys} or password."

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -35,6 +35,7 @@ fr:
       send_instructions: Vous allez recevoir sous quelques minutes un email comportant des instructions pour confirmer votre compte.
       send_paranoid_instructions: Si votre email existe sur notre base de données, vous recevrez sous quelques minutes un message avec des instructions pour confirmer votre compte.
     failure:
+      account_deactivated: Votre compte a été désactivé. Contactez un administrateur.
       already_authenticated: Vous êtes déjà connecté(e).
       inactive: Votre compte n’est pas encore activé.
       invalid: "%{authentication_keys} ou mot de passe incorrect."

--- a/db/migrate/20260720200000_add_roles_enabled_to_humans.rb
+++ b/db/migrate/20260720200000_add_roles_enabled_to_humans.rb
@@ -1,0 +1,5 @@
+class AddRolesEnabledToHumans < ActiveRecord::Migration[7.0]
+  def change
+    add_column :humans, :roles_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260720200100_add_restricted_to_experiences_to_users.rb
+++ b/db/migrate/20260720200100_add_restricted_to_experiences_to_users.rb
@@ -1,0 +1,5 @@
+class AddRestrictedToExperiencesToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :restricted_to_experiences, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_20_190000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -384,6 +384,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_190000) do
     t.datetime "updated_at", null: false
     t.string "status", default: "active"
     t.boolean "cycle_active", default: false
+    t.boolean "roles_enabled", default: true, null: false
   end
 
   create_table "humans_tasks", id: false, force: :cascade do |t|
@@ -710,6 +711,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_190000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "human_id"
+    t.boolean "restricted_to_experiences", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["human_id"], name: "index_users_on_human_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/human_spec.rb
+++ b/spec/models/human_spec.rb
@@ -16,5 +16,21 @@
 require 'rails_helper'
 
 RSpec.describe Human, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "roles_enabled" do
+    it "vaut true par défaut (données existantes inchangées)" do
+      human = Human.create!(name: "Membre Par Défaut")
+      expect(human.roles_enabled).to be(true)
+    end
+
+    describe ".roles_enabled scope" do
+      it "ne renvoie que les membres dont la gestion des rôles est activée" do
+        with_roles    = Human.create!(name: "Avec Rôles", roles_enabled: true)
+        without_roles = Human.create!(name: "Sans Rôles", roles_enabled: false)
+
+        result = Human.roles_enabled
+        expect(result).to include(with_roles)
+        expect(result).not_to include(without_roles)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,5 +15,39 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "restricted_to_experiences" do
+    it "vaut false par défaut (comptes existants inchangés)" do
+      user = User.create!(email: "libre@example.com", password: "password123")
+      expect(user.restricted_to_experiences?).to be(false)
+    end
+  end
+
+  describe "blocage des comptes de membres désactivés" do
+    it "un compte admin (sans human) reste toujours actif" do
+      user = User.create!(email: "admin@example.com", password: "password123")
+      expect(user.member_deactivated?).to be(false)
+      expect(user.active_for_authentication?).to be(true)
+    end
+
+    it "un compte lié à un membre actif reste connectable" do
+      human = Human.create!(name: "Membre Actif", status: "active")
+      user = User.create!(email: "actif@example.com", password: "password123", human: human)
+      expect(user.member_deactivated?).to be(false)
+      expect(user.active_for_authentication?).to be(true)
+    end
+
+    it "un compte lié à un membre inactif ne peut plus s'authentifier" do
+      human = Human.create!(name: "Membre Inactif")
+      human.update_column(:status, "inactive")
+      user = User.create!(email: "inactif@example.com", password: "password123", human_id: human.id)
+
+      # `user.human` est masqué par le default_scope (status active) : on doit
+      # passer par linked_human (unscoped) pour détecter la désactivation.
+      expect(user.human).to be_nil
+      expect(user.linked_human).to eq(human)
+      expect(user.member_deactivated?).to be(true)
+      expect(user.active_for_authentication?).to be(false)
+      expect(user.inactive_message).to eq(:account_deactivated)
+    end
+  end
 end

--- a/spec/requests/deactivated_member_access_spec.rb
+++ b/spec/requests/deactivated_member_access_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+# Addendum 3/4 — un compte rattaché à un membre d'équipe désactivé
+# (`status: "inactive"`) ne peut plus accéder à l'app : même une session déjà
+# ouverte est coupée à la requête suivante (BaseController#enforce_active_member).
+RSpec.describe "Blocage d'accès des membres désactivés", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  it "coupe la session d'un compte dont le membre a été désactivé" do
+    human = Human.create!(name: "Membre Bientot Inactif", status: "active")
+    user = User.create!(email: "bientot-inactif@les4sources.be",
+                        password: "password123", human: human)
+    sign_in user
+
+    # Accès normal tant que le membre est actif.
+    get root_path
+    expect(response).to have_http_status(:ok)
+
+    # Désactivation du membre → la session est coupée à la requête suivante.
+    human.update_column(:status, "inactive")
+
+    get root_path
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  it "laisse passer un compte admin sans membre lié" do
+    admin = User.create!(email: "admin-libre@les4sources.be", password: "password123")
+    sign_in admin
+
+    get root_path
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/humans_roles_enabled_spec.rb
+++ b/spec/requests/humans_roles_enabled_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+# Feature 1 — « Gestion des rôles » par membre : un membre avec
+# `roles_enabled: false` reste dans l'équipe mais disparaît des écrans
+# d'assignation de rôles (veilleur, nourrissage…).
+RSpec.describe "Humans — gestion des rôles activable", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent-roles@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  describe "GET /roles/new (sélecteur de membres assignables à un rôle)" do
+    it "ne propose que les membres dont la gestion des rôles est activée" do
+      with_roles    = Human.create!(name: "Veilleur Assignable", roles_enabled: true)
+      without_roles = Human.create!(name: "Sans Gestion Roles", roles_enabled: false)
+
+      get new_role_path
+
+      expect(response).to have_http_status(:ok)
+      # On cible les cases à cocher du champ `role_team` : le layout
+      # (avatars/tooltips) affiche légitimement tous les membres ailleurs sur la
+      # page, donc on n'assertionne pas sur le nom brut.
+      team_checkbox = ->(human) { /type="checkbox"[^>]*value="#{human.id}"[^>]*name="role\[role_team\]\[\]"/ }
+      expect(response.body).to match(team_checkbox.call(with_roles))
+      expect(response.body).not_to match(team_checkbox.call(without_roles))
+    end
+  end
+
+  describe "édition d'un membre" do
+    it "permet de désactiver la gestion des rôles via le formulaire" do
+      human = Human.create!(name: "Membre A Restreindre", roles_enabled: true)
+
+      patch human_path(human), params: { human: { name: human.name, roles_enabled: "0" } }
+
+      expect(human.reload.roles_enabled).to be(false)
+    end
+
+    it "permet de désactiver le statut (membre inactif)" do
+      human = Human.create!(name: "Membre A Desactiver", status: "active")
+
+      patch human_path(human), params: { human: { name: human.name, status: "inactive" } }
+
+      expect(Human.unscoped.find(human.id).status).to eq("inactive")
+    end
+  end
+end

--- a/spec/requests/restricted_experience_carriers_spec.rb
+++ b/spec/requests/restricted_experience_carriers_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+# Feature 2 — accès restreint « porteur d'activités » : un utilisateur avec
+# `restricted_to_experiences: true` est cloisonné sur son planning d'activités
+# (liste de SES activités) et toute autre page le renvoie vers ce planning.
+RSpec.describe "Accès restreint aux porteurs d'activités", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:carrier_human) { Human.create!(name: "Porteur Restreint") }
+  let(:other_human)   { Human.create!(name: "Autre Porteur") }
+
+  let(:restricted_user) do
+    User.create!(email: "porteur@les4sources.be", password: "password123",
+                 human: carrier_human, restricted_to_experiences: true)
+  end
+  let(:admin_user) do
+    User.create!(email: "admin@les4sources.be", password: "password123")
+  end
+
+  let!(:own_experience)   { Experience.create!(name: "Balade du porteur", human: carrier_human) }
+  let!(:other_experience) { Experience.create!(name: "Atelier voisin", human: other_human) }
+
+  context "utilisateur restreint" do
+    before { sign_in restricted_user }
+
+    it "est redirigé depuis la racine vers son planning d'activités" do
+      get root_path
+      expect(response).to redirect_to(experiences_path)
+    end
+
+    it "est redirigé depuis /stays vers son planning" do
+      get stays_path
+      expect(response).to redirect_to(experiences_path)
+    end
+
+    it "est redirigé depuis /customers vers son planning" do
+      get customers_path
+      expect(response).to redirect_to(experiences_path)
+    end
+
+    it "accède à son planning d'activités et n'y voit que les siennes" do
+      get experiences_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Balade du porteur")
+      expect(response.body).not_to include("Atelier voisin")
+    end
+
+    it "accède à la fiche de SA propre activité" do
+      get experience_path(own_experience)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "est renvoyé vers son planning s'il cible l'activité d'un autre porteur" do
+      get experience_path(other_experience)
+      expect(response).to redirect_to(experiences_path)
+    end
+  end
+
+  context "utilisateur admin (non restreint) — comportement inchangé" do
+    before { sign_in admin_user }
+
+    it "accède normalement à la racine" do
+      get root_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "accède normalement à /stays" do
+      get stays_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "voit toutes les activités sur /experiences" do
+      get experiences_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Balade du porteur")
+      expect(response.body).to include("Atelier voisin")
+    end
+  end
+end


### PR DESCRIPTION
## Demandes Michael

1. Ajouter des membres d'équipe sans qu'ils soient assignables aux rôles (switch « Gestion des rôles » à la création).
2. Statut du membre éditable ; un membre inactif ne peut plus se connecter même si son User est actif.
3. Certains utilisateurs n'accèdent qu'au planning des activités dont ils sont porteurs.

## Livré

- `humans.roles_enabled` (défaut true) : switch au form, filtrage de TOUS les écrans d'assignation (day, month_details, organisation, navbar, roles). Données existantes inchangées.
- Statut membre : switch actif/inactif au form. **Blocage Devise** : `active_for_authentication?` refuse le sign-in d'un User lié à un Human non actif (message « compte désactivé », locales FR/EN) + coupure des sessions déjà ouvertes (`enforce_active_member`). Piège du `default_scope` de Human contourné (`Human.unscoped` via `linked_human`).
- `users.restricted_to_experiences` : porteur restreint → atterrit sur `/experiences` scopé à SES activités (réutilise la fondation `for_user` existante), allowlist stricte (activités, disponibilités, réservations d'activités, déconnexion), tout le reste redirige. Flag réglé depuis le form du membre (lien `Human has_one :user`). Le calendrier global mensuel est scopé aussi (pas de fuite des activités des autres).

## Vérifications

- Suite complète sur la branche : **927 examples, 0 failures, EXIT=0 prouvé** (20 nouveaux exemples : scopes, filtrage des écrans, sign-in refusé, session coupée, redirections du restreint, admin inchangé).
- Parcours réel porteur restreint + rendu des switches : passe navigateur à suivre.