### PR TITLE
feat(stays): forfait Terrasse 2,50 €/pers/jour — fieldset admin dédié

### DIFF
--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -564,6 +564,10 @@ class StaysController < BaseController
       campings:       camping_entries(p),
       vans:           van_entries(p),
       meals:          meal_entries(p),
+      # Terrasse (ADMIN uniquement, décision Michael 2026-07-20) : lignes datées
+      # {date, people}. Le funnel public ne porte JAMAIS cette clé (non permise
+      # dans le contrôleur public) ; ce contrôleur admin la lit du form.
+      terrasses:      terrace_entries(p),
       # Facturation espace (epic #81, Phase 6) : le sous-hash brut transite tel
       # quel ; le Draft normalise (presence → nil) et la persistance convertit les
       # montants via les setters `monetize`. Absent du form → `space_billing` nil,
@@ -636,6 +640,19 @@ class StaysController < BaseController
       people = row[:people].to_i
       next if kind.blank? || people < 1
       { kind: kind, date: row[:date].to_s.presence, people: people }
+    end
+  end
+
+  # Terrasse datée {date, people} — une ligne par JOUR d'occupation. On écarte les
+  # lignes incomplètes (sans date ou sans personnes). ADMIN uniquement.
+  def terrace_entries(p)
+    rows = p[:terrasses]
+    rows = rows.respond_to?(:values) ? rows.values : Array(rows)
+    rows.filter_map do |row|
+      date   = row[:date].to_s.presence
+      people = row[:people].to_i
+      next if date.blank? || people < 1
+      { date: date, people: people }
     end
   end
 

--- a/app/decorators/stay_decorator.rb
+++ b/app/decorators/stay_decorator.rb
@@ -197,7 +197,9 @@ class StayDecorator < ApplicationDecorator
         h.t("public.stays.items.space")
       end
     when CampingBooking
-      h.t("public.stays.items.camping")
+      # Un CampingBooking terrasse (kind "terrasse") a son propre libellé (🪑),
+      # distinct du camping (⛺) — décision Michael 2026-07-20.
+      bookable.kind == "terrasse" ? h.t("public.stays.items.terrace") : h.t("public.stays.items.camping")
     when VanBooking
       h.t("public.stays.items.van")
     else

--- a/app/helpers/stays_composition_helper.rb
+++ b/app/helpers/stays_composition_helper.rb
@@ -21,6 +21,7 @@ module StaysCompositionHelper
     icons << composition_icon("🍳", "Cuisine")      if stay_has_kitchen?(stay)
     icons << composition_icon("🚐", "Van")          if stay_has_van?(stay)
     icons << composition_icon("⛺", "Tente")        if stay_has_tent?(stay)
+    icons << composition_icon("🪑", "Terrasse")     if stay_has_terrace?(stay)
     icons << composition_icon("🎯", "Activité")     if stay_has_activity?(stay)
     return if icons.empty?
 
@@ -61,9 +62,15 @@ module StaysCompositionHelper
     stay_items_of(stay, "VanBooking").any?
   end
 
-  # Camping = tente (seul `kind` persisté aujourd'hui — cf. note hamac ci-dessus).
+  # Camping = tente. Un `CampingBooking` peut aussi être une TERRASSE (kind
+  # "terrasse", décision Michael 2026-07-20) : on distingue par `kind`.
   def stay_has_tent?(stay)
-    stay_items_of(stay, "CampingBooking").any?
+    stay_items_of(stay, "CampingBooking").any? { |i| i.bookable&.kind != "terrasse" }
+  end
+
+  # Terrasse = occupation de jour (kind "terrasse") — icône dédiée 🪑.
+  def stay_has_terrace?(stay)
+    stay_items_of(stay, "CampingBooking").any? { |i| i.bookable&.kind == "terrasse" }
   end
 
   # Activité = au moins un ExperienceBooking ACTIF (ni annulé, ni refusé — même

--- a/app/presenters/calendar/day_stay_blocks.rb
+++ b/app/presenters/calendar/day_stay_blocks.rb
@@ -14,6 +14,7 @@ module Calendar
     # Un bloc unifié : un séjour et ses composants présents ce jour-là.
     StayBlock = Struct.new(
       :stay, :booking_groups, :space_groups, :camping_bookings, :van_bookings,
+      :terrace_bookings,
       keyword_init: true
     ) do
       # Le bookable « nommé » (Booking ou SpaceBooking, tous deux décorés et
@@ -25,14 +26,16 @@ module Calendar
 
       # Le séjour dort-il SUR PLACE la nuit de cette carte ? Vrai dès qu'un
       # composant NUITÉ est présent ce jour-là (chambres, camping, van) —
-      # jamais pour une salle seule (les espaces sont des forfaits de journée).
+      # jamais pour une salle seule NI pour une TERRASSE (occupation de jour,
+      # pas une nuitée — décision Michael 2026-07-20).
       def overnight?
         booking_groups.any? || camping_bookings.any? || van_bookings.any?
       end
 
-      # Repli quand le séjour n'a que du camping / van (pas de bookable nommé).
+      # Repli quand le séjour n'a que du camping / van / terrasse (pas de
+      # bookable nommé).
       def fallback_bookable
-        camping_bookings.first || van_bookings.first
+        camping_bookings.first || van_bookings.first || terrace_bookings.first
       end
     end
 
@@ -71,7 +74,14 @@ module Calendar
 
       @camping.each do |camping|
         next if camping.stay.nil?
-        (by_stay[camping.stay.id] ||= new_block(camping.stay)).camping_bookings << camping
+        block = (by_stay[camping.stay.id] ||= new_block(camping.stay))
+        # Terrasse (kind "terrasse") : CampingBooking, mais rendu distinct (🪑,
+        # pas ⛺️) et exclu de la nuitée (`overnight?`). Décision Michael 2026-07-20.
+        if camping.kind == "terrasse"
+          block.terrace_bookings << camping
+        else
+          block.camping_bookings << camping
+        end
       end
 
       @van.each do |van|
@@ -88,8 +98,9 @@ module Calendar
     end
 
     # Camping / van SANS séjour : gardent leur bloc informatif « Camping » / « Van ».
+    # La terrasse (kind "terrasse") en est exclue (jamais un bloc « Camping »).
     def no_stay_camping
-      @camping.select { |camping| camping.stay.nil? }
+      @camping.select { |camping| camping.stay.nil? && camping.kind != "terrasse" }
     end
 
     def no_stay_van
@@ -100,7 +111,7 @@ module Calendar
 
     def new_block(stay)
       StayBlock.new(stay: stay, booking_groups: [], space_groups: [],
-                    camping_bookings: [], van_bookings: [])
+                    camping_bookings: [], van_bookings: [], terrace_bookings: [])
     end
 
     # Réplique le regroupement historique des vues : trie par heure, regroupe par

--- a/app/services/concerns/camping_composition.rb
+++ b/app/services/concerns/camping_composition.rb
@@ -281,18 +281,24 @@ module CampingComposition
     )
   end
 
-  # Réservables déjà rattachés au séjour (édition), ou nil.
+  # Réservables déjà rattachés au séjour (édition), ou nil. Un `CampingBooking`
+  # peut désormais aussi être une TERRASSE (`kind: "terrasse"`, décision Michael
+  # 2026-07-20) : on l'EXCLUT ici — le camping ne compte que les tentes, sinon la
+  # réconciliation camping écraserait les terrasses du séjour.
   def existing_camping_booking(stay)
-    stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
+    existing_camping_bookings(stay).first
   end
 
   def existing_van_booking(stay)
     stay.stay_items.where(bookable_type: "VanBooking").first&.bookable
   end
 
-  # TOUS les CampingBooking / VanBooking du séjour (une plage par nuit possible).
+  # TOUS les CampingBooking CAMPING (kind "tente") du séjour — les terrasses
+  # (kind "terrasse", `TerraceComposition`) sont exclues du périmètre camping.
   def existing_camping_bookings(stay)
-    stay.stay_items.where(bookable_type: "CampingBooking").filter_map(&:bookable)
+    stay.stay_items.where(bookable_type: "CampingBooking")
+        .filter_map(&:bookable)
+        .reject { |b| b.kind == "terrasse" }
   end
 
   def existing_van_bookings(stay)
@@ -304,6 +310,9 @@ module CampingComposition
   # `rebuild_reservations!` pour les chambres) plutôt que de réconcilier N↔N.
   def detach_camping_bookings!(stay)
     stay.stay_items.where(bookable_type: "CampingBooking").each do |item|
+      # Ne JAMAIS détacher une terrasse ici (kind "terrasse") : elle a son propre
+      # cycle de vie (`TerraceComposition`). Le camping ne touche qu'aux tentes.
+      next if item.bookable&.kind == "terrasse"
       item.bookable&.soft_delete!(validate: false)
       item.soft_delete!(validate: false)
     end

--- a/app/services/concerns/terrace_composition.rb
+++ b/app/services/concerns/terrace_composition.rb
@@ -1,0 +1,97 @@
+# Composition TERRASSE d'un séjour depuis un `Reservations::Draft` (décision
+# Michael, 2026-07-20). Concern PARTAGÉ par `Reservations::Builder` (création) et
+# `Stays::AdminUpdater` (édition), sur le modèle de `MealComposition`.
+#
+# Décisions figées :
+#   - La terrasse est réservée à des groupes qui occupent UNIQUEMENT la terrasse
+#     (ex. randonneurs venant faire un BBQ) : forfait 2,50 €/pers/JOUR.
+#   - ADMIN UNIQUEMENT — jamais proposé sur le funnel public /reservation.
+#   - Sémantique = JOURS d'occupation. Un BBQ d'un jour = une ligne `{date, people}`
+#     → un `CampingBooking` de `kind: "terrasse"`, `from = date`, `to = date + 1`
+#     (convention `[from, to)` partagée avec Booking/Camping/Van) — donc l'existant
+#     (calendrier, StayItem, totaux) fonctionne sans modification.
+#   - La terrasse N'EST PAS une nuitée : elle ne déclenche pas l'emoji 💤 (cf.
+#     `Calendar::DayStayBlocks::StayBlock#overnight?`).
+#   - Le montant vient du barème B2C (`Pricing::Catalog::TERRACE_PER_PERSON_DAY_CENTS`)
+#     — la même source que la ligne `:terrace` du devis, donc aucun double-compte.
+module TerraceComposition
+  extend ActiveSupport::Concern
+
+  # `kind` du CampingBooking qui matérialise une terrasse (vs "tente" = camping).
+  TERRACE_KIND = "terrasse".freeze
+
+  private
+
+  # Entrées terrasse exploitables du draft : [{ date: Date, people: Integer }].
+  # Une ligne sans date OU sans personnes est écartée (saisie incomplète).
+  def draft_terrace_entries(draft)
+    Array(draft.terrasses).filter_map do |raw|
+      entry  = raw.respond_to?(:symbolize_keys) ? raw.symbolize_keys : raw
+      people = entry[:people].to_i
+      date   = parse_terrace_date(entry[:date])
+      next if people < 1 || date.nil?
+      { date: date, people: people }
+    end
+  end
+
+  def draft_has_terrace?(draft)
+    draft_terrace_entries(draft).any?
+  end
+
+  # Prix TVAC d'une entrée terrasse (source unique = Catalog, comme `terrace_lines`).
+  def terrace_entry_price_cents(entry)
+    Pricing::Catalog::TERRACE_PER_PERSON_DAY_CENTS * entry[:people].to_i
+  end
+
+  # Persiste la terrasse en N CampingBooking `kind: "terrasse"` (un par JOUR).
+  # Chacun couvre `[date, date + 1)` et porte son propre prix `people × 250` :
+  # ∑ price_cents == `quote.terrace_cents` (invariant devis). Retourne les
+  # CampingBooking créés.
+  def persist_terrace_bookings!(stay:, draft:, status:)
+    draft_terrace_entries(draft).map do |entry|
+      camping = CampingBooking.new(
+        firstname:   draft.first_name, lastname: draft.last_name,
+        email:       Customer.normalize_email(draft.email), phone: draft.phone,
+        group_name:  draft.group_name,
+        from_date:   entry[:date], to_date: entry[:date] + 1,
+        people:      entry[:people], kind: TERRACE_KIND,
+        status:      status, price_cents: terrace_entry_price_cents(entry)
+      )
+      camping.save!
+      stay.stay_items.create!(bookable: camping)
+      camping
+    end
+  end
+
+  # Tous les CampingBooking terrasse du séjour (une occupation par jour possible).
+  def existing_terrace_bookings(stay)
+    stay.stay_items
+        .select { |i| i.bookable_type == "CampingBooking" }
+        .filter_map(&:bookable)
+        .select { |b| b.kind == TERRACE_KIND }
+  end
+
+  # Détache + soft-delete toutes les terrasses du séjour (rebuild à l'édition).
+  def detach_terrace_bookings!(stay)
+    stay.stay_items.where(bookable_type: "CampingBooking").each do |item|
+      next unless item.bookable&.kind == TERRACE_KIND
+      item.bookable&.soft_delete!(validate: false)
+      item.soft_delete!(validate: false)
+    end
+  end
+
+  # Réconcilie la terrasse à l'édition : rebuild complet (petit volume), comme les
+  # repas. Les anciennes occupations sont soft-deleted, les nouvelles recréées.
+  def reconcile_terrace!(stay, draft)
+    detach_terrace_bookings!(stay)
+    persist_terrace_bookings!(stay: stay, draft: draft, status: stay.status) if draft_has_terrace?(draft)
+  end
+
+  def parse_terrace_date(value)
+    return nil if value.blank?
+    return value if value.is_a?(Date)
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+end

--- a/app/services/pricing/catalog.rb
+++ b/app/services/pricing/catalog.rb
@@ -62,6 +62,11 @@ module Pricing
     # Van / camping-car : forfait/nuit/véhicule.
     VAN_PER_NIGHT_CENTS = 1_500 # 15 €/nuit
 
+    # Terrasse : forfait €/pers/JOUR (occupation d'un jour, ex. BBQ de randonneurs).
+    # ADMIN UNIQUEMENT — jamais proposé sur le funnel public (décision Michael,
+    # 2026-07-20). Persisté en `CampingBooking` de `kind: "terrasse"`, un par jour.
+    TERRACE_PER_PERSON_DAY_CENTS = 250 # 2,50 €/pers/jour
+
     # Salles & cuisine pro — tarifs semaine (lun-jeu + ven journée).
     # Source : https://www.les4sources.be/sejours/tarifs
     # Périodes : "journee" | "soiree" | "journee_et_soiree"

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -54,6 +54,9 @@ class PricingModel
     def camping_cents = category_cents(:camping)
     def van_cents     = category_cents(:van)
     def meals_cents   = category_cents(:meal)
+    # Terrasse (ADMIN uniquement, décision Michael 2026-07-20) : part datée à la
+    # journée, portée par des `CampingBooking` de `kind: "terrasse"`.
+    def terrace_cents = category_cents(:terrace)
 
     # Base hébergement/camping/repas = total hors activités ET hors espaces.
     # INCHANGÉ pour préserver EXACTEMENT le canal public (funnel) : côté public,
@@ -67,7 +70,7 @@ class PricingModel
     # camping/van/repas vivent sur leurs propres modèles. Invariant admin :
     #   lodging_only + spaces + camping + van + meals == total_excluding_experiences.
     def lodging_only_cents
-      lodging_bundle_cents - camping_cents - van_cents - meals_cents
+      lodging_bundle_cents - camping_cents - van_cents - meals_cents - terrace_cents
     end
 
     def category_cents(category)
@@ -106,6 +109,7 @@ class PricingModel
     lines.concat(hall_lines)
     lines.concat(space_slot_lines)
     lines.concat(meal_lines)
+    lines.concat(terrace_lines)
     lines.concat(pizza_party_lines)
     lines.concat(dog_lines)
 
@@ -258,6 +262,27 @@ class PricingModel
       next if people < 1
       Line.new(label: "#{humanize(entry[:kind])} — #{people} pers",
                amount_cents: unit * people, category: :meal)
+    end
+  end
+
+  # --- Terrasse : forfait €/pers/JOUR, une ligne par jour d'occupation ---
+  # ADMIN uniquement (décision Michael 2026-07-20). Chaque entrée `{date, people}`
+  # devient une ligne `category: :terrace`. Le funnel public ne porte jamais cette
+  # clé (non permise dans le contrôleur public) → aucune ligne côté public.
+  def terrace_lines
+    Array(read(:terrasses)).filter_map do |entry|
+      entry  = entry.symbolize_keys if entry.respond_to?(:symbolize_keys)
+      people = entry[:people].to_i
+      next if people < 1
+      date_label = begin
+        Date.parse(entry[:date].to_s).strftime("%-d/%m")
+      rescue ArgumentError, TypeError
+        nil
+      end
+      label = date_label ? "Terrasse — #{date_label}, #{people} pers" : "Terrasse — #{people} pers"
+      Line.new(label: label,
+               amount_cents: Pricing::Catalog::TERRACE_PER_PERSON_DAY_CENTS * people,
+               category: :terrace)
     end
   end
 

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -17,6 +17,7 @@ module Reservations
     include SpaceComposition
     include CampingComposition
     include MealComposition
+    include TerraceComposition
     # Reservations de chambres de l'hébergement (epic #66, Phase 6) : on réutilise
     # `build_reservations` + `get_rooms` du concern Bookable — SOURCE UNIQUE
     # partagée avec Bookings::CreateService — plutôt que de dupliquer la logique.
@@ -79,6 +80,11 @@ module Reservations
     end
 
     def run!
+      # Terrasse = ADMIN uniquement (décision Michael 2026-07-20). Hors admin, on
+      # NEUTRALISE tout param `terrasses` forgé AVANT le devis : il ne doit ni être
+      # facturé, ni gonfler le total/acompte, ni être persisté (miroir de
+      # `admin_price_override`, ignoré côté public même sur param forgé).
+      draft.terrasses = [] unless @admin
       validate_draft!
       quote = draft.quote(deposit_rate: @deposit_rate)
 
@@ -131,6 +137,11 @@ module Reservations
         @camping_booking = build_camping_booking_for!(@stay, quote)
         @van_booking     = build_van_booking_for!(@stay, quote)
         create_meal_orders!(@stay, draft)
+        # Terrasse (décision Michael 2026-07-20) : ADMIN UNIQUEMENT. Une occupation
+        # `CampingBooking` de `kind: "terrasse"` par JOUR. Ignorée hors admin, même
+        # sur param forgé (comme `price_override_cents`) — le funnel public ne
+        # l'expose jamais. Sa part de prix vient du devis (`quote.terrace_cents`).
+        build_terrace_bookings_for!(@stay) if terrace_enabled?
         # Sélections d'activités du funnel (epic #55, Phase 4) : chaque créneau
         # choisi devient un ExperienceBooking `pending` rattaché au Stay — de la
         # MÊME nature que ceux du rail email, donc soumis à la validation porteur.
@@ -275,7 +286,20 @@ module Reservations
         draft.hamacs.any? ||
         draft_has_spaces?(draft) ||
         draft.bookable_experiences? ||
-        draft_has_meals?(draft)
+        draft_has_meals?(draft) ||
+        (terrace_enabled? && draft_has_terrace?(draft))
+    end
+
+    # Terrasse activée : ADMIN uniquement (jamais le funnel public, même sur param
+    # forgé — miroir de `admin_price_override`).
+    def terrace_enabled?
+      @admin && draft_has_terrace?(draft)
+    end
+
+    # Crée les CampingBooking terrasse (un par jour) du séjour. No-op si aucune
+    # entrée exploitable. Retourne les occupations créées.
+    def build_terrace_bookings_for!(stay)
+      persist_terrace_bookings!(stay: stay, draft: draft, status: stay_status)
     end
 
     # Réservables facturés À LA NUIT : ils exigent au moins une nuit. Les espaces

--- a/app/services/reservations/draft.rb
+++ b/app/services/reservations/draft.rb
@@ -10,6 +10,11 @@ module Reservations
     attr_accessor :lodging_id, :lodging_night_ids, :per_night_resources,
                   :arrival_date, :departure_date, :dogs_count,
                   :halls, :space_slots, :meals, :pizza_parties,
+                  # Terrasse (ADMIN uniquement, décision Michael 2026-07-20) :
+                  # lignes datées `[{date:, people:}]` — une par JOUR d'occupation,
+                  # comme les repas datés. Le funnel public ne la porte JAMAIS
+                  # (non permis dans le contrôleur public).
+                  :terrasses,
                   :experiences,
                   :first_name, :last_name, :email, :phone, :group_name,
                   # Client organisation vs particulier (form admin, addendum) :
@@ -49,6 +54,7 @@ module Reservations
       @halls             = symbolize_rows(attrs[:halls])
       @space_slots       = parse_space_slots(attrs[:space_slots])
       @meals             = symbolize_rows(attrs[:meals])
+      @terrasses         = symbolize_rows(attrs[:terrasses])
       @pizza_parties     = symbolize_rows(attrs[:pizza_parties])
       @hamacs            = symbolize_rows(attrs[:hamacs])
       @experiences       = symbolize_rows(attrs[:experiences])
@@ -144,6 +150,7 @@ module Reservations
         halls:              halls,
         space_slots:        space_slots,
         meals:              meals,
+        terrasses:          terrasses,
         pizza_parties:      pizza_parties,
         hamacs:             hamacs,
         experiences:        experiences,

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -24,6 +24,7 @@ module Stays
     include SpaceComposition
     include CampingComposition
     include MealComposition
+    include TerraceComposition
 
     class Invalid < StandardError; end
 
@@ -75,6 +76,10 @@ module Stays
         reconcile_camping!
         reconcile_van!
         reconcile_meals!(@stay, @draft)
+        # Terrasse (ADMIN uniquement, décision Michael 2026-07-20) : rebuild complet
+        # des occupations `CampingBooking` de kind "terrasse", indépendamment du
+        # camping (tente). Ce canal EST admin — aucun garde-fou public à prévoir.
+        reconcile_terrace!(@stay, @draft)
         reconcile_experiences!
         @stay.recompute_aggregates!
       end
@@ -97,7 +102,8 @@ module Stays
       # des compositions légitimes (validé par Michael).
       unless @draft.lodging.present? || draft_has_spaces?(@draft) ||
              draft_has_camping?(@draft) || draft_has_van?(@draft) ||
-             @draft.bookable_experiences? || draft_has_meals?(@draft)
+             @draft.bookable_experiences? || draft_has_meals?(@draft) ||
+             draft_has_terrace?(@draft)
         raise_invalid("Veuillez sélectionner un hébergement, un espace, un emplacement camping/van, une activité ou un repas.")
       end
       unless Customer.exploitable_email?(@draft.email)

--- a/app/services/stays/draft_reconstructor.rb
+++ b/app/services/stays/draft_reconstructor.rb
@@ -48,6 +48,7 @@ module Stays
         campings:       campings_from_stay,
         vans:           vans_from_stay,
         meals:          meals_from_stay,
+        terrasses:      terrasses_from_stay,
         space_billing:  space_billing_from_stay
       )
     end
@@ -65,7 +66,10 @@ module Stays
       nights = (departure - arrival).to_i
       return nil if nights < 1
 
-      campings = @stay.stay_items.select { |i| i.bookable_type == "CampingBooking" }.filter_map(&:bookable)
+      # Les TERRASSES (kind "terrasse") sont des CampingBooking mais N'ENTRENT PAS
+      # dans la grille camping/van par nuit — elles ont leur propre reconstruction.
+      campings = @stay.stay_items.select { |i| i.bookable_type == "CampingBooking" }
+                      .filter_map(&:bookable).reject { |b| b.kind == "terrasse" }
       vans     = @stay.stay_items.select { |i| i.bookable_type == "VanBooking" }.filter_map(&:bookable)
       return nil if campings.empty? && vans.empty?
 
@@ -126,7 +130,8 @@ module Stays
     # Reconstruit l'entrée camping {kind, people, nights} depuis le CampingBooking
     # persisté (nights déduit de la fenêtre).
     def campings_from_stay
-      camping = @stay.stay_items.where(bookable_type: "CampingBooking").first&.bookable
+      camping = @stay.stay_items.where(bookable_type: "CampingBooking")
+                     .filter_map(&:bookable).reject { |b| b.kind == "terrasse" }.first
       return [] if camping.nil?
       nights = camping.from_date && camping.to_date ? (camping.to_date - camping.from_date).to_i : @stay.experience_bookings.size
       [{ kind: camping.kind, people: camping.people, nights: [nights, 1].max }]
@@ -138,6 +143,16 @@ module Stays
       return [] if van.nil?
       nights = van.from_date && van.to_date ? (van.to_date - van.from_date).to_i : 1
       Array.new([van.vehicles, 1].max) { { nights: [nights, 1].max } }
+    end
+
+    # Reconstruit les terrasses {date, people} depuis les CampingBooking terrasse
+    # (un par jour, `from_date` = jour d'occupation). Prérempli le fieldset admin.
+    def terrasses_from_stay
+      @stay.stay_items.select { |i| i.bookable_type == "CampingBooking" }
+           .filter_map(&:bookable)
+           .select { |b| b.kind == "terrasse" }
+           .sort_by { |b| b.from_date.to_s }
+           .map { |b| { date: b.from_date&.iso8601, people: b.people } }
     end
 
     # Reconstruit les repas {kind, date, people} depuis les MealOrder du séjour.

--- a/app/views/pages/calendar/_day_stay_block.html.slim
+++ b/app/views/pages/calendar/_day_stay_block.html.slim
@@ -46,6 +46,9 @@ div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min
       / Van / camping-car : même logique que le camping.
       - block.van_bookings.each do |van|
         span(class="text-xs text-gray-600 whitespace-nowrap") 🚐 #{van.vehicles} véhicule#{"s" if van.vehicles.to_i > 1}
+      / Terrasse : occupation de JOUR (pas une nuitée) → chip distincte 🪑, pas ⛺️.
+      - block.terrace_bookings.each do |terrace|
+        span(class="text-xs text-gray-600 whitespace-nowrap") 🪑 Terrasse · #{terrace.people} pers.
 
   / Overlay cliquable : ouvre la modale séjour (epic #66, Phase 5) et sert de
   / cible unique au mode fusion pour tout le séjour.

--- a/app/views/stays/_form.html.slim
+++ b/app/views/stays/_form.html.slim
@@ -235,6 +235,21 @@
             = date_field_tag "stay[meals][#{index}][date]", row[:date], class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
             = number_field_tag "stay[meals][#{index}][people]", row[:people], min: 0, placeholder: "Convives", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
 
+    / --- Terrasse (ADMIN uniquement) ---------------------------------------
+    / Groupes occupant UNIQUEMENT la terrasse (ex. randonneurs / BBQ) : forfait
+    / 2,50 €/pers/jour. Une ligne par JOUR (date + nb de personnes), comme les
+    / repas datés. Jamais proposé sur le funnel public.
+    - existing_terrasses = Array(@draft&.terrasses).map { |t| t.respond_to?(:symbolize_keys) ? t.symbolize_keys : t }
+    - terrace_rows = existing_terrasses + Array.new([3 - existing_terrasses.size, 1].max) { {} }
+    section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
+      h2.text-base.font-semibold.text-gray-900 Terrasse
+      p.text-sm.text-gray-500 Groupe occupant uniquement la terrasse (ex. BBQ). Forfait 2,50 €/pers/jour — une ligne par jour (date + nombre de personnes).
+      ul.divide-y.divide-gray-100
+        - terrace_rows.each_with_index do |row, index|
+          li.py-2.grid.grid-cols-2.gap-2
+            = date_field_tag "stay[terrasses][#{index}][date]", row[:date], class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+            = number_field_tag "stay[terrasses][#{index}][people]", row[:people], min: 0, placeholder: "Personnes", class: "rounded-md border-gray-300 shadow-sm sm:text-sm"
+
     / --- Activités ----------------------------------------------------------
     section.bg-white.shadow.ring-1.ring-black.ring-opacity-5.rounded-lg.p-5.space-y-4
       h2.text-base.font-semibold.text-gray-900 Activités

--- a/config/locales/public.en.yml
+++ b/config/locales/public.en.yml
@@ -20,6 +20,7 @@ en:
         space: "Space"
         camping: "Camping"
         van: "Van / campervan"
+        terrace: "Terrace"
         meal: "Meal"
         other: "Service"
       payment_status:

--- a/config/locales/public.fr.yml
+++ b/config/locales/public.fr.yml
@@ -16,6 +16,7 @@ fr:
         space: "Espace"
         camping: "Camping"
         van: "Van / camping-car"
+        terrace: "Terrasse"
         meal: "Repas"
         other: "Prestation"
       payment_status:

--- a/config/locales/public.nl.yml
+++ b/config/locales/public.nl.yml
@@ -20,6 +20,7 @@ nl:
         space: "Ruimte"
         camping: "Camping"
         van: "Camper"
+        terrace: "Terras"
         meal: "Maaltijd"
         other: "Dienst"
       payment_status:

--- a/spec/requests/calendar_terrace_block_spec.rb
+++ b/spec/requests/calendar_terrace_block_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+# Terrasse au calendrier — chip distincte « 🪑 Terrasse · N pers. » (PAS ⛺️) dans
+# le bloc séjour unifié, et surtout PAS de 💤 : la terrasse est une occupation de
+# JOUR, jamais une nuitée (décision Michael, 2026-07-20).
+RSpec.describe "Calendrier — bloc terrasse", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent-terrasse@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  it "rend une chip 🪑 Terrasse, sans ⛺️ ni 💤, sur un séjour terrasse-seule" do
+    day = Date.today.next_occurring(:tuesday)
+
+    customer = Customers::UpsertByEmail.call(email: "bbq@example.com", attrs: { first_name: "BBQ" })
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: day, departure_date: day + 1)
+    terrace = CampingBooking.create!(firstname: "BBQ", group_name: "Rando BBQ",
+                                     from_date: day, to_date: day + 1, people: 8,
+                                     status: "confirmed", kind: "terrasse",
+                                     price_cents: 2_000)
+    StayItem.create!(stay: stay, bookable: terrace)
+
+    get "/"
+    expect(response).to have_http_status(:ok)
+
+    block = response.body[/data-stay-id="#{stay.id}".*?<\/div>/m]
+    full  = response.body
+    # Chip terrasse présente…
+    expect(full).to include("🪑 Terrasse · 8 pers.")
+    # …et un séjour terrasse-seule ne dort PAS sur place (pas de 💤) ni ⛺️.
+    expect(block).not_to include("💤")
+    expect(full).not_to include("⛺️ 8 pers.")
+    # UN seul bloc pour ce séjour.
+    expect(full.scan("data-stay-id=\"#{stay.id}\"").size).to eq(1)
+  end
+end
+
+# Icônes de composition de la fiche client : 🪑 pour la terrasse (distincte de ⛺).
+RSpec.describe StaysCompositionHelper, "terrasse", type: :helper do
+  it "affiche 🪑 pour une terrasse et jamais ⛺ à sa place" do
+    day = Date.today + 10
+    customer = Customers::UpsertByEmail.call(email: "fiche@example.com", attrs: { first_name: "Fiche" })
+    stay = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                        arrival_date: day, departure_date: day + 1)
+    terrace = CampingBooking.create!(firstname: "Fiche", from_date: day, to_date: day + 1,
+                                     people: 4, status: "confirmed", kind: "terrasse",
+                                     price_cents: 1_000)
+    StayItem.create!(stay: stay, bookable: terrace)
+
+    html = helper.stay_composition_icons(stay.reload).to_s
+    expect(html).to include("🪑")
+    expect(html).not_to include("⛺")
+  end
+end

--- a/spec/services/reservations/builder_terrace_spec.rb
+++ b/spec/services/reservations/builder_terrace_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+# Terrasse (décision Michael, 2026-07-20) — des groupes occupent UNIQUEMENT la
+# terrasse (ex. randonneurs / BBQ) : forfait 2,50 €/pers/JOUR. ADMIN UNIQUEMENT,
+# jamais sur le funnel public. Persistée en `CampingBooking` de `kind: "terrasse"`,
+# un par JOUR d'occupation (`from = date`, `to = date + 1`).
+RSpec.describe Reservations::Builder, "terrasse (ADMIN uniquement)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  let(:day1) { Date.today + 30 }
+  let(:day2) { Date.today + 31 }
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  describe "création admin — 2 lignes terrasse (jours différents)" do
+    let(:d) do
+      draft(
+        arrival_date: day1.iso8601, departure_date: day2.iso8601,
+        terrasses: [{ date: day1.iso8601, people: 8 }, { date: day2.iso8601, people: 5 }]
+      )
+    end
+
+    it "crée 2 CampingBooking kind terrasse, un par jour, prix people×250" do
+      builder = described_class.new(draft: d, admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      terrasses = builder.stay.stay_items.map(&:bookable)
+                         .select { |b| b.is_a?(CampingBooking) && b.kind == "terrasse" }
+                         .sort_by(&:from_date)
+      expect(terrasses.size).to eq(2)
+
+      first, second = terrasses
+      expect(first.people).to eq(8)
+      expect(first.from_date).to eq(day1)
+      expect(first.to_date).to eq(day1 + 1)          # occupation d'UN jour
+      expect(first.price_cents).to eq(2_000)         # 8 × 2,50 €
+      expect(second.people).to eq(5)
+      expect(second.from_date).to eq(day2)
+      expect(second.price_cents).to eq(1_250)        # 5 × 2,50 €
+
+      # Total du séjour juste = somme des terrasses (aucun autre réservable).
+      expect(builder.stay.total_amount_cents).to eq(3_250)
+      # Aucun paiement (canal admin).
+      expect(builder.stay.payments).to be_empty
+    end
+
+    it "n'assimile PAS la terrasse au camping (kind tente)" do
+      described_class.new(draft: d, admin: true, source: "manual").run
+      expect(CampingBooking.where(kind: "tente")).to be_empty
+      expect(CampingBooking.where(kind: "terrasse").count).to eq(2)
+    end
+  end
+
+  describe "combinée à un hébergement — invariant de ventilation" do
+    it "Booking(hébergement pur) + terrasses == total, sans double-compte" do
+      d = draft(
+        lodging_id: hulotte.id,
+        arrival_date: day1.iso8601, departure_date: (day1 + 2).iso8601, # 2 nuits Hulotte
+        terrasses: [{ date: day1.iso8601, people: 4 }]
+      )
+      builder = described_class.new(draft: d, admin: true, source: "manual")
+      expect(builder.run).to be(true)
+
+      terrace_cents = CampingBooking.where(kind: "terrasse").sum(:price_cents)
+      expect(terrace_cents).to eq(1_000)              # 4 × 2,50 €
+      # Hébergement PUR = 2 nuits Hulotte (48 500 + 26 000), SANS la terrasse.
+      expect(builder.booking.price_cents).to eq(74_500)
+      expect(builder.booking.price_cents + terrace_cents).to eq(builder.stay.total_amount_cents)
+    end
+  end
+
+  describe "funnel public — anti-critère (param terrasses forgé)" do
+    it "IGNORE terrasses hors admin, même en param forgé" do
+      d = draft(
+        lodging_id: hulotte.id,
+        arrival_date: day1.iso8601, departure_date: (day1 + 2).iso8601,
+        terrasses: [{ date: day1.iso8601, people: 8 }] # param forgé
+      )
+      builder = described_class.new(draft: d) # PAS admin (funnel public)
+      expect(builder.run).to be(true)
+
+      expect(CampingBooking.where(kind: "terrasse")).to be_empty
+      # Total inchangé = 2 nuits Hulotte, la terrasse forgée n'est jamais facturée.
+      expect(builder.stay.total_amount_cents).to eq(74_500)
+      expect(builder.booking.price_cents).to eq(74_500)
+    end
+  end
+end
+
+RSpec.describe PricingModel, "terrasse" do
+  def draft(**attrs)
+    OpenStruct.new({ lodging: nil, nights: 0, dogs_count: 0,
+                     campings: [], vans: [], halls: [], meals: [], terrasses: [] }.merge(attrs))
+  end
+
+  it "produit une ligne :terrace par entrée (people × 2,50 €)" do
+    quote = described_class.quote(draft(terrasses: [{ date: "2026-08-12", people: 8 },
+                                                    { date: "2026-08-13", people: 5 }]))
+    expect(quote.terrace_cents).to eq(3_250)
+    expect(quote.total_cents).to eq(3_250)
+    expect(quote.breakdown.map { |l| l[:label] }).to all(match(/Terrasse/))
+  end
+
+  it "exclut la terrasse de l'hébergement pur (lodging_only_cents)" do
+    grand_duc = Lodging.create!(name: "Le Grand-Duc", price_night_cents: 75_000)
+    quote = described_class.quote(draft(lodging: grand_duc, nights: 1,
+                                        terrasses: [{ date: "2026-08-12", people: 4 }]))
+    expect(quote.terrace_cents).to eq(1_000)
+    expect(quote.lodging_only_cents).to eq(75_000) # 1 nuit Grand-Duc, hors terrasse
+    expect(quote.lodging_only_cents + quote.terrace_cents).to eq(quote.total_excluding_experiences_cents)
+  end
+end

--- a/spec/services/stays/terrace_reconcile_spec.rb
+++ b/spec/services/stays/terrace_reconcile_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# Terrasse — édition admin (`Stays::AdminUpdater`) et reconstruction du Draft
+# (`Stays::DraftReconstructor`). La terrasse (CampingBooking kind "terrasse") a
+# son propre cycle de vie, indépendant du camping (kind "tente").
+RSpec.describe "Terrasse — réconciliation admin + reconstruction du draft" do
+  let(:day1) { Date.today + 30 }
+  let(:day2) { Date.today + 31 }
+
+  def base_draft(terrasses:)
+    Reservations::Draft.new(
+      arrival_date: day1.iso8601, departure_date: (day1 + 1).iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233",
+      terrasses: terrasses
+    )
+  end
+
+  def build_stay!(terrasses:)
+    b = Reservations::Builder.new(draft: base_draft(terrasses: terrasses), admin: true, source: "manual")
+    raise "build failed: #{b.error_message}" unless b.run
+    b.stay
+  end
+
+  describe "Stays::DraftReconstructor" do
+    it "reconstruit fidèlement les terrasses {date, people} du séjour" do
+      stay = build_stay!(terrasses: [{ date: day1.iso8601, people: 8 },
+                                     { date: day2.iso8601, people: 5 }])
+
+      draft = Stays::DraftReconstructor.call(stay)
+      reconstructed = draft.terrasses.map { |t| t.symbolize_keys }
+                           .sort_by { |t| t[:date].to_s }
+      expect(reconstructed).to eq([{ date: day1.iso8601, people: 8 },
+                                   { date: day2.iso8601, people: 5 }])
+      # La terrasse ne pollue PAS la grille camping ni les entrées camping.
+      expect(draft.campings).to be_empty
+    end
+  end
+
+  describe "Stays::AdminUpdater" do
+    it "réconcilie les terrasses (ajout / modif / retrait) sans toucher au camping" do
+      stay = build_stay!(terrasses: [{ date: day1.iso8601, people: 8 }])
+      expect(CampingBooking.where(kind: "terrasse").count).to eq(1)
+
+      # Édition : la terrasse du jour 1 passe à 6 pers, une nouvelle au jour 2.
+      draft = base_draft(terrasses: [{ date: day1.iso8601, people: 6 },
+                                     { date: day2.iso8601, people: 3 }])
+      updater = Stays::AdminUpdater.new(stay: stay, draft: draft)
+      expect(updater.run).to be(true)
+
+      live = CampingBooking.where(kind: "terrasse").order(:from_date)
+      expect(live.map(&:people)).to eq([6, 3])
+      expect(live.map(&:price_cents)).to eq([1_500, 750]) # 6×250, 3×250
+      # Total du séjour réaligné (2 250 c).
+      expect(stay.reload.total_amount_cents).to eq(2_250)
+    end
+
+    it "retire toutes les terrasses quand le draft n'en porte plus" do
+      stay = build_stay!(terrasses: [{ date: day1.iso8601, people: 8 }])
+      # On garde un hébergement fictif ? Non : on ajoute une terrasse vide impossible.
+      # Le séjour doit rester valide → on met une nouvelle terrasse pour ne pas vider.
+      draft = base_draft(terrasses: [{ date: day2.iso8601, people: 2 }])
+      Stays::AdminUpdater.new(stay: stay, draft: draft).run
+
+      remaining = CampingBooking.where(kind: "terrasse")
+      expect(remaining.count).to eq(1)
+      expect(remaining.first.from_date).to eq(day2)
+    end
+  end
+end


### PR DESCRIPTION
## Décision Michael (20/07)

Les groupes « terrasse seule » (BBQ randonneurs…) : forfait **2,50 €/personne/jour**, saisi dans un **fieldset dédié** du formulaire séjour admin — **jamais proposé au funnel public**.

## Implémentation

- `CampingBooking kind: "terrasse"`, un enregistrement par JOUR (`[date, date+1)`), prix = people × 250 ; catégorie `:terrace` au devis, retranchée de `lodging_only_cents` (invariant #79 : la somme des parts = total, specs vertes).
- **Toute la logique camping existante scopée** pour exclure la terrasse (réconciliation, reconstruction, grille par nuit) — pas d'écrasement croisé.
- Public : `terrasses` non permis ET neutralisé dans le Builder hors admin (miroir `price_override`) — spec sur param forgé.
- Affichage : chip `🪑 Terrasse · N pers.` au calendrier (exclue du 💤 — pas une nuitée), icône 🪑 fiche client, libellés i18n FR/EN/NL.

## Vérifications

Suite complète sur la branche : **950 examples, 0 failures, EXIT=0** (11 nouveaux : création admin, param public forgé ignoré, round-trip édition, chip calendrier, pas de 💤). Contrôle visuel (fieldset + chip) dans la prochaine passe navigateur groupée.