### PR TITLE
feat(spaces): retrait « Les 2 salles » — remise duo automatique + conversion de l'historique

### DIFF
--- a/app/services/pricing/catalog.rb
+++ b/app/services/pricing/catalog.rb
@@ -85,6 +85,16 @@ module Pricing
         "journee"           => 11_000,  # 110 €
         "soiree"            =>  7_000,  # 70 €
         "journee_et_soiree" => 14_000   # 110 + extension soirée 30 €
+      }.freeze,
+      # Remise DUO (décision Michael 2026-07-20) : quand Grande Salle ET Petite
+      # Salle sont louées le MÊME jour, la MÊME période, un tarif duo remplace la
+      # somme des deux (< somme). L'ancien espace « Les 2 salles » disparaît au
+      # profit de cette remise automatique. Journée+soirée = jour duo + 150 €
+      # (extensions soirée des deux salles : 90 + 60).
+      "deux_salles" => {
+        "journee"           => 39_000,  # 390 € (au lieu de 290 + 140 = 430)
+        "soiree"            => 25_000,  # 250 €
+        "journee_et_soiree" => 54_000   # 390 + 150 = 540 €
       }.freeze
     }.freeze
 
@@ -105,6 +115,12 @@ module Pricing
         "journee"           => 15_000,  # 150 €
         "soiree"            =>  9_500,  # 95 €
         "journee_et_soiree" => 18_000   # 150 + extension soirée 30 €
+      }.freeze,
+      # Remise DUO week-end (cf. HALL_RATES["deux_salles"]).
+      "deux_salles" => {
+        "journee"           => 49_500,  # 495 € (au lieu de 380 + 190 = 570)
+        "soiree"            => 33_500,  # 335 €
+        "journee_et_soiree" => 64_500   # 495 + 150 = 645 €
       }.freeze
     }.freeze
 

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -106,8 +106,7 @@ class PricingModel
     lines.concat(van_lines)
     lines.concat(hamac_lines)
     lines.concat(experience_lines)
-    lines.concat(hall_lines)
-    lines.concat(space_slot_lines)
+    lines.concat(space_lines)
     lines.concat(meal_lines)
     lines.concat(terrace_lines)
     lines.concat(pizza_party_lines)
@@ -202,28 +201,45 @@ class PricingModel
     "cuisine_pro"  => "Cuisine professionnelle"
   }.freeze
 
-  def hall_lines
+  # --- Espaces (salles / cuisine pro) : lignes ponctuelles `halls` + grille
+  # nuit-par-nuit `space_slots`, avec REMISE DUO (décision Michael 2026-07-20).
+  #
+  # Les deux représentations produisent d'abord des ENTRÉES normalisées
+  # ({key, date, period, weekend, position_label, label, amount_cents}), puis un
+  # passage de combinaison remplace chaque paire Grande + Petite salle du MÊME
+  # jour et de la MÊME période par une seule ligne « Les 2 salles (duo) » au tarif
+  # duo (< somme). Périodes différentes le même jour → pas de duo, somme normale.
+  # Vaut au funnel public comme en admin (même moteur, décision figée).
+  DUO_KEYS = %w[grande_salle petite_salle].freeze
+
+  def space_lines
+    combine_duo(hall_space_entries + slot_space_entries)
+  end
+
+  # Entrées ponctuelles `halls` ({kind, date, period}). Tarif SEMAINE (comme
+  # historiquement — pas de logique week-end sur ce canal ponctuel).
+  def hall_space_entries
     Array(read(:halls)).filter_map do |entry|
-      rates = Pricing::Catalog::HALL_RATES[entry[:kind].to_s]
+      key   = entry[:kind].to_s
+      rates = Pricing::Catalog::HALL_RATES[key]
       next if rates.nil?
       period = entry[:period].to_s
-      unit = rates[period]
+      unit   = rates[period]
       next if unit.nil?
-      date_label = begin
-        Date.parse(entry[:date].to_s).strftime("%-d/%m")
-      rescue ArgumentError, TypeError
-        nil
-      end
+      date = parse_space_date(entry[:date])
+      date_label = date&.strftime("%-d/%m")
       next if date_label.nil?
       period_label = PERIOD_LABELS[period] || period
-      Line.new(label: "#{humanize(entry[:kind])} — #{date_label}, #{period_label}",
-               amount_cents: unit, category: :space)
+      { key: key, date: date, period: period, weekend: false,
+        position_label: date_label,
+        label: "#{humanize(key)} — #{date_label}, #{period_label}",
+        amount_cents: unit }
     end
   end
 
-  # --- Espaces (grille nuit-par-nuit) : tarif semaine ou week-end selon la date ---
-  # ven (wday=5) et sam (wday=6) → tarifs week-end ; autres jours → tarifs semaine.
-  def space_slot_lines
+  # Entrées grille nuit-par-nuit `space_slots` : tarif semaine ou week-end selon
+  # la date. ven (wday=5) et sam (wday=6) → tarifs week-end ; autres → semaine.
+  def slot_space_entries
     slots = read(:space_slots)
     return [] if slots.blank?
 
@@ -232,25 +248,72 @@ class PricingModel
     stay_dates = (arrival && departure) ? (arrival...departure).to_a : []
 
     slots.flat_map do |space_key, periods|
-      weekday_rates = Pricing::Catalog::HALL_RATES[space_key.to_s]
-      weekend_rates = Pricing::Catalog::HALL_RATES_WEEKEND[space_key.to_s]
+      key = space_key.to_s
+      weekday_rates = Pricing::Catalog::HALL_RATES[key]
+      weekend_rates = Pricing::Catalog::HALL_RATES_WEEKEND[key]
       next [] if weekday_rates.nil?
-      space_name = SPACE_NAMES[space_key.to_s] || space_key.to_s
+      space_name = SPACE_NAMES[key] || key
 
       Array(periods).each_with_index.filter_map do |period, night_idx|
         next if period.blank?
+        p       = period.to_s
         date    = stay_dates[night_idx]
-        weekend = date && [5, 6].include?(date.wday)
+        weekend = !!(date && [5, 6].include?(date.wday))
         rates   = (weekend && weekend_rates) ? weekend_rates : weekday_rates
-        unit    = rates[period.to_s]
+        unit    = rates[p]
         next if unit.nil?
-        period_label = PERIOD_LABELS[period.to_s] || period.to_s
-        Line.new(
-          label:        "#{space_name} — nuit #{night_idx + 1}, #{period_label}",
-          amount_cents: unit, category: :space
-        )
+        period_label = PERIOD_LABELS[p] || p
+        { key: key, date: date, period: p, weekend: weekend,
+          position_label: "nuit #{night_idx + 1}",
+          label: "#{space_name} — nuit #{night_idx + 1}, #{period_label}",
+          amount_cents: unit }
       end
     end.compact
+  end
+
+  # Combine les entrées d'espaces : chaque paire Grande + Petite salle sur le
+  # MÊME (date, période) → une ligne duo. Le reste passe inchangé. On apparie au
+  # plus UNE grande avec UNE petite par groupe (un éventuel doublon reste séparé).
+  def combine_duo(entries)
+    duo_groups = entries
+      .select { |e| e[:date] && DUO_KEYS.include?(e[:key]) }
+      .group_by { |e| [e[:date], e[:period]] }
+      .select { |_, es| es.map { |e| e[:key] }.uniq.sort == DUO_KEYS.sort }
+
+    # Le duo n'emprunte le tarif week-end que si les DEUX salles étaient
+    # week-end (cas propre de la grille un ven/sam) ; sinon tarif semaine.
+    group_weekend = duo_groups.transform_values { |es| es.all? { |e| e[:weekend] } }
+
+    consumed = Hash.new { |h, k| h[k] = { "grande_salle" => false, "petite_salle" => false } }
+    emitted  = {}
+
+    entries.filter_map do |e|
+      gid = [e[:date], e[:period]]
+      if e[:date] && DUO_KEYS.include?(e[:key]) && duo_groups.key?(gid) && !consumed[gid][e[:key]]
+        consumed[gid][e[:key]] = true
+        next nil if emitted[gid]
+        emitted[gid] = true
+        duo_line(e, group_weekend[gid])
+      else
+        Line.new(label: e[:label], amount_cents: e[:amount_cents], category: :space)
+      end
+    end
+  end
+
+  def duo_line(entry, weekend)
+    rates = weekend ? Pricing::Catalog::HALL_RATES_WEEKEND["deux_salles"]
+                    : Pricing::Catalog::HALL_RATES["deux_salles"]
+    unit = rates[entry[:period]]
+    period_label = PERIOD_LABELS[entry[:period]] || entry[:period]
+    Line.new(label: "Les 2 salles (duo) — #{entry[:position_label]}, #{period_label}",
+             amount_cents: unit, category: :space)
+  end
+
+  def parse_space_date(value)
+    return value if value.is_a?(Date)
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
   end
 
   # --- Repas : €/pers ---

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,7 +55,9 @@ LodgingComposition.find_or_create_by!(composite_lodging: lodging_25, component_l
 
 Space.find_or_create_by!(code: "TIL") { |s| s.name = "Tilleul"; s.description = "1er étage, 140 m2" }
 Space.find_or_create_by!(code: "SAU") { |s| s.name = "Saule"; s.description = "1er étage, 45 m2" }
-Space.find_or_create_by!(code: "T+S") { |s| s.name = "Les 2 salles"; s.description = "1er étage, 185 m2" }
+# « Les 2 salles » (code T+S) RETIRÉ (décision Michael 2026-07-20) : remplacé par
+# la remise DUO automatique au devis (Grande + Petite salle le même jour). Voir
+# rake spaces:convert_deux_salles pour la conversion de l'historique en prod.
 Space.find_or_create_by!(code: "CUI") { |s| s.name = "Cuisine professionnelle" }
 Space.find_or_create_by!(code: "CWK") { |s| s.name = "Coworking"; s.description = "Espace de travail avec écrans" }
 

--- a/lib/tasks/deux_salles.rake
+++ b/lib/tasks/deux_salles.rake
@@ -1,0 +1,160 @@
+namespace :spaces do
+  # One-shot idempotente : convertit l'historique de l'espace « Les 2 salles »
+  # (décision Michael 2026-07-20). Cet espace disparaît au profit d'une remise
+  # DUO automatique au devis (Grande + Petite salle le même jour). On veut donc,
+  # côté historique, voir les VRAIS espaces loués : chaque `SpaceReservation`
+  # vivante sur « Les 2 salles » devient DEUX `SpaceReservation` (Grande Salle +
+  # Petite Salle, MÊME date, MÊME duration) sur le MÊME `SpaceBooking` ; l'originale
+  # est DÉTRUITE (hard destroy — ce modèle n'a pas de soft-deletion). Le
+  # `price_cents` du SpaceBooking reste STRICTEMENT INCHANGÉ (le prix historique
+  # facturé est conservé tel quel) : on assert le total par booking et on rollback
+  # ce booking en cas d'écart. En fin d'APPLY, si plus AUCUNE réservation vivante
+  # ne pointe l'espace, il est SOFT-DELETÉ.
+  #
+  # DRY-RUN par défaut (rapport seul, ZÉRO écriture) ; APPLY=1 pour appliquer.
+  # Savepoint PAR SpaceBooking (`requires_new: true`) → le DRY-RUN annule réellement
+  # ses écritures, même sous fixtures transactionnelles des specs. Idempotente :
+  # un re-run après APPLY ne trouve plus de réservation vivante (espace soft-deleté
+  # ou vidé) → no-op.
+  #
+  # Capacité : Grande/Petite ont `capacity 1`. La conversion peut créer un
+  # dépassement THÉORIQUE un jour où l'une des salles était déjà réservée
+  # séparément → ces collisions sont DÉTECTÉES et listées (`converted_with_conflict`)
+  # SANS bloquer (l'historique est l'historique).
+  #
+  #   bundle exec rake spaces:convert_deux_salles          # DRY-RUN
+  #   APPLY=1 bundle exec rake spaces:convert_deux_salles  # RÉEL
+  #
+  # Résolution des espaces par CODE stable (puis noms candidats) — jamais d'id en
+  # dur (cf. SpaceComposition).
+  DEUX_SALLES_CODE  = "T+S".freeze
+  DEUX_SALLES_NAMES = ["Les 2 salles"].freeze
+  GRANDE_CODE  = "TIL".freeze
+  GRANDE_NAMES = ["Grande Salle", "Tilleul"].freeze
+  PETITE_CODE  = "SAU".freeze
+  PETITE_NAMES = ["Petite Salle", "Saule"].freeze
+
+  desc "Convertit l'historique « Les 2 salles » en paires Grande + Petite salle (prix conservé), puis soft-delete l'espace. DRY-RUN sauf APPLY=1"
+  task convert_deux_salles: :environment do
+    apply = ENV["APPLY"] == "1"
+
+    # Résolution `unscoped` : l'espace « Les 2 salles » peut déjà être soft-deleté
+    # (re-run) — on veut quand même le retrouver pour rapporter le no-op idempotent.
+    deux   = resolve_space_deux(DEUX_SALLES_CODE, DEUX_SALLES_NAMES)
+    grande = resolve_space_deux(GRANDE_CODE, GRANDE_NAMES)
+    petite = resolve_space_deux(PETITE_CODE, PETITE_NAMES)
+
+    abort "Espace Grande Salle introuvable (code #{GRANDE_CODE})." if grande.nil?
+    abort "Espace Petite Salle introuvable (code #{PETITE_CODE})." if petite.nil?
+
+    if deux.nil?
+      puts "=== spaces:convert_deux_salles ==="
+      puts "Aucun espace « Les 2 salles » (code #{DEUX_SALLES_CODE}) — rien à convertir (idempotent)."
+      next
+    end
+
+    report = {
+      bookings_scanned: [],           # SpaceBooking touchés
+      converted: [],                  # réservations converties (paires OK)
+      converted_with_conflict: [],    # paires créées MAIS collision capacité théorique
+      failed: [],                     # bookings en erreur (total modifié / exception)
+      space_soft_deleted: false
+    }
+
+    booking_ids = SpaceBooking.unscoped
+                              .joins(:space_reservations)
+                              .where(space_reservations: { space_id: deux.id })
+                              .distinct
+                              .pluck(:id)
+
+    booking_ids.each do |sb_id|
+      sb = SpaceBooking.unscoped.find(sb_id)
+      report[:bookings_scanned] << sb.id
+      originals = sb.space_reservations.where(space_id: deux.id).to_a
+
+      begin
+        ActiveRecord::Base.transaction(requires_new: true) do
+          before_price = sb.price_cents
+
+          originals.each do |res|
+            [grande, petite].each do |target|
+              nr = sb.space_reservations.create!(space: target, date: res.date, duration: res.duration)
+              if deux_salles_collision?(target: target, date: res.date, exclude_id: nr.id)
+                report[:converted_with_conflict] <<
+                  "SpaceBooking ##{sb.id} : #{target.name} le #{res.date} déjà réservé séparément (capacité dépassée)"
+              end
+            end
+            res.destroy!
+          end
+
+          # Total du SpaceBooking INCHANGÉ (jamais touché ici) — assert + rollback ce
+          # booking sinon (garde-fou : on ne reventile pas le prix historique).
+          sb.reload
+          if sb.price_cents != before_price
+            raise "Total modifié (#{before_price} → #{sb.price_cents})"
+          end
+
+          raise ActiveRecord::Rollback unless apply
+        end
+
+        report[:converted] << "SpaceBooking ##{sb.id} : #{originals.size} rés. → #{originals.size * 2} (Grande + Petite)"
+      rescue => e
+        report[:failed] << "SpaceBooking ##{sb.id} : #{e.class} #{e.message}"
+      end
+    end
+
+    # Soft-delete de l'espace SI plus aucune réservation vivante ne le pointe.
+    if apply && report[:failed].empty? && SpaceReservation.where(space_id: deux.id).none?
+      deux.soft_delete!(validate: false) unless deux.deleted_at.present?
+      report[:space_soft_deleted] = true
+    end
+
+    print_deux_salles_report(report, apply, deux)
+    abort("ÉCHEC : #{report[:failed].size} SpaceBooking en erreur.") if report[:failed].any?
+  end
+end
+
+# Résolution `unscoped` (inclut soft-deletés) : code stable d'abord, puis noms.
+def resolve_space_deux(code, names)
+  by_code = Space.unscoped.find_by(code: code)
+  return by_code if by_code
+
+  Space.unscoped.where(name: names).min_by { |s| names.index(s.name) || 99 }
+end
+
+# Une collision capacité (théorique) existe si une AUTRE réservation vivante
+# CONFIRMÉE occupe déjà `target` à `date` (capacity 1) — hors la réservation
+# qu'on vient de créer. L'historique n'est pas bloqué, seulement signalé.
+def deux_salles_collision?(target:, date:, exclude_id:)
+  SpaceReservation
+    .joins(:space_booking)
+    .where(space_id: target.id, date: date, space_bookings: { status: "confirmed" })
+    .where.not(id: exclude_id)
+    .exists?
+end
+
+def print_deux_salles_report(report, apply, deux)
+  puts "=== spaces:convert_deux_salles #{apply ? '(RÉEL)' : '(DRY-RUN)'} ==="
+  puts "Espace ciblé                      : ##{deux.id} #{deux.name.inspect} (code #{deux.code.inspect})"
+  puts "SpaceBooking touchés              : #{report[:bookings_scanned].size} #{deux_salles_ids(report[:bookings_scanned])}"
+  puts "Conversions (paires créées)       : #{report[:converted].size}"
+  report[:converted].each { |l| puts "  + #{l}" }
+  puts "Collisions capacité (non bloquantes) : #{report[:converted_with_conflict].size}"
+  report[:converted_with_conflict].each { |l| puts "  ! #{l}" }
+  unless report[:failed].empty?
+    puts "Échecs                            : #{report[:failed].size}"
+    report[:failed].each { |l| puts "  ✗ #{l}" }
+  end
+  if apply
+    puts(report[:space_soft_deleted] ?
+      "Espace « Les 2 salles » SOFT-DELETÉ (plus aucune réservation vivante)." :
+      "Espace « Les 2 salles » CONSERVÉ (réservations vivantes restantes ou échecs).")
+    puts "OK — conversion appliquée."
+  else
+    puts "DRY-RUN — aucune écriture. Relancer avec APPLY=1 pour appliquer."
+  end
+end
+
+def deux_salles_ids(list)
+  list.empty? ? "" : "→ #{list.sort.join(', ')}"
+end

--- a/spec/services/pricing_model_spec.rb
+++ b/spec/services/pricing_model_spec.rb
@@ -108,6 +108,87 @@ RSpec.describe PricingModel do
       expect(quote.total_cents).to eq(33_000)
     end
 
+    describe "remise DUO Grande + Petite salle (décision Michael 2026-07-20)" do
+      it "duo journée SEMAINE — 1 ligne « Les 2 salles (duo) » = 390 € (au lieu de 430 €)" do
+        quote = described_class.quote(draft(halls: [
+          { kind: "grande_salle", date: "2026-09-01", period: "journee" },
+          { kind: "petite_salle", date: "2026-09-01", period: "journee" }
+        ]))
+        expect(quote.total_cents).to eq(39_000)
+        expect(quote.breakdown.size).to eq(1)
+        expect(quote.breakdown.first[:label]).to include("Les 2 salles (duo)")
+        expect(quote.spaces_cents).to eq(39_000)
+      end
+
+      it "duo soirée SEMAINE = 250 €" do
+        quote = described_class.quote(draft(halls: [
+          { kind: "grande_salle", date: "2026-09-01", period: "soiree" },
+          { kind: "petite_salle", date: "2026-09-01", period: "soiree" }
+        ]))
+        expect(quote.total_cents).to eq(25_000)
+        expect(quote.breakdown.size).to eq(1)
+      end
+
+      it "duo journée + soirée SEMAINE = 540 € (jour duo + 150 €)" do
+        quote = described_class.quote(draft(halls: [
+          { kind: "grande_salle", date: "2026-09-01", period: "journee_et_soiree" },
+          { kind: "petite_salle", date: "2026-09-01", period: "journee_et_soiree" }
+        ]))
+        expect(quote.total_cents).to eq(54_000)
+        expect(quote.breakdown.size).to eq(1)
+      end
+
+      it "duo WEEK-END (grille un vendredi) — journée = 495 €, soirée = 335 €, jour+soirée = 645 €" do
+        {
+          "journee" => 49_500, "soiree" => 33_500, "journee_et_soiree" => 64_500
+        }.each do |period, expected|
+          quote = described_class.quote(draft(
+            arrival_date: Date.parse("2026-09-04"),      # vendredi (week-end)
+            departure_date: Date.parse("2026-09-05"),
+            space_slots: { "grande_salle" => [period], "petite_salle" => [period] }
+          ))
+          expect(quote.total_cents).to eq(expected), "période #{period}"
+          expect(quote.breakdown.size).to eq(1)
+          expect(quote.breakdown.first[:label]).to include("Les 2 salles (duo)")
+        end
+      end
+
+      it "PAS de duo si périodes différentes le même jour — somme normale, 2 lignes" do
+        quote = described_class.quote(draft(halls: [
+          { kind: "grande_salle", date: "2026-09-01", period: "journee" }, # 290 €
+          { kind: "petite_salle", date: "2026-09-01", period: "soiree" }   #  90 €
+        ]))
+        expect(quote.total_cents).to eq(38_000)
+        expect(quote.breakdown.size).to eq(2)
+        expect(quote.breakdown.map { |l| l[:label] }.join).not_to include("duo")
+      end
+
+      it "PAS de duo si dates différentes — somme normale (grande le 1er, petite le 2)" do
+        quote = described_class.quote(draft(halls: [
+          { kind: "grande_salle", date: "2026-09-01", period: "journee" }, # 290 €
+          { kind: "petite_salle", date: "2026-09-02", period: "journee" }  # 140 €
+        ]))
+        expect(quote.total_cents).to eq(43_000)
+        expect(quote.breakdown.size).to eq(2)
+      end
+
+      it "invariant #79 sur un séjour composite avec duo : bundle + spaces == total hors activités" do
+        quote = described_class.quote(draft(
+          lodging: hulotte, nights: 1,                       # 485 €
+          halls: [
+            { kind: "grande_salle", date: "2026-09-01", period: "journee" },
+            { kind: "petite_salle", date: "2026-09-01", period: "journee" }, # duo 390 €
+            { kind: "cuisine_pro",  date: "2026-09-01", period: "journee" }  # 110 €
+          ]
+        ))
+        expect(quote.spaces_cents).to eq(50_000)             # duo 390 + cuisine 110
+        expect(quote.lodging_bundle_cents).to eq(48_500)     # Hulotte 485
+        expect(quote.lodging_bundle_cents + quote.spaces_cents)
+          .to eq(quote.total_excluding_experiences_cents)
+        expect(quote.total_cents).to eq(98_500)
+      end
+    end
+
     it "€/pers (repas végé midi) — 10 pers × 15 € = 150 €" do
       quote = described_class.quote(draft(meals: [{ kind: "repas_vege_midi", people: 10 }]))
       expect(quote.total_cents).to eq(15_000)

--- a/spec/tasks/spaces_convert_deux_salles_spec.rb
+++ b/spec/tasks/spaces_convert_deux_salles_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+require "rake"
+
+# Conversion de l'historique « Les 2 salles » en paires Grande + Petite salle
+# (décision Michael 2026-07-20). Chaque SpaceReservation vivante sur l'espace
+# « Les 2 salles » devient DEUX réservations (Grande + Petite, même date, même
+# duration) sur le MÊME SpaceBooking ; l'originale est détruite ; le prix du
+# SpaceBooking reste inchangé. En fin d'APPLY, l'espace est soft-deleté.
+RSpec.describe "spaces:convert_deux_salles", type: :task do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("spaces:convert_deux_salles")
+  end
+
+  def run_task(apply: false)
+    task = Rake::Task["spaces:convert_deux_salles"]
+    task.reenable
+    previous_apply = ENV["APPLY"]
+    ENV["APPLY"] = apply ? "1" : nil
+    original = $stdout
+    $stdout = StringIO.new
+    task.invoke
+    $stdout.string
+  ensure
+    $stdout = original
+    ENV["APPLY"] = previous_apply
+  end
+
+  let!(:deux)   { Space.create!(name: "Les 2 salles", code: "T+S", capacity: 1) }
+  let!(:grande) { Space.create!(name: "Grande Salle", code: "TIL", capacity: 1) }
+  let!(:petite) { Space.create!(name: "Petite Salle", code: "SAU", capacity: 1) }
+
+  let(:from) { Date.new(2024, 6, 1) }
+  let(:to)   { Date.new(2024, 6, 2) }
+
+  def build_space_booking(status: "confirmed", price_cents: 43_000)
+    SpaceBooking.create!(firstname: "Ada", group_name: "Les Analytiques",
+                         from_date: from, to_date: to, status: status,
+                         price_cents: price_cents)
+  end
+
+  context "DRY-RUN (par défaut)" do
+    it "n'écrit rien : ni conversion, ni suppression, ni soft-delete" do
+      sb = build_space_booking
+      sb.space_reservations.create!(space: deux, date: from, duration: "day")
+
+      expect { run_task(apply: false) }.not_to change(SpaceReservation, :count)
+      expect(sb.space_reservations.reload.map(&:space_id)).to eq([deux.id])
+      expect(Space.exists?(deux.id)).to be(true)
+    end
+  end
+
+  context "APPLY — conversion d'une réservation" do
+    it "remplace la résa par une paire Grande + Petite (même date, même duration), prix conservé" do
+      sb = build_space_booking(price_cents: 43_000)
+      sb.space_reservations.create!(space: deux, date: from, duration: "fullday")
+
+      run_task(apply: true)
+
+      reservations = sb.space_reservations.reload
+      expect(reservations.map(&:space_id)).to contain_exactly(grande.id, petite.id)
+      expect(reservations.map(&:date).uniq).to eq([from])
+      expect(reservations.map(&:duration).uniq).to eq(["fullday"])
+      expect(sb.reload.price_cents).to eq(43_000)     # total INCHANGÉ
+      expect(SpaceReservation.where(space_id: deux.id)).to be_empty
+    end
+
+    it "convertit plusieurs réservations du même booking (N → 2N)" do
+      sb = build_space_booking
+      sb.space_reservations.create!(space: deux, date: from, duration: "day")
+      sb.space_reservations.create!(space: deux, date: to, duration: "evening")
+
+      run_task(apply: true)
+
+      expect(sb.space_reservations.reload.count).to eq(4)
+      expect(sb.space_reservations.where(space_id: grande.id).pluck(:date)).to contain_exactly(from, to)
+    end
+  end
+
+  context "collision de capacité (jour déjà réservé séparément)" do
+    it "convertit quand même MAIS liste la collision (non bloquant)" do
+      # Une Grande Salle déjà réservée (confirmée) le même jour → dépassement.
+      other = build_space_booking
+      other.space_reservations.create!(space: grande, date: from, duration: "day")
+
+      sb = build_space_booking
+      sb.space_reservations.create!(space: deux, date: from, duration: "day")
+
+      output = run_task(apply: true)
+
+      expect(sb.space_reservations.reload.map(&:space_id)).to contain_exactly(grande.id, petite.id)
+      expect(output).to include("Collisions capacité")
+      expect(output).to match(/Grande Salle le #{from} déjà réservé/)
+    end
+  end
+
+  context "soft-delete de l'espace en fin d'APPLY" do
+    it "soft-delete « Les 2 salles » quand plus aucune réservation vivante ne le pointe" do
+      sb = build_space_booking
+      sb.space_reservations.create!(space: deux, date: from, duration: "day")
+
+      run_task(apply: true)
+
+      expect(Space.exists?(deux.id)).to be(false)          # hors du default_scope
+      expect(Space.unscoped.find(deux.id).deleted_at).to be_present
+    end
+  end
+
+  context "idempotence" do
+    it "un second APPLY ne crée aucune nouvelle réservation" do
+      sb = build_space_booking
+      sb.space_reservations.create!(space: deux, date: from, duration: "day")
+
+      run_task(apply: true)
+      expect { run_task(apply: true) }.not_to change(SpaceReservation, :count)
+    end
+  end
+end


### PR DESCRIPTION
## Décisions Michael (20/07)

L'espace « Les 2 salles » disparaît : les détails d'un séjour montrent les VRAIS espaces. La remise duo s'applique automatiquement quand Grande + Petite salle sont prises le même jour, même période — tarifs confirmés : jour 390/495 € (semaine/WE), soirée 250/335 €, jour+soirée = jour duo + 150 €.

## Implémentation

- Barème duo (`deux_salles`) semaine/week-end ; le devis remplace chaque paire (même date, même période) par UNE ligne « Les 2 salles (duo) » — plus clair pour le client, ventilation de persistance inchangée (les deux SpaceReservation restent créées séparément). Invariant #79 (somme des parts = total) spécifié sur un séjour composite.
- Le duo s'applique au funnel public comme en admin (même PricingModel) — voulu.
- **Rake `spaces:convert_deux_salles`** (dry-run/APPLY, idempotente) : chaque réservation « Les 2 salles » devient une PAIRE Grande + Petite (même date/période), prix du booking conservé (assert + rollback), collisions de capacité historiques listées sans bloquer, soft-delete de l'espace en fin d'APPLY.

## Vérifications

Suite complète sur la branche : **966 examples, 0 failures, EXIT=0**. Conversion rejouée sur la copie prod locale — rapport en commentaire.