### PR TITLE
feat(camping): persistance PAR NUIT du camping/van (plages contiguës) — funnel + admin

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -555,6 +555,12 @@ class StaysController < BaseController
       organization_name: contact[:organization_name],
       experiences:    activity_entries(p),
       halls:          space_entries(p),
+      # Grille camping/van par nuit (parité funnel, Michael 2026-07-20) : quand le
+      # form poste `stay[per_night_resources][tente|van][]`, le Draft en dérive
+      # `campings`/`vans` — même chemin que le funnel public. `campings:`/`vans:`
+      # ci-dessous ne servent plus que de REPLI (grille absente : emails legacy /
+      # form historique reconstruit sans dates).
+      per_night_resources: p[:per_night_resources],
       campings:       camping_entries(p),
       vans:           van_entries(p),
       meals:          meal_entries(p),

--- a/app/frontend/utils/setupStimulus.js
+++ b/app/frontend/utils/setupStimulus.js
@@ -34,6 +34,12 @@ import SpacesCalendarController from '../controllers/public/spaces_calendar_cont
 application.register('public--space-slot', SpaceSlotController);
 application.register('public--spaces-calendar', SpacesCalendarController);
 
+// Grille camping/van par nuit (Michael 2026-07-20) : le form Séjour admin
+// embarque la même grille steppers que le funnel. On enregistre le contrôleur
+// stepper public — MÊME fichier que le funnel, aucune copie de code.
+import StepperController from '../controllers/public/stepper_controller.js';
+application.register('public--stepper', StepperController);
+
 // Load and register view_components controllers
 registerControllers(
   application,

--- a/app/helpers/stays_composition_helper.rb
+++ b/app/helpers/stays_composition_helper.rb
@@ -27,6 +27,19 @@ module StaysCompositionHelper
     tag.span(safe_join(icons, " "), class: "inline-flex items-center gap-1")
   end
 
+  # Libellé de la ou des nuits couvertes par un réservable plein air (camping /
+  # van), fenêtre `[from, to)`. Sert à distinguer les PLAGES d'un même séjour
+  # quand le camping/van varie d'une nuit à l'autre (grille par nuit, Michael
+  # 2026-07-20) : « Nuit du 12 août » ou « Du 12 au 14 août ». nil si pas de dates.
+  def outdoor_nights_label(booking)
+    from = booking.try(:from_date)
+    to   = booking.try(:to_date)
+    return nil if from.blank? || to.blank?
+    last = to - 1
+    return "Nuit du #{l(from, format: :long)}" if last <= from
+    "Du #{l(from, format: :long)} au #{l(last, format: :long)}"
+  end
+
   private
 
   def composition_icon(emoji, label)

--- a/app/services/concerns/camping_composition.rb
+++ b/app/services/concerns/camping_composition.rb
@@ -80,19 +80,30 @@ module CampingComposition
 
   # Plages camping depuis la grille `per_night_resources["tente"]`.
   def camping_night_ranges(draft)
-    night_value_ranges(draft.per_night_resources&.[]("tente"), draft.arrival_date)
+    night_value_ranges(draft.per_night_resources&.[]("tente"), draft.arrival_date, max_nights: draft_window_nights(draft))
   end
 
   # Plages van depuis la grille `per_night_resources["van"]`.
   def van_night_ranges(draft)
-    night_value_ranges(draft.per_night_resources&.[]("van"), draft.arrival_date)
+    night_value_ranges(draft.per_night_resources&.[]("van"), draft.arrival_date, max_nights: draft_window_nights(draft))
   end
 
   # Découpe un tableau de valeurs par nuit (indexé depuis `arrival_date`) en
   # plages contiguës de valeur constante NON NULLE. Retourne
   # `[{from_date:, to_date:, nights:, value:}, ...]` — `to_date` exclusif.
-  def night_value_ranges(values, arrival_date)
+  # Nombre de nuits de la fenêtre du séjour (nil si dates absentes — la grille
+  # n'est de toute façon pas dérivable sans arrivée).
+  def draft_window_nights(draft)
+    return nil if draft.arrival_date.blank? || draft.departure_date.blank?
+    [(draft.departure_date - draft.arrival_date).to_i, 0].max
+  end
+
+  def night_value_ranges(values, arrival_date, max_nights: nil)
     ints = Array(values).map { |v| v.to_i }
+    # Revue Forge F1 : la longueur de la grille vient du CLIENT — bornée à la
+    # fenêtre du séjour, sinon un tableau forgé plus long créerait des plages
+    # (prix + occupation) AU-DELÀ du départ.
+    ints = ints.first(max_nights) if max_nights
     return [] if arrival_date.blank?
 
     ranges = []

--- a/app/services/concerns/camping_composition.rb
+++ b/app/services/concerns/camping_composition.rb
@@ -62,6 +62,74 @@ module CampingComposition
     draft_van_vehicles(draft).positive?
   end
 
+  # --- Grille par nuit → plages contiguës (décision Michael 2026-07-20) -----
+  #
+  # Le funnel expose une grille `per_night_resources = { "tente" => [2,2,0,3],
+  # "van" => [...] }` (une valeur par nuit, indexée depuis l'arrivée). On la
+  # PERSISTE HONNÊTEMENT en N réservables, un par PLAGE CONTIGUË de valeur
+  # constante non nulle : `[2,2,0,3]` → CampingBooking(nuits 1-2, 2 pers) +
+  # CampingBooking(nuit 4, 3 pers). Chaque plage porte from/to = [nuit_début,
+  # nuit_fin+1) — même convention `[from, to)` que Booking/SpaceBooking — donc
+  # tout l'existant (calendrier, capacité, totaux) fonctionne sans modification.
+
+  # Le draft porte-t-il la grille par nuit (funnel / form admin parité) ?
+  # Sinon on retombe sur la représentation pleine-fenêtre (`campings`/`vans`).
+  def draft_per_night_grid?(draft)
+    draft.respond_to?(:per_night_resources) && draft.per_night_resources.present?
+  end
+
+  # Plages camping depuis la grille `per_night_resources["tente"]`.
+  def camping_night_ranges(draft)
+    night_value_ranges(draft.per_night_resources&.[]("tente"), draft.arrival_date)
+  end
+
+  # Plages van depuis la grille `per_night_resources["van"]`.
+  def van_night_ranges(draft)
+    night_value_ranges(draft.per_night_resources&.[]("van"), draft.arrival_date)
+  end
+
+  # Découpe un tableau de valeurs par nuit (indexé depuis `arrival_date`) en
+  # plages contiguës de valeur constante NON NULLE. Retourne
+  # `[{from_date:, to_date:, nights:, value:}, ...]` — `to_date` exclusif.
+  def night_value_ranges(values, arrival_date)
+    ints = Array(values).map { |v| v.to_i }
+    return [] if arrival_date.blank?
+
+    ranges = []
+    i = 0
+    n = ints.length
+    while i < n
+      v = ints[i]
+      if v <= 0
+        i += 1
+        next
+      end
+      j = i
+      j += 1 while j < n && ints[j] == v
+      ranges << { from_date: arrival_date + i, to_date: arrival_date + j,
+                  nights: j - i, value: v }
+      i = j
+    end
+    ranges
+  end
+
+  # Ventile un total en cents sur des plages, au prorata de leurs poids
+  # (`value × nights`), le reste de division allant aux plus fortes parts
+  # fractionnaires (largest-remainder). Somme EXACTEMENT égale à `total` —
+  # c'est l'invariant asserté en spec : ∑ plages == part camping/van du devis.
+  # Sur le cas uniforme, chaque plage porte exactement `people × nuits × tarif`.
+  def distribute_cents(total, weights)
+    total = total.to_i
+    sum = weights.sum
+    return Array.new(weights.size, 0) if sum <= 0
+
+    base = weights.map { |w| total * w / sum }
+    remainder = total - base.sum
+    order = weights.each_index.sort_by { |i| [-((total * weights[i]) % sum), i] }
+    remainder.times { |k| base[order[k % base.size]] += 1 }
+    base
+  end
+
   # --- Disponibilité capacité globale (forçable) ---------------------------
 
   # Renvoie un message d'avertissement si la demande dépasse la capacité globale,
@@ -88,7 +156,74 @@ module CampingComposition
     "Emplacements van complets le #{date.strftime('%-d/%m')} (capacité #{VanBooking::TOTAL_CAPACITY} véhicules)."
   end
 
+  # Messages capacité GRILLE (par nuit) : chaque nuit demandée est confrontée à
+  # SA propre demande (pas la somme des nuits — sinon un séjour [2,2,0,3] serait
+  # évalué à 7 pers/nuit à tort). Renvoie le 1er conflit, ou nil.
+  def camping_grid_capacity_message(draft, excluding_id: nil)
+    camping_night_ranges(draft).each do |r|
+      date = CampingBooking.capacity_conflict_date(
+        units: r[:value], from: r[:from_date], to: r[:to_date], excluding_id: excluding_id
+      )
+      return "Camping complet le #{date.strftime('%-d/%m')} (capacité #{CampingBooking.total_capacity} pers)." if date
+    end
+    nil
+  end
+
+  def van_grid_capacity_message(draft, excluding_id: nil)
+    van_night_ranges(draft).each do |r|
+      date = VanBooking.capacity_conflict_date(
+        units: r[:value], from: r[:from_date], to: r[:to_date], excluding_id: excluding_id
+      )
+      return "Emplacements van complets le #{date.strftime('%-d/%m')} (capacité #{VanBooking.total_capacity} véhicules)." if date
+    end
+    nil
+  end
+
   # --- Persistance ---------------------------------------------------------
+
+  # Persiste la grille camping en N CampingBooking (une par plage contiguë). Le
+  # `total_price_cents` (= `quote.camping_cents`) est VENTILÉ sur les plages au
+  # prorata `people × nuits` : ∑ price_cents == total (invariant devis). Retourne
+  # les CampingBooking créés (peut être vide si la grille est toute nulle).
+  def persist_camping_ranges!(stay:, draft:, status:, total_price_cents:)
+    ranges  = camping_night_ranges(draft)
+    return [] if ranges.empty?
+    prices  = distribute_cents(total_price_cents, ranges.map { |r| r[:value] * r[:nights] })
+    ranges.each_with_index.map do |r, idx|
+      camping = CampingBooking.new(
+        firstname:   draft.first_name, lastname: draft.last_name,
+        email:       Customer.normalize_email(draft.email), phone: draft.phone,
+        group_name:  draft.group_name,
+        from_date:   r[:from_date], to_date: r[:to_date],
+        people:      [r[:value], 1].max, kind: "tente",
+        status:      status, price_cents: prices[idx]
+      )
+      camping.save!
+      stay.stay_items.create!(bookable: camping)
+      camping
+    end
+  end
+
+  # Persiste la grille van en N VanBooking (une par plage contiguë). Même
+  # ventilation que le camping (poids `vehicles × nuits`).
+  def persist_van_ranges!(stay:, draft:, status:, total_price_cents:)
+    ranges  = van_night_ranges(draft)
+    return [] if ranges.empty?
+    prices  = distribute_cents(total_price_cents, ranges.map { |r| r[:value] * r[:nights] })
+    ranges.each_with_index.map do |r, idx|
+      van = VanBooking.new(
+        firstname:   draft.first_name, lastname: draft.last_name,
+        email:       Customer.normalize_email(draft.email), phone: draft.phone,
+        group_name:  draft.group_name,
+        from_date:   r[:from_date], to_date: r[:to_date],
+        vehicles:    [r[:value], 1].max,
+        status:      status, price_cents: prices[idx]
+      )
+      van.save!
+      stay.stay_items.create!(bookable: van)
+      van
+    end
+  end
 
   def persist_camping_booking!(stay:, draft:, status:, price_cents:)
     camping = build_camping_booking(draft: draft, status: status, price_cents: price_cents)
@@ -142,6 +277,32 @@ module CampingComposition
 
   def existing_van_booking(stay)
     stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
+  end
+
+  # TOUS les CampingBooking / VanBooking du séjour (une plage par nuit possible).
+  def existing_camping_bookings(stay)
+    stay.stay_items.where(bookable_type: "CampingBooking").filter_map(&:bookable)
+  end
+
+  def existing_van_bookings(stay)
+    stay.stay_items.where(bookable_type: "VanBooking").filter_map(&:bookable)
+  end
+
+  # Détache + soft-delete tous les CampingBooking (resp. VanBooking) du séjour.
+  # Utilisé à l'édition GRILLE : on reconstruit intégralement les plages (comme
+  # `rebuild_reservations!` pour les chambres) plutôt que de réconcilier N↔N.
+  def detach_camping_bookings!(stay)
+    stay.stay_items.where(bookable_type: "CampingBooking").each do |item|
+      item.bookable&.soft_delete!(validate: false)
+      item.soft_delete!(validate: false)
+    end
+  end
+
+  def detach_van_bookings!(stay)
+    stay.stay_items.where(bookable_type: "VanBooking").each do |item|
+      item.bookable&.soft_delete!(validate: false)
+      item.soft_delete!(validate: false)
+    end
   end
 
   def symbol(entry)

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -232,7 +232,14 @@ module Reservations
     # garde son comportement historique. Même logique de force que l'hébergement.
     def check_outdoor_capacity!
       return unless @admin
-      messages = [camping_capacity_message(draft), van_capacity_message(draft)].compact
+      # Grille par nuit → capacité vérifiée nuit par nuit (chaque plage contre SA
+      # demande) ; sinon repli pleine-fenêtre historique.
+      messages =
+        if draft_per_night_grid?(draft)
+          [camping_grid_capacity_message(draft), van_grid_capacity_message(draft)].compact
+        else
+          [camping_capacity_message(draft), van_capacity_message(draft)].compact
+        end
       return if messages.empty?
 
       if @skip_availability
@@ -295,26 +302,46 @@ module Reservations
 
     # Camping (epic #66, Phase 3) : no-op si aucune personne demandée. Sa part de
     # prix vient du devis (`camping_cents`). Retourne le CampingBooking ou nil.
+    # Grille par nuit (funnel public natif + form admin parité) → une plage
+    # persistée par tranche contiguë (issue « camping/van une nuit du séjour »,
+    # Michael 2026-07-20). REPLI inchangé sur la représentation pleine-fenêtre
+    # (`campings: [{people, nights}]`) quand la grille est absente (rétrocompat
+    # emails legacy / admin historique). `@camping_booking` reste la 1re plage
+    # pour la compatibilité de l'accesseur (aucun consommateur ne suppose l'unicité).
     def build_camping_booking_for!(stay, quote)
       return nil unless draft_has_camping?(draft)
 
-      persist_camping_booking!(
-        stay:        stay,
-        draft:       draft,
-        status:      stay_status,
-        price_cents: quote.camping_cents
-      )
+      if draft_per_night_grid?(draft)
+        persist_camping_ranges!(
+          stay: stay, draft: draft, status: stay_status,
+          total_price_cents: quote.camping_cents
+        ).first
+      else
+        persist_camping_booking!(
+          stay:        stay,
+          draft:       draft,
+          status:      stay_status,
+          price_cents: quote.camping_cents
+        )
+      end
     end
 
     def build_van_booking_for!(stay, quote)
       return nil unless draft_has_van?(draft)
 
-      persist_van_booking!(
-        stay:        stay,
-        draft:       draft,
-        status:      stay_status,
-        price_cents: quote.van_cents
-      )
+      if draft_per_night_grid?(draft)
+        persist_van_ranges!(
+          stay: stay, draft: draft, status: stay_status,
+          total_price_cents: quote.van_cents
+        ).first
+      else
+        persist_van_booking!(
+          stay:        stay,
+          draft:       draft,
+          status:      stay_status,
+          price_cents: quote.van_cents
+        )
+      end
     end
 
     def upsert_customer!

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -128,10 +128,19 @@ module Stays
     # réservables PROPRES au séjour (sinon l'édition d'un séjour camping-seul se
     # bloquerait elle-même). Même logique de force que l'hébergement/espaces.
     def check_outdoor_capacity!
-      messages = [
-        camping_capacity_message(@draft, excluding_id: existing_camping_booking(@stay)&.id),
-        van_capacity_message(@draft,     excluding_id: existing_van_booking(@stay)&.id)
-      ].compact
+      # On exclut TOUTES les propres réservations plein air du séjour (une plage
+      # par nuit possible désormais), sinon l'édition d'un séjour camping/van se
+      # bloquerait elle-même. Grille → capacité nuit par nuit ; sinon pleine fenêtre.
+      camping_ids = existing_camping_bookings(@stay).map(&:id)
+      van_ids     = existing_van_bookings(@stay).map(&:id)
+      messages =
+        if draft_per_night_grid?(@draft)
+          [camping_grid_capacity_message(@draft, excluding_id: camping_ids.presence),
+           van_grid_capacity_message(@draft,     excluding_id: van_ids.presence)].compact
+        else
+          [camping_capacity_message(@draft, excluding_id: camping_ids.presence),
+           van_capacity_message(@draft,     excluding_id: van_ids.presence)].compact
+        end
       return if messages.empty?
 
       if @skip_availability
@@ -391,17 +400,24 @@ module Stays
     # détache le CampingBooking selon le draft. Comme pour l'hébergement, on ne
     # touche ni au token ni à l'email à l'édition.
     def reconcile_camping!
-      camping = existing_camping_booking(@stay)
-
       unless draft_has_camping?(@draft)
-        if camping
-          @stay.stay_items.where(bookable_type: "CampingBooking").each { |i| i.soft_delete!(validate: false) }
-          camping.soft_delete!(validate: false)
-        end
+        detach_camping_bookings!(@stay)
         return
       end
 
       price = @draft.quote.camping_cents
+
+      # Grille par nuit → reconstruction INTÉGRALE des plages (comme les chambres
+      # dans `rebuild_reservations!`) : détacher l'existant puis recréer une plage
+      # par tranche contiguë. Une nuit modifiée recompose proprement les plages.
+      if draft_per_night_grid?(@draft)
+        detach_camping_bookings!(@stay)
+        persist_camping_ranges!(stay: @stay, draft: @draft, status: @stay.status, total_price_cents: price)
+        return
+      end
+
+      # Repli pleine-fenêtre (admin historique / emails legacy) : update en place.
+      camping = existing_camping_booking(@stay)
       if camping
         camping.update!(
           firstname:   @draft.first_name,
@@ -419,17 +435,20 @@ module Stays
     end
 
     def reconcile_van!
-      van = existing_van_booking(@stay)
-
       unless draft_has_van?(@draft)
-        if van
-          @stay.stay_items.where(bookable_type: "VanBooking").each { |i| i.soft_delete!(validate: false) }
-          van.soft_delete!(validate: false)
-        end
+        detach_van_bookings!(@stay)
         return
       end
 
       price = @draft.quote.van_cents
+
+      if draft_per_night_grid?(@draft)
+        detach_van_bookings!(@stay)
+        persist_van_ranges!(stay: @stay, draft: @draft, status: @stay.status, total_price_cents: price)
+        return
+      end
+
+      van = existing_van_booking(@stay)
       if van
         van.update!(
           firstname:   @draft.first_name,

--- a/app/services/stays/draft_reconstructor.rb
+++ b/app/services/stays/draft_reconstructor.rb
@@ -28,6 +28,12 @@ module Stays
         room_ids:       rooms_mode ? booking.reservations.map(&:room_id).uniq : [],
         arrival_date:   @stay.arrival_date,
         departure_date: @stay.departure_date,
+        # Grille par nuit (Michael 2026-07-20) : reconstituée depuis les N
+        # CampingBooking / VanBooking (une plage par tranche contiguë) pour que
+        # l'édition ré-affiche FIDÈLEMENT la grille du funnel. Présente → le Draft
+        # dérive `campings`/`vans` d'elle ; absente (pas de dates / pas de plein
+        # air) → repli sur les entrées pleine-fenêtre ci-dessous.
+        per_night_resources: per_night_resources_from_stay,
         adults:         booking&.adults,
         children:       booking&.children,
         group_name:     booking&.group_name,
@@ -47,6 +53,41 @@ module Stays
     end
 
     private
+
+    # Reconstruit `per_night_resources = { "tente" => [...], "van" => [...] }` en
+    # étalant chaque CampingBooking / VanBooking sur ses nuits `[from, to)`,
+    # indexé depuis l'arrivée du séjour. nil si le séjour n'a pas de dates OU pas
+    # de plein air — l'édition retombe alors sur les entrées pleine-fenêtre legacy.
+    def per_night_resources_from_stay
+      arrival   = @stay.arrival_date
+      departure = @stay.departure_date
+      return nil if arrival.blank? || departure.blank?
+      nights = (departure - arrival).to_i
+      return nil if nights < 1
+
+      campings = @stay.stay_items.select { |i| i.bookable_type == "CampingBooking" }.filter_map(&:bookable)
+      vans     = @stay.stay_items.select { |i| i.bookable_type == "VanBooking" }.filter_map(&:bookable)
+      return nil if campings.empty? && vans.empty?
+
+      pnr = {}
+      pnr["tente"] = spread_nights(campings, arrival, nights, &:people)   if campings.any?
+      pnr["van"]   = spread_nights(vans,     arrival, nights, &:vehicles) if vans.any?
+      pnr
+    end
+
+    # Tableau de `nights` valeurs (0 par défaut), rempli par `yield(b)` sur chaque
+    # nuit couverte par le réservable `b` (fenêtre `[from, to)`).
+    def spread_nights(bookings, arrival, nights)
+      arr = Array.new(nights, 0)
+      bookings.each do |b|
+        next if b.from_date.blank? || b.to_date.blank?
+        (b.from_date...b.to_date).each do |date|
+          idx = (date - arrival).to_i
+          arr[idx] = yield(b) if idx >= 0 && idx < nights
+        end
+      end
+      arr
+    end
 
     def lodging_booking
       @stay.stay_items.where(bookable_type: "Booking").first&.bookable

--- a/app/services/stays/draft_reconstructor.rb
+++ b/app/services/stays/draft_reconstructor.rb
@@ -83,7 +83,9 @@ module Stays
         next if b.from_date.blank? || b.to_date.blank?
         (b.from_date...b.to_date).each do |date|
           idx = (date - arrival).to_i
-          arr[idx] = yield(b) if idx >= 0 && idx < nights
+          # Somme (revue Forge F2) : deux réservables du même type qui se
+          # chevaucheraient une nuit (hors grille) ne s'écrasent pas en silence.
+          arr[idx] += yield(b).to_i if idx >= 0 && idx < nights
         end
       end
       arr

--- a/app/views/public/reservations/_camping_calendar.html.slim
+++ b/app/views/public/reservations/_camping_calendar.html.slim
@@ -1,0 +1,52 @@
+/ Grille "Camping / Van" nuit par nuit — extraite pour être RÉUTILISÉE par le
+/ form admin (issue camping/van une nuit du séjour, Michael 2026-07-20), sur le
+/ modèle de `_spaces_calendar`. Chaque cellule est un stepper (0..max), le name
+/ posté est `#{param_root}[per_night_resources][tente|van][]` — MÊME représentation
+/ que le funnel public, donc même persistance (plages contiguës).
+/ Locals :
+/   - param_root : préfixe des name= (défaut "reservation" ; le form admin passe "stay") ;
+/   - draft      : le Draft à préremplir (défaut @draft) ;
+/   - days       : les jours-colonnes (défaut @stay_nights).
+- param_root  = local_assigns.fetch(:param_root, "reservation")
+- draft       = local_assigns.fetch(:draft, @draft)
+- stay_nights = local_assigns.fetch(:days, @stay_nights)
+- fr_short_days = %w[Dim Lun Mar Mer Jeu Ven Sam]
+- pnr = (draft&.per_night_resources || {})
+
+.bg-white.rounded-2xl.shadow-sm.border.border-gray-100.p-5
+  .flex.items-start.justify-between.mb-4
+    div
+      h2.text-base.font-semibold.text-gray-900 🏕️ Camping / Van
+      p.text-xs.text-gray-400.mt-0.5 Nombre de personnes en tente et de véhicules, nuit par nuit. Capacité globale du terrain (forçable).
+
+  - if stay_nights.blank?
+    p.text-xs.text-gray-400 Choisissez les dates du séjour pour composer le camping nuit par nuit.
+  - else
+    .overflow-x-auto.-mx-5.px-5
+      table.border-collapse style="min-width: #{130 + stay_nights.size * 104}px"
+        thead
+          tr
+            th.text-left.py-2.pr-4.text-xs.font-normal.text-gray-400.whitespace-nowrap.sticky.left-5.z-10.bg-white style="width:130px"
+            - stay_nights.each_with_index do |night, i|
+              th.text-center.py-2.px-1 style="width:104px"
+                p.text-xs.font-bold.text-gray-600 = "Nuit #{i + 1}"
+                p.text-xs.text-gray-400.font-normal = "#{fr_short_days[night.wday]} #{night.strftime("%-d/%-m")}"
+
+        tbody
+          tr class="border-t border-gray-50"
+            td.py-2.pr-4.whitespace-nowrap.sticky.left-5.z-10.bg-white
+              .text-sm.text-gray-800.font-medium ⛺ Tentes
+              p.text-xs.text-gray-400.leading-tight nb de personnes
+            - stay_nights.each_with_index do |_night, i|
+              - val = (pnr["tente"] || [])[i].to_i
+              td.py-2.px-1.text-center
+                = render "public/reservations/stepper_cell", name: "#{param_root}[per_night_resources][tente][]", val: val, max: 50
+
+          tr class="border-t border-gray-50"
+            td.py-2.pr-4.whitespace-nowrap.sticky.left-5.z-10.bg-white
+              .text-sm.text-gray-800.font-medium 🚐 Vans
+              p.text-xs.text-gray-400.leading-tight nb de véhicules
+            - stay_nights.each_with_index do |_night, i|
+              - val = (pnr["van"] || [])[i].to_i
+              td.py-2.px-1.text-center
+                = render "public/reservations/stepper_cell", name: "#{param_root}[per_night_resources][van][]", val: val, max: 20

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -78,6 +78,8 @@ div id="stay-details-#{@stay.id}"
                 .min-w-0
                   .text-gray-900.font-medium ⛺ Camping (#{camping.kind})
                   .text-gray-500 = "#{camping.people} personne(s)"
+                  - if (nights_label = outdoor_nights_label(camping))
+                    .text-gray-500 = nights_label
                 span.text-gray-500.shrink-0 = @stay.formatted_item_amount(camping)
 
       - if @stay.van_bookings.any?
@@ -88,6 +90,8 @@ div id="stay-details-#{@stay.id}"
               li.py-2.text-sm.flex.items-start.justify-between.gap-3
                 .min-w-0
                   .text-gray-900.font-medium 🚐 Van (#{van.vehicles} véhicule(s))
+                  - if (nights_label = outdoor_nights_label(van))
+                    .text-gray-500 = nights_label
                 span.text-gray-500.shrink-0 = @stay.formatted_item_amount(van)
 
       - if @stay.meals.any?

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -195,23 +195,31 @@
             label.block.text-sm.font-medium.text-gray-700 for="stay_space_billing_departure_time" Heure de départ
             = text_field_tag "stay[space_billing][departure_time]", space_billing[:departure_time], id: "stay_space_billing_departure_time", placeholder: "ex. 11:00", class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
-    / --- Camping (tente) ----------------------------------------------------
-    - camping_people = Array(@draft&.campings).sum { |c| (c.respond_to?(:symbolize_keys) ? c.symbolize_keys : c)[:people].to_i }
-    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
-      h2.text-base.font-semibold.text-gray-900 Camping (tente)
-      p.text-sm.text-gray-500 Nombre de personnes en tente sur la durée du séjour. Capacité globale du terrain (forçable). Un séjour peut être composé de camping seul.
-      .space-y-1
-        label.block.text-sm.font-medium.text-gray-700 Personnes
-        = number_field_tag "stay[camping][people]", (camping_people.positive? ? camping_people : nil), min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
-
-    / --- Van / camping-car --------------------------------------------------
-    - van_vehicles = Array(@draft&.vans).size
-    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
-      h2.text-base.font-semibold.text-gray-900 Van / camping-car
-      p.text-sm.text-gray-500 Nombre de véhicules sur la durée du séjour. Capacité globale (forçable).
-      .space-y-1
-        label.block.text-sm.font-medium.text-gray-700 Véhicules
-        = number_field_tag "stay[van][vehicles]", (van_vehicles.positive? ? van_vehicles : nil), min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+    / --- Camping / Van (grille par nuit) ------------------------------------
+    / Parité funnel (Michael 2026-07-20) : dès que le séjour a des dates, on
+    / réutilise la grille steppers nuit-par-nuit du funnel (`per_night_resources`)
+    / — persistée honnêtement en plages contiguës. Sans dates (jamais un camping
+    / valide, mais on ne casse pas le form), on retombe sur les compteurs
+    / pleine-fenêtre historiques (`stay[camping][people]` / `stay[van][vehicles]`).
+    - if use_space_grid
+      section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+        h2.text-base.font-semibold.text-gray-900 Camping / Van
+        = render "public/reservations/camping_calendar", param_root: "stay", draft: @draft, days: @stay_nights
+    - else
+      - camping_people = Array(@draft&.campings).sum { |c| (c.respond_to?(:symbolize_keys) ? c.symbolize_keys : c)[:people].to_i }
+      - van_vehicles = Array(@draft&.vans).size
+      section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+        h2.text-base.font-semibold.text-gray-900 Camping (tente)
+        p.text-sm.text-gray-500 Choisissez les dates du séjour pour composer le camping nuit par nuit. À défaut, nombre de personnes sur toute la durée.
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Personnes
+          = number_field_tag "stay[camping][people]", (camping_people.positive? ? camping_people : nil), min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
+      section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+        h2.text-base.font-semibold.text-gray-900 Van / camping-car
+        p.text-sm.text-gray-500 Nombre de véhicules sur la durée du séjour. Capacité globale (forçable).
+        .space-y-1
+          label.block.text-sm.font-medium.text-gray-700 Véhicules
+          = number_field_tag "stay[van][vehicles]", (van_vehicles.positive? ? van_vehicles : nil), min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
     / --- Repas --------------------------------------------------------------
     - meal_kind_options = [["Repas végé (midi)", "repas_vege_midi"], ["Buffet pain-fromages", "buffet"]]

--- a/spec/requests/stays_admin_camping_spec.rb
+++ b/spec/requests/stays_admin_camping_spec.rb
@@ -87,12 +87,18 @@ RSpec.describe "Stays — camping / van / repas (epic #66, Phase 3)", type: :req
       }
     end
 
-    it "préremplit le form d'édition avec le camping existant" do
+    it "préremplit la GRILLE d'édition avec le camping existant" do
+      # Réécrit (Michael 2026-07-20) : le séjour ayant des dates, le form rend la
+      # grille camping/van par nuit (parité funnel) — plus les champs pleine-fenêtre.
+      # Le camping [3 pers × 2 nuits] est reconstruit en `per_night_resources`
+      # {tente:[3,3]} par le DraftReconstructor → les steppers affichent 3 par nuit.
       stay = create_camping_only_stay
       get edit_stay_path(stay)
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Camping (tente)")
-      expect(response.body).to include('value="3"') # people prérempli
+      expect(response.body).to include("Camping / Van")
+      # Cellules de grille préremplies à 3 (name per_night_resources) + display.
+      expect(response.body).to include('name="stay[per_night_resources][tente][]"')
+      expect(response.body).to include('value="3"')
     end
 
     it "change le nombre de personnes et recalcule le total" do

--- a/spec/services/reservations/per_night_camping_van_spec.rb
+++ b/spec/services/reservations/per_night_camping_van_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+# Camping / van « une nuit du séjour » (Michael 2026-07-20) : la grille par nuit
+# `per_night_resources` est PERSISTÉE honnêtement en N réservables, un par PLAGE
+# CONTIGUË de valeur constante non nulle. Invariant de prix : ∑ plages == part
+# camping/van du devis. Repli inchangé sur la représentation pleine-fenêtre.
+RSpec.describe "Persistance camping/van par nuit (plages contiguës)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 34 } # 4 nuits
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  describe "Reservations::Builder — grille [2,2,0,3]" do
+    let(:grid_draft) { draft(per_night_resources: { "tente" => %w[2 2 0 3] }) }
+
+    it "crée 2 plages aux bonnes dates/people, ∑ prix == quote.camping_cents" do
+      builder = Reservations::Builder.new(draft: grid_draft)
+      expect(builder.run).to be(true)
+
+      campings = builder.stay.stay_items.where(bookable_type: "CampingBooking")
+                        .filter_map(&:bookable).sort_by(&:from_date)
+      expect(campings.size).to eq(2)
+
+      # Plage 1 : nuits 1-2 (arrivée, arrivée+2 exclu), 2 personnes.
+      expect(campings[0].from_date).to eq(arrival)
+      expect(campings[0].to_date).to eq(arrival + 2)
+      expect(campings[0].people).to eq(2)
+      expect(campings[0].price_cents).to eq(750 * 2 * 2) # 3 000 c
+
+      # Plage 2 : nuit 4 uniquement, 3 personnes.
+      expect(campings[1].from_date).to eq(arrival + 3)
+      expect(campings[1].to_date).to eq(arrival + 4)
+      expect(campings[1].people).to eq(3)
+      expect(campings[1].price_cents).to eq(750 * 3 * 1) # 2 250 c
+
+      # Invariant : la somme des plages == la part camping du devis.
+      expect(campings.sum(&:price_cents)).to eq(grid_draft.quote.camping_cents)
+    end
+
+    it "n'ampute jamais le total du séjour (ventilation exhaustive)" do
+      builder = Reservations::Builder.new(draft: grid_draft)
+      builder.run
+      stay = builder.stay
+      parts = stay.bookables.sum { |b| b.try(:price_cents).to_i } +
+              stay.meal_orders.sum(:price_cents)
+      expect(parts).to eq(stay.total_amount_cents)
+    end
+  end
+
+  describe "Reservations::Builder — grille van [0,1,1,0]" do
+    it "crée une plage van sur les nuits 2-3, ∑ prix == quote.van_cents" do
+      d = draft(per_night_resources: { "van" => %w[0 1 1 0] })
+      builder = Reservations::Builder.new(draft: d)
+      expect(builder.run).to be(true)
+
+      vans = builder.stay.stay_items.where(bookable_type: "VanBooking").filter_map(&:bookable)
+      expect(vans.size).to eq(1)
+      expect(vans.first.from_date).to eq(arrival + 1)
+      expect(vans.first.to_date).to eq(arrival + 3)
+      expect(vans.first.vehicles).to eq(1)
+      expect(vans.sum(&:price_cents)).to eq(d.quote.van_cents)
+    end
+  end
+
+  describe "grille absente — comportement historique intact" do
+    it "persiste UN camping pleine-fenêtre depuis campings: [{people, nights}]" do
+      d = draft(campings: [{ kind: "tente", people: 4, nights: 4 }])
+      builder = Reservations::Builder.new(draft: d)
+      expect(builder.run).to be(true)
+
+      campings = builder.stay.stay_items.where(bookable_type: "CampingBooking").filter_map(&:bookable)
+      expect(campings.size).to eq(1)
+      expect(campings.first.people).to eq(4)
+      expect(campings.first.from_date).to eq(arrival)
+      expect(campings.first.to_date).to eq(departure)
+      expect(campings.first.price_cents).to eq(d.quote.camping_cents)
+    end
+  end
+end

--- a/spec/services/reservations/per_night_camping_van_spec.rb
+++ b/spec/services/reservations/per_night_camping_van_spec.rb
@@ -89,3 +89,46 @@ RSpec.describe "Persistance camping/van par nuit (plages contiguës)" do
     end
   end
 end
+
+# Revue Forge F1/F4 — durcissements.
+RSpec.describe Reservations::Builder, "grille par nuit — garde-fous (revue Forge)" do
+  let(:arrival)   { Date.today + 40 }
+  let(:departure) { arrival + 2 } # 2 nuits
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Forge", last_name: "Garde",
+      email: "forge-garde@example.com", phone: "+32470000000"
+    }.merge(overrides))
+  end
+
+  it "F1 : une grille plus longue que la fenêtre est bornée (aucune plage après le départ)" do
+    builder = described_class.new(
+      draft: draft(per_night_resources: { "tente" => [2, 2, 5, 5, 5] }), # 5 valeurs, 2 nuits
+      admin: true, source: "manual"
+    )
+    expect(builder.run).to be(true)
+
+    campings = builder.stay.stay_items.where(bookable_type: "CampingBooking").map(&:bookable)
+    expect(campings.size).to eq(1)
+    expect(campings.first.to_date).to eq(departure) # jamais au-delà du départ
+    expect(campings.first.people).to eq(2)
+  end
+
+  it "F4 : prix imposé + grille — les plages somment toujours à la part camping du devis" do
+    builder = described_class.new(
+      draft: draft(per_night_resources: { "tente" => [2, 3] }),
+      admin: true, source: "manual", price_override_cents: 99_900
+    )
+    expect(builder.run).to be(true)
+
+    quote = builder.stay ? Reservations::Draft.new(
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601, dogs_count: 0,
+      first_name: "x", email: "x@x.be", per_night_resources: { "tente" => [2, 3] }
+    ).quote : nil
+    campings = builder.stay.stay_items.where(bookable_type: "CampingBooking").map(&:bookable)
+    expect(campings.sum(&:price_cents)).to eq(quote.camping_cents)
+    expect(builder.stay.reload.total_amount_cents).to eq(99_900) # l'override gouverne le total
+  end
+end

--- a/spec/services/stays/per_night_reconstruct_update_spec.rb
+++ b/spec/services/stays/per_night_reconstruct_update_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+# Round-trip grille → bookings → grille (DraftReconstructor) et recomposition des
+# plages à l'édition (AdminUpdater), pour le camping/van par nuit (Michael 2026-07-20).
+RSpec.describe "Camping/van par nuit — reconstruction & édition" do
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 34 } # 4 nuits
+
+  def build_stay(pnr)
+    draft = Reservations::Draft.new(
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Alice", last_name: "Martin",
+      email: "alice@example.com", phone: "0470111222",
+      per_night_resources: pnr
+    )
+    Reservations::Builder.new(draft: draft, admin: true, source: "manual").tap(&:run!).stay
+  end
+
+  describe "Stays::DraftReconstructor" do
+    it "reconstitue fidèlement per_night_resources depuis les N bookings" do
+      stay = build_stay("tente" => %w[2 2 0 3], "van" => %w[0 1 1 0])
+      pnr  = Stays::DraftReconstructor.call(stay).per_night_resources
+
+      expect(pnr["tente"]).to eq(%w[2 2 0 3])
+      expect(pnr["van"]).to eq(%w[0 1 1 0])
+    end
+
+    it "round-trip : grille → bookings → grille → mêmes bookings" do
+      stay1 = build_stay("tente" => %w[3 0 3 3])
+      draft = Stays::DraftReconstructor.call(stay1)
+
+      # La grille reconstruite doit reproduire les MÊMES plages.
+      ranges = draft.campings # dérivées de per_night_resources
+      # 3 nuits actives (idx 0, 2, 3), une entrée per-nuit (contrat pricing).
+      expect(ranges.map { |r| r[:people] }).to eq([3, 3, 3])
+    end
+  end
+
+  describe "Stays::AdminUpdater — édition d'une nuit" do
+    it "recompose les plages sans perte quand une nuit change" do
+      stay = build_stay("tente" => %w[2 2 2 2]) # 1 plage au départ
+      expect(stay.stay_items.where(bookable_type: "CampingBooking").count).to eq(1)
+
+      # On creuse la nuit 3 à 0 → doit produire 2 plages (nuits 1-2 et nuit 4).
+      new_draft = Reservations::Draft.new(
+        arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+        dogs_count: 0, first_name: "Alice", last_name: "Martin",
+        email: "alice@example.com", phone: "0470111222",
+        per_night_resources: { "tente" => %w[2 2 0 2] }
+      )
+      updater = Stays::AdminUpdater.new(stay: stay, draft: new_draft)
+      expect(updater.run).to be(true)
+
+      campings = stay.reload.stay_items.where(bookable_type: "CampingBooking")
+                     .filter_map(&:bookable).sort_by(&:from_date)
+      expect(campings.size).to eq(2)
+      expect(campings[0].from_date).to eq(arrival)
+      expect(campings[0].to_date).to eq(arrival + 2)
+      expect(campings[1].from_date).to eq(arrival + 3)
+      expect(campings[1].to_date).to eq(arrival + 4)
+      # Invariant prix : ∑ plages == part camping du devis recalculé.
+      expect(campings.sum(&:price_cents)).to eq(new_draft.quote.camping_cents)
+      # Total du séjour cohérent (aucune plage perdue).
+      expect(stay.total_amount_cents).to eq(new_draft.quote.total_excluding_experiences_cents)
+    end
+  end
+end


### PR DESCRIPTION
## Décision produit (Michael, 20/07)

« Poser des tentes pour une seule nuit qui se déroule durant le séjour — et savoir QUAND. » Le funnel proposait la grille par nuit mais la persistance écrasait tout (un seul CampingBooking au pic sur toute la fenêtre).

## Design : plages contiguës, zéro nouvelle table

`per_night_resources = { tente: [2,2,0,3] }` → CampingBooking(2 nuits, 2 pers) + CampingBooking(1 nuit, 3 pers), convention `[from, to)`. Calendrier, capacité globale, totaux, fusion et suppression fonctionnent tels quels (N StayItems).

- **Prix** : ventilation largest-remainder — la somme des plages égale EXACTEMENT la part camping/van du devis (invariant asserté, y compris sous prix imposé).
- **Admin** : la grille steppers du funnel remplace les champs pleine-fenêtre dès que le séjour a des dates (partial paramétré réutilisé, zéro duplication) ; repli intégral sur l'ancienne saisie sinon (rétrocompat totale, specs conservées).
- **Édition** : `DraftReconstructor` reconstruit la grille depuis les N plages ; `AdminUpdater` réconcilie (détache/recrée) en excluant ses propres plages du contrôle de capacité.
- **Affichage** : chips ⛺️/🚐 par nuit exactes ; fiche/modale montrent les plages avec leurs nuits.

## Revue Forge (GPT-5.4) : concerns → durcis

- **F1** : grille CLIENT bornée à la fenêtre du séjour (un tableau forgé plus long créait prix + occupation après le départ) — clampée + spec.
- **F2** : reconstruction en SOMME (pas d'écrasement silencieux si deux réservables se chevauchent une nuit).
- **F4** : spec prix imposé + grille (plages = part devis, total = override).
- Vérifiés sains par Forge : exactitude monétaire de `distribute_cents` dans tous les cas tracés, détachement sans résidu, capacité/force-dispo, rétrocompat stricte, aucun code ne suppose un camping unique.

## Vérifications

Suite complète sur la branche : **938 examples, 0 failures, EXIT=0**. Passe navigateur (steppers admin + devis live + chips par nuit) post-merge.