### PR TITLE
Paramètres > Tarifs : gérer tous les prix depuis l'admin (#124)

### DIFF
--- a/app/controllers/rates_controller.rb
+++ b/app/controllers/rates_controller.rb
@@ -1,0 +1,47 @@
+# Paramètres > Tarifs (issue #124) : édition des montants du barème sans
+# redéploiement. La liste est groupée par domaine ; chaque ligne s'édite en
+# euros (ou en % pour le taux d'acompte) et est convertie en cents.
+class RatesController < BaseController
+  before_action :get_rate, only: [:update]
+
+  breadcrumb "Tarifs", :rates_path, match: :exact
+
+  def index
+    @grouped_rates = Rate.grouped
+  end
+
+  def update
+    if @rate.update(amount_cents: submitted_amount_cents)
+      Pricing::Rates.reset!
+      redirect_to rates_path, notice: "Le tarif « #{@rate.label.presence || @rate.key} » a été mis à jour."
+    else
+      @grouped_rates = Rate.grouped
+      flash.now[:alert] = @rate.errors.full_messages.to_sentence
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def get_rate
+    @rate = Rate.find(params[:id])
+  end
+
+  # Montant saisi : euros (virgule tolérée) pour les tarifs, % pour un taux.
+  # Une saisie vide ou non numérique retombe sur -1 pour déclencher la
+  # validation « ≥ 0 » plutôt que de passer silencieusement à zéro.
+  def submitted_amount_cents
+    raw = params.dig(:rate, :amount).to_s.strip.tr(",", ".")
+    return -1 unless raw.match?(/\A-?\d+(\.\d+)?\z/)
+
+    @rate.percent? ? raw.to_f.round : (raw.to_f * 100).round
+  end
+
+  def set_presenters
+    @menu_presenter = Components::MenuPresenter.new(
+      active_primary: "settings",
+      active_secondary: "rates"
+    )
+    @settings_view = true
+  end
+end

--- a/app/models/rate.rb
+++ b/app/models/rate.rb
@@ -1,0 +1,57 @@
+# Tarif paramétrable en base (issue #124).
+#
+# Une ligne = une clé du barème (ex. `camping.tente_per_person_night`) et son
+# montant. `Pricing::Catalog` lit cette table EN PREMIER et retombe sur ses
+# constantes codées quand la clé manque — la base ne fait donc jamais varier un
+# prix tant qu'elle n'a pas été seedée (`rake rates:seed_from_catalog`).
+#
+# `unit` distingue les montants monétaires (`cents`, l'écrasante majorité) des
+# valeurs exprimées en pourcentage (`percent`, ex. le taux d'acompte par
+# défaut). L'écran d'édition rend les deux différemment.
+class Rate < ApplicationRecord
+  UNITS = %w[cents percent].freeze
+
+  # Regroupement d'affichage de l'écran Paramètres > Tarifs, dans l'ordre.
+  # Chaque entrée : libellé du groupe => préfixes de clés qui y tombent.
+  GROUPS = {
+    "Hébergements"  => %w[lodging.],
+    "Salles"        => %w[hall. hall_weekend.],
+    "Camping & van" => %w[camping. van. terrace. hamac.],
+    "Repas"         => %w[meal. pizza_party.]
+  }.freeze
+
+  OTHER_GROUP = "Divers".freeze
+
+  has_paper_trail
+
+  validates :key, presence: true, uniqueness: true
+  validates :amount_cents,
+            presence: true,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :unit, inclusion: { in: UNITS }
+
+  scope :ordered, -> { order(key: :asc) }
+
+  def percent? = unit == "percent"
+
+  def group
+    GROUPS.each do |name, prefixes|
+      return name if prefixes.any? { |prefix| key.to_s.start_with?(prefix) }
+    end
+    OTHER_GROUP
+  end
+
+  # Tous les tarifs groupés pour l'écran d'édition, groupes dans l'ordre déclaré.
+  def self.grouped
+    by_group = ordered.group_by(&:group)
+    (GROUPS.keys + [OTHER_GROUP]).filter_map do |name|
+      rates = by_group[name]
+      [name, rates] if rates.present?
+    end
+  end
+
+  # Valeur affichable/éditable : euros pour `cents`, pourcentage pour `percent`.
+  def amount
+    percent? ? amount_cents : amount_cents / 100.0
+  end
+end

--- a/app/services/concerns/meal_composition.rb
+++ b/app/services/concerns/meal_composition.rb
@@ -22,7 +22,7 @@ module MealComposition
       kind   = entry[:kind].to_s
       people = entry[:people].to_i
       next if kind.blank? || people < 1
-      next unless Pricing::Catalog::MEAL_PER_PERSON_CENTS.key?(kind)
+      next unless Pricing::Catalog.meal_kinds.include?(kind)
       { kind: kind, date: parse_meal_date(entry[:date]), people: people }
     end
   end
@@ -33,7 +33,7 @@ module MealComposition
 
   # Prix TVAC d'une entrée repas (source unique = Catalog, comme `meal_lines`).
   def meal_entry_price_cents(entry)
-    Pricing::Catalog::MEAL_PER_PERSON_CENTS[entry[:kind].to_s].to_i * entry[:people].to_i
+    Pricing::Catalog.meal_per_person_cents(entry[:kind]).to_i * entry[:people].to_i
   end
 
   # Crée les MealOrder du séjour depuis les entrées du draft. Retourne la somme

--- a/app/services/concerns/terrace_composition.rb
+++ b/app/services/concerns/terrace_composition.rb
@@ -40,7 +40,7 @@ module TerraceComposition
 
   # Prix TVAC d'une entrée terrasse (source unique = Catalog, comme `terrace_lines`).
   def terrace_entry_price_cents(entry)
-    Pricing::Catalog::TERRACE_PER_PERSON_DAY_CENTS * entry[:people].to_i
+    Pricing::Catalog.terrace_per_person_day_cents * entry[:people].to_i
   end
 
   # Persiste la terrasse en N CampingBooking `kind: "terrasse"` (un par JOUR).

--- a/app/services/pricing/catalog.rb
+++ b/app/services/pricing/catalog.rb
@@ -137,13 +137,113 @@ module Pricing
     PIZZA_PARTY_BASE_CENTS = 4_000
     PIZZA_PARTY_PER_PERSON_CENTS = 700
 
-    def lodging_rate(name)
-      LODGING_RATES[name]
+    # ------------------------------------------------------------------
+    # Façade de lecture (issue #124) : BASE D'ABORD, constantes en repli.
+    #
+    # Chaque accesseur ci-dessous interroge `Pricing::Rates` (table `rates`,
+    # mémoïsée pour la requête) puis retombe sur la constante codée juste
+    # au-dessus quand la clé n'est pas paramétrée. Les constantes restent la
+    # source du seed (`rake rates:seed_from_catalog`) et le filet de sécurité :
+    # à barème identique en base, aucun devis ne bouge.
+    #
+    # Les consommateurs (PricingModel, drafts, vues) DOIVENT passer par ces
+    # méthodes et non plus lire les constantes directement.
+    # ------------------------------------------------------------------
+
+    # Slug de clé stable pour un nom d'hébergement ("La Chevêche" → la_cheveche).
+    def lodging_key(name)
+      I18n.transliterate(name.to_s).tr("-", " ").parameterize(separator: "_")
     end
 
-    # Prix d'un hamac (RentalItem) pour une nuit. Lookup DB d'abord, fallback
-    # sur HAMAC_FALLBACK_CENTS si le RentalItem n'est pas encore seedé.
+    def default_deposit_rate
+      Pricing::Rates.rate_or("deposit.default_rate", DEFAULT_DEPOSIT_RATE)
+    end
+
+    def dog_supplement_cents
+      Pricing::Rates.cents_or("dog.supplement", DOG_SUPPLEMENT_CENTS)
+    end
+
+    def camping_per_person_night_cents(kind)
+      return nil unless CAMPING_PER_PERSON_NIGHT_CENTS.key?(kind.to_s)
+
+      Pricing::Rates.cents_or("camping.#{kind}_per_person_night",
+                              CAMPING_PER_PERSON_NIGHT_CENTS[kind.to_s])
+    end
+
+    def van_per_night_cents
+      Pricing::Rates.cents_or("van.per_night", VAN_PER_NIGHT_CENTS)
+    end
+
+    def terrace_per_person_day_cents
+      Pricing::Rates.cents_or("terrace.per_person_day", TERRACE_PER_PERSON_DAY_CENTS)
+    end
+
+    def meal_per_person_cents(kind)
+      return nil unless MEAL_PER_PERSON_CENTS.key?(kind.to_s)
+
+      Pricing::Rates.cents_or("meal.#{kind}.per_person", MEAL_PER_PERSON_CENTS[kind.to_s])
+    end
+
+    def meal_kinds
+      MEAL_PER_PERSON_CENTS.keys
+    end
+
+    def pizza_party_base_cents
+      Pricing::Rates.cents_or("pizza_party.base", PIZZA_PARTY_BASE_CENTS)
+    end
+
+    def pizza_party_per_person_cents
+      Pricing::Rates.cents_or("pizza_party.per_person", PIZZA_PARTY_PER_PERSON_CENTS)
+    end
+
+    # Barème d'un espace pour une période, tarif semaine ou week-end.
+    # Retourne nil si l'espace ou la période n'existe pas au catalogue.
+    def hall_rate_cents(kind, period, weekend: false)
+      # Un espace sans grille week-end retombe sur son tarif semaine (parité
+      # avec le comportement historique de PricingModel).
+      weekend  = weekend && HALL_RATES_WEEKEND.key?(kind.to_s)
+      table    = weekend ? HALL_RATES_WEEKEND : HALL_RATES
+      fallback = table.dig(kind.to_s, period.to_s)
+      return nil if fallback.nil?
+
+      Pricing::Rates.cents_or(hall_key(kind, period, weekend: weekend), fallback)
+    end
+
+    # true si l'espace existe au catalogue (semaine — référence structurelle).
+    def hall_kind?(kind)
+      HALL_RATES.key?(kind.to_s)
+    end
+
+    def hall_key(kind, period, weekend: false)
+      "#{weekend ? 'hall_weekend' : 'hall'}.#{kind}.#{period}"
+    end
+
+    def lodging_rate(name)
+      base = LODGING_RATES[name]
+      return nil if base.nil?
+
+      slug = lodging_key(name)
+      Pricing::LodgingRate.new(
+        name: base.name,
+        first_night_cents: Pricing::Rates.cents_or("lodging.#{slug}.first_night",
+                                                   base.first_night_cents),
+        extra_night_cents: Pricing::Rates.cents_or("lodging.#{slug}.extra_night",
+                                                   base.extra_night_cents),
+        named_packages: base.named_packages.to_h { |nights, package|
+          [nights, package.merge(
+            amount_cents: Pricing::Rates.cents_or("lodging.#{slug}.package_#{nights}",
+                                                  package[:amount_cents])
+          )]
+        }
+      )
+    end
+
+    # Prix d'un hamac (RentalItem) pour une nuit. Tarif paramétré d'abord, puis
+    # lookup RentalItem, puis fallback sur HAMAC_FALLBACK_CENTS.
     def hamac_rate(kind)
+      configured = Pricing::Rates.cents("hamac.#{kind}")
+      return configured if configured
+
       db_name = kind.to_s == "double" ? "Hamac double" : "Hamac simple"
       RentalItem.find_by(name: db_name)&.price_cents || HAMAC_FALLBACK_CENTS[kind.to_s]
     end

--- a/app/services/pricing/rates.rb
+++ b/app/services/pricing/rates.rb
@@ -1,0 +1,56 @@
+module Pricing
+  # Façade de lecture des tarifs paramétrés en base (issue #124).
+  #
+  # `Pricing::Catalog` interroge ce module AVANT ses constantes : si la clé
+  # existe en base, c'est elle qui gagne ; sinon on retombe sur la constante
+  # codée. Tant que `rake rates:seed_from_catalog` n'a pas tourné, ou tant que
+  # la table reflète fidèlement le catalogue, aucun devis ne change.
+  #
+  # Le chargement est mémoïsé pour la durée de la requête (via
+  # `ActiveSupport::CurrentAttributes`, remis à zéro par Rails à chaque requête
+  # et à chaque job) : un devis composite ne fait donc qu'UN seul SELECT.
+  module Rates
+    module_function
+
+    # Montant en cents pour `key`, ou nil si la clé n'est pas paramétrée.
+    def cents(key)
+      lookup[key.to_s]
+    end
+
+    # Montant en cents, avec repli explicite sur la valeur codée.
+    def cents_or(key, fallback)
+      cents(key) || fallback
+    end
+
+    # Valeur décimale (0.5 pour 50 %) d'une clé stockée en `percent`.
+    def rate_or(key, fallback)
+      value = cents(key)
+      value.nil? ? fallback : value / 100.0
+    end
+
+    def lookup
+      Pricing::Rates::Store.lookup ||= load_lookup
+    end
+
+    def reset!
+      Pricing::Rates::Store.lookup = nil
+    end
+
+    def load_lookup
+      return {} unless table_available?
+
+      Rate.pluck(:key, :amount_cents).to_h
+    end
+
+    def table_available?
+      Rate.table_exists?
+    rescue ActiveRecord::NoDatabaseError, ActiveRecord::ConnectionNotEstablished
+      false
+    end
+
+    # Porte-mémoire remis à zéro par Rails à chaque requête / job.
+    class Store < ActiveSupport::CurrentAttributes
+      attribute :lookup
+    end
+  end
+end

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -90,11 +90,11 @@ class PricingModel
   end
 
   # API publique (AC-T2-12). Retourne un Quote.
-  def self.quote(stay_draft, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE)
+  def self.quote(stay_draft, deposit_rate: Pricing::Catalog.default_deposit_rate)
     new(stay_draft, deposit_rate: deposit_rate).quote
   end
 
-  def initialize(stay_draft, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE)
+  def initialize(stay_draft, deposit_rate: Pricing::Catalog.default_deposit_rate)
     @draft = stay_draft
     @deposit_rate = deposit_rate
   end
@@ -164,7 +164,7 @@ class PricingModel
   # --- Camping / bivouac : €/pers/nuit ---
   def camping_lines
     Array(read(:campings)).filter_map do |entry|
-      unit = Pricing::Catalog::CAMPING_PER_PERSON_NIGHT_CENTS[entry[:kind].to_s]
+      unit = Pricing::Catalog.camping_per_person_night_cents(entry[:kind])
       next if unit.nil?
       people = entry[:people].to_i
       nights = entry[:nights].to_i
@@ -184,7 +184,7 @@ class PricingModel
       nights = entry[:nights].to_i
       next if nights < 1
       Line.new(label: "Van / camping-car — #{nights} nuit(s)",
-               amount_cents: Pricing::Catalog::VAN_PER_NIGHT_CENTS * nights, category: :van)
+               amount_cents: Pricing::Catalog.van_per_night_cents * nights, category: :van)
     end
   end
 
@@ -220,11 +220,10 @@ class PricingModel
   # historiquement — pas de logique week-end sur ce canal ponctuel).
   def hall_space_entries
     Array(read(:halls)).filter_map do |entry|
-      key   = entry[:kind].to_s
-      rates = Pricing::Catalog::HALL_RATES[key]
-      next if rates.nil?
+      key = entry[:kind].to_s
+      next unless Pricing::Catalog.hall_kind?(key)
       period = entry[:period].to_s
-      unit   = rates[period]
+      unit   = Pricing::Catalog.hall_rate_cents(key, period)
       next if unit.nil?
       date = parse_space_date(entry[:date])
       date_label = date&.strftime("%-d/%m")
@@ -249,9 +248,7 @@ class PricingModel
 
     slots.flat_map do |space_key, periods|
       key = space_key.to_s
-      weekday_rates = Pricing::Catalog::HALL_RATES[key]
-      weekend_rates = Pricing::Catalog::HALL_RATES_WEEKEND[key]
-      next [] if weekday_rates.nil?
+      next [] unless Pricing::Catalog.hall_kind?(key)
       space_name = SPACE_NAMES[key] || key
 
       Array(periods).each_with_index.filter_map do |period, night_idx|
@@ -259,8 +256,7 @@ class PricingModel
         p       = period.to_s
         date    = stay_dates[night_idx]
         weekend = !!(date && [5, 6].include?(date.wday))
-        rates   = (weekend && weekend_rates) ? weekend_rates : weekday_rates
-        unit    = rates[p]
+        unit    = Pricing::Catalog.hall_rate_cents(key, p, weekend: weekend)
         next if unit.nil?
         period_label = PERIOD_LABELS[p] || p
         { key: key, date: date, period: p, weekend: weekend,
@@ -301,9 +297,7 @@ class PricingModel
   end
 
   def duo_line(entry, weekend)
-    rates = weekend ? Pricing::Catalog::HALL_RATES_WEEKEND["deux_salles"]
-                    : Pricing::Catalog::HALL_RATES["deux_salles"]
-    unit = rates[entry[:period]]
+    unit = Pricing::Catalog.hall_rate_cents("deux_salles", entry[:period], weekend: weekend)
     period_label = PERIOD_LABELS[entry[:period]] || entry[:period]
     Line.new(label: "Les 2 salles (duo) — #{entry[:position_label]}, #{period_label}",
              amount_cents: unit, category: :space)
@@ -319,7 +313,7 @@ class PricingModel
   # --- Repas : €/pers ---
   def meal_lines
     Array(read(:meals)).filter_map do |entry|
-      unit = Pricing::Catalog::MEAL_PER_PERSON_CENTS[entry[:kind].to_s]
+      unit = Pricing::Catalog.meal_per_person_cents(entry[:kind])
       next if unit.nil?
       people = entry[:people].to_i
       next if people < 1
@@ -344,7 +338,7 @@ class PricingModel
       end
       label = date_label ? "Terrasse — #{date_label}, #{people} pers" : "Terrasse — #{people} pers"
       Line.new(label: label,
-               amount_cents: Pricing::Catalog::TERRACE_PER_PERSON_DAY_CENTS * people,
+               amount_cents: Pricing::Catalog.terrace_per_person_day_cents * people,
                category: :terrace)
     end
   end
@@ -387,8 +381,8 @@ class PricingModel
   def pizza_party_lines
     Array(read(:pizza_parties)).filter_map do |entry|
       people = entry[:people].to_i
-      amount = Pricing::Catalog::PIZZA_PARTY_BASE_CENTS +
-               Pricing::Catalog::PIZZA_PARTY_PER_PERSON_CENTS * people
+      amount = Pricing::Catalog.pizza_party_base_cents +
+               Pricing::Catalog.pizza_party_per_person_cents * people
       Line.new(label: "Pizza Party — allumage + #{people} pers",
                amount_cents: amount)
     end
@@ -400,7 +394,7 @@ class PricingModel
     return [] if dogs < 1
     # Le flow auto ne facture qu'un seul chien, quel que soit le nombre demandé
     # (multi-chiens = hors flow, traité manuellement par Malau — AC-T2-09b/15).
-    [Line.new(label: "Supplément chien", amount_cents: Pricing::Catalog::DOG_SUPPLEMENT_CENTS)]
+    [Line.new(label: "Supplément chien", amount_cents: Pricing::Catalog.dog_supplement_cents)]
   end
 
   def read(method)

--- a/app/services/rates/seed_from_catalog.rb
+++ b/app/services/rates/seed_from_catalog.rb
@@ -1,0 +1,143 @@
+module Rates
+  # Matérialise TOUTES les valeurs de `Pricing::Catalog` dans la table `rates`
+  # (issue #124). Idempotent : relancer ne crée pas de doublon et n'écrase pas
+  # un montant déjà édité par l'équipe — sauf en mode `force: true`.
+  #
+  # Le seed n'invente aucun prix : à l'issue d'un run, chaque clé porte
+  # exactement le montant du catalogue, donc aucun devis ne change.
+  class SeedFromCatalog
+    Result = Struct.new(:created, :updated, :unchanged, :skipped, keyword_init: true) do
+      def total = created + updated + unchanged + skipped
+
+      def to_s
+        "#{total} tarifs — #{created} créés, #{updated} mis à jour, " \
+          "#{unchanged} inchangés, #{skipped} conservés (édités en base)"
+      end
+    end
+
+    def initialize(force: false)
+      @force = force
+    end
+
+    def run
+      result = Result.new(created: 0, updated: 0, unchanged: 0, skipped: 0)
+
+      entries.each do |entry|
+        rate = Rate.find_by(key: entry[:key])
+
+        if rate.nil?
+          Rate.create!(entry)
+          result.created += 1
+        elsif rate.amount_cents == entry[:amount_cents]
+          rate.update!(label: entry[:label], unit: entry[:unit])
+          result.unchanged += 1
+        elsif @force
+          rate.update!(entry)
+          result.updated += 1
+        else
+          result.skipped += 1
+        end
+      end
+
+      Pricing::Rates.reset!
+      result
+    end
+
+    # Toutes les entrées du catalogue, à plat.
+    def entries
+      lodging_entries + hall_entries + outdoor_entries + meal_entries + misc_entries
+    end
+
+    private
+
+    def entry(key, amount_cents, label, unit: "cents")
+      { key: key, amount_cents: amount_cents, label: label, unit: unit }
+    end
+
+    def lodging_entries
+      Pricing::Catalog::LODGING_RATES.flat_map do |name, rate|
+        slug = Pricing::Catalog.lodging_key(name)
+        rows = [
+          entry("lodging.#{slug}.first_night", rate.first_night_cents, "#{name} — première nuit"),
+          entry("lodging.#{slug}.extra_night", rate.extra_night_cents, "#{name} — nuit suivante")
+        ]
+        rate.named_packages.each do |nights, package|
+          rows << entry("lodging.#{slug}.package_#{nights}",
+                        package[:amount_cents],
+                        "#{name} — #{package[:label]} (#{nights} nuits)")
+        end
+        rows
+      end
+    end
+
+    def hall_entries
+      [[Pricing::Catalog::HALL_RATES, "hall", "semaine"],
+       [Pricing::Catalog::HALL_RATES_WEEKEND, "hall_weekend", "week-end"]].flat_map do |table, prefix, period_label|
+        table.flat_map do |kind, periods|
+          periods.map do |period, amount|
+            entry("#{prefix}.#{kind}.#{period}", amount,
+                  "#{hall_label(kind)} — #{PERIOD_LABELS.fetch(period, period)} (#{period_label})")
+          end
+        end
+      end
+    end
+
+    PERIOD_LABELS = {
+      "journee"           => "journée",
+      "soiree"            => "soirée",
+      "journee_et_soiree" => "journée + soirée"
+    }.freeze
+
+    HALL_LABELS = {
+      "grande_salle" => "Grande Salle",
+      "petite_salle" => "Petite Salle",
+      "cuisine_pro"  => "Cuisine professionnelle",
+      "deux_salles"  => "Les 2 salles (duo)"
+    }.freeze
+
+    def hall_label(kind) = HALL_LABELS.fetch(kind, kind.to_s.tr("_", " ").capitalize)
+
+    def outdoor_entries
+      rows = Pricing::Catalog::CAMPING_PER_PERSON_NIGHT_CENTS.map do |kind, amount|
+        entry("camping.#{kind}_per_person_night", amount, "Camping #{kind} — €/pers/nuit")
+      end
+      rows << entry("van.per_night", Pricing::Catalog::VAN_PER_NIGHT_CENTS,
+                    "Van / camping-car — €/nuit")
+      rows << entry("terrace.per_person_day", Pricing::Catalog::TERRACE_PER_PERSON_DAY_CENTS,
+                    "Terrasse — €/pers/jour")
+      Pricing::Catalog::HAMAC_FALLBACK_CENTS.each do |kind, amount|
+        rows << entry("hamac.#{kind}", amount, "Hamac #{kind} — €/nuit/unité")
+      end
+      rows
+    end
+
+    def meal_entries
+      rows = Pricing::Catalog::MEAL_PER_PERSON_CENTS.map do |kind, amount|
+        entry("meal.#{kind}.per_person", amount, "#{meal_label(kind)} — €/pers")
+      end
+      rows << entry("pizza_party.base", Pricing::Catalog::PIZZA_PARTY_BASE_CENTS,
+                    "Pizza Party — forfait allumage")
+      rows << entry("pizza_party.per_person", Pricing::Catalog::PIZZA_PARTY_PER_PERSON_CENTS,
+                    "Pizza Party — €/pers")
+      rows
+    end
+
+    MEAL_LABELS = {
+      "repas_vege_midi" => "Repas végétarien (midi)",
+      "buffet"          => "Buffet pain-fromages"
+    }.freeze
+
+    def meal_label(kind) = MEAL_LABELS.fetch(kind, kind.to_s.tr("_", " ").capitalize)
+
+    def misc_entries
+      [
+        entry("dog.supplement", Pricing::Catalog::DOG_SUPPLEMENT_CENTS,
+              "Supplément chien — par séjour"),
+        entry("deposit.default_rate",
+              (Pricing::Catalog::DEFAULT_DEPOSIT_RATE * 100).round,
+              "Acompte par défaut (% du total hors activités)",
+              unit: "percent")
+      ]
+    end
+  end
+end

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -53,7 +53,7 @@ module Reservations
     # `price_override_cents` / `platform` (epic #81, Phase 3) : prix libre imposé
     # et attribution OTA — RÉSERVÉS au canal admin. Ignorés hors `admin: true`,
     # même sur param forgé (le funnel public ne les expose jamais).
-    def initialize(draft:, deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE,
+    def initialize(draft:, deposit_rate: Pricing::Catalog.default_deposit_rate,
                    admin: false, status: nil, source: nil, skip_availability: false,
                    price_override_cents: nil, platform: nil)
       @draft = draft

--- a/app/services/reservations/draft.rb
+++ b/app/services/reservations/draft.rb
@@ -167,7 +167,7 @@ module Reservations
       }
     end
 
-    def quote(deposit_rate: Pricing::Catalog::DEFAULT_DEPOSIT_RATE)
+    def quote(deposit_rate: Pricing::Catalog.default_deposit_rate)
       PricingModel.quote(self, deposit_rate: deposit_rate)
     end
 

--- a/app/views/layouts/components/_navbar.html.slim
+++ b/app/views/layouts/components/_navbar.html.slim
@@ -189,6 +189,10 @@ nav.bg-white.shadow-sm.lg:px-6
                       experiences_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'experiences' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
           li
+            = link_to "Tarifs",
+                      rates_path,
+                      class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'rates' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
+          li
             = link_to "Événements",
                       events_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{(controller_name == 'events' || controller_name == 'events_categories') ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"

--- a/app/views/rates/index.html.slim
+++ b/app/views/rates/index.html.slim
@@ -1,0 +1,46 @@
+- content_for :page_header do
+  = render "layouts/components/page_header",
+           title: "Tarifs"
+
+- if @grouped_rates.blank?
+  .p-6.text-sm.text-gray-500.bg-white.rounded-lg.border.border-gray-100
+    p.font-medium.text-gray-700 Aucun tarif paramétré.
+    p.mt-1
+      | Les prix appliqués sont ceux codés dans le catalogue. Lance
+      code.mx-1.px-1.py-0.5.bg-gray-100.rounded rake rates:seed_from_catalog
+      | pour les rendre éditables ici.
+- else
+  .space-y-8
+    - @grouped_rates.each do |group_name, rates|
+      section
+        h2.text-sm.font-semibold.text-gray-700.uppercase.tracking-wide.mb-2
+          = group_name
+        .overflow-x-auto.relative
+          table.w-full.text-sm.text-left.text-gray-500
+            thead.text-xs.text-gray-700.uppercase.bg-gray-50
+              tr
+                th.py-3.px-6[scope="col"]
+                  | Tarif
+                th.py-3.px-6[scope="col"]
+                  | Clé
+                th.w-64.py-3.px-6[scope="col"]
+                  | Montant
+            tbody
+              - rates.each do |rate|
+                tr.border-b.bg-white
+                  td.py-3.px-6.font-medium.text-gray-900[scope="row"]
+                    = rate.label.presence || rate.key
+                  td.py-3.px-6.text-xs.text-gray-400.font-mono
+                    = rate.key
+                  td.py-3.px-6
+                    = form_with model: rate, url: rate_path(rate), method: :patch, class: "flex items-center gap-2" do |f|
+                      = number_field_tag "rate[amount]",
+                                         rate.amount,
+                                         step: (rate.percent? ? 1 : 0.01),
+                                         min: 0,
+                                         class: "w-28 rounded-md border-gray-300 text-sm",
+                                         "aria-label" => "Montant pour #{rate.key}"
+                      span.text-gray-500
+                        = rate.percent? ? "%" : "€"
+                      = f.submit "Enregistrer",
+                                 class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 cursor-pointer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
   resources :payments, only: [:index, :show, :destroy]
   resources :products
   resources :projects
+  resources :rates, only: [:index, :update]
   resources :rental_items
   resources :reports
   resources :roles

--- a/db/migrate/20260721011642_create_rates.rb
+++ b/db/migrate/20260721011642_create_rates.rb
@@ -1,0 +1,14 @@
+class CreateRates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rates do |t|
+      t.string :key, null: false
+      t.integer :amount_cents, null: false, default: 0
+      t.string :label
+      t.string :unit, null: false, default: "cents"
+
+      t.timestamps
+    end
+
+    add_index :rates, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_21_011642) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -498,6 +498,16 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["human_id"], name: "index_projects_on_human_id"
+  end
+
+  create_table "rates", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "amount_cents", default: 0, null: false
+    t.string "label"
+    t.string "unit", default: "cents", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_rates_on_key", unique: true
   end
 
   create_table "rental_items", force: :cascade do |t|

--- a/lib/tasks/rates.rake
+++ b/lib/tasks/rates.rake
@@ -1,0 +1,7 @@
+namespace :rates do
+  desc "Matérialise tous les tarifs de Pricing::Catalog dans la table rates (idempotent). FORCE=1 pour écraser les montants édités."
+  task seed_from_catalog: :environment do
+    result = Rates::SeedFromCatalog.new(force: ENV["FORCE"].present?).run
+    puts "[rates:seed_from_catalog] #{result}"
+  end
+end

--- a/spec/models/rate_spec.rb
+++ b/spec/models/rate_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+# Issue #124 — table des tarifs paramétrables.
+RSpec.describe Rate, type: :model do
+  it "exige une clé unique" do
+    Rate.create!(key: "van.per_night", amount_cents: 1_500, label: "Van")
+    duplicate = Rate.new(key: "van.per_night", amount_cents: 2_000)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:key]).to be_present
+  end
+
+  it "refuse un montant négatif" do
+    rate = Rate.new(key: "van.per_night", amount_cents: -1)
+
+    expect(rate).not_to be_valid
+    expect(rate.errors[:amount_cents]).to be_present
+  end
+
+  it "refuse une unité inconnue" do
+    expect(Rate.new(key: "x", amount_cents: 0, unit: "bananes")).not_to be_valid
+  end
+
+  it "expose le montant en euros, ou en points de pourcentage" do
+    expect(Rate.new(key: "a", amount_cents: 1_550).amount).to eq(15.5)
+    expect(Rate.new(key: "b", amount_cents: 50, unit: "percent").amount).to eq(50)
+  end
+
+  it "trace les modifications avec PaperTrail" do
+    rate = Rate.create!(key: "van.per_night", amount_cents: 1_500)
+    expect { rate.update!(amount_cents: 1_800) }.to change { rate.versions.count }.by(1)
+  end
+
+  describe ".grouped" do
+    it "range chaque tarif dans son domaine, groupes dans l'ordre" do
+      Rate.create!(key: "meal.buffet.per_person", amount_cents: 1_200)
+      Rate.create!(key: "lodging.la_hulotte.first_night", amount_cents: 48_500)
+      Rate.create!(key: "dog.supplement", amount_cents: 5_000)
+
+      expect(Rate.grouped.map(&:first)).to eq(["Hébergements", "Repas", "Divers"])
+    end
+  end
+end

--- a/spec/requests/rates_spec.rb
+++ b/spec/requests/rates_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+# Issue #124 — écran Paramètres > Tarifs.
+RSpec.describe "Paramètres > Tarifs", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  before do
+    sign_in user
+    Rates::SeedFromCatalog.new.run
+  end
+
+  describe "GET /rates" do
+    it "liste les tarifs groupés par domaine dans le menu paramètres" do
+      get rates_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Tarifs")
+      expect(response.body).to include("Hébergements")
+      expect(response.body).to include("Salles")
+      expect(response.body).to include("Camping &amp; van")
+      expect(response.body).to include("Repas")
+      expect(response.body).to include("Divers")
+      expect(response.body).to include("van.per_night")
+      # menu secondaire paramètres présent
+      expect(response.body).to include("Expériences")
+    end
+
+    it "affiche un montant en euros et un taux en pourcentage" do
+      get rates_path
+
+      expect(response.body).to include('value="15.0"')  # van : 15 €/nuit
+      expect(response.body).to include('value="50"')    # acompte : 50 %
+    end
+  end
+
+  describe "PATCH /rates/:id" do
+    let(:van) { Rate.find_by(key: "van.per_night") }
+
+    it "met à jour le montant en convertissant les euros en cents" do
+      patch rate_path(van), params: { rate: { amount: "18,50" } }
+
+      expect(response).to redirect_to(rates_path)
+      expect(van.reload.amount_cents).to eq(1_850)
+      follow_redirect!
+      expect(response.body).to include("a été mis à jour")
+    end
+
+    it "met à jour un taux en points de pourcentage" do
+      deposit = Rate.find_by(key: "deposit.default_rate")
+      patch rate_path(deposit), params: { rate: { amount: "30" } }
+
+      expect(deposit.reload.amount_cents).to eq(30)
+    end
+
+    it "refuse un montant négatif et laisse le tarif intact" do
+      patch rate_path(van), params: { rate: { amount: "-5" } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(van.reload.amount_cents).to eq(1_500)
+    end
+
+    it "refuse une saisie non numérique" do
+      patch rate_path(van), params: { rate: { amount: "gratuit" } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(van.reload.amount_cents).to eq(1_500)
+    end
+  end
+
+  describe "sans authentification" do
+    it "redirige vers la connexion" do
+      sign_out user
+      get rates_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end

--- a/spec/services/pricing_rates_spec.rb
+++ b/spec/services/pricing_rates_spec.rb
@@ -1,0 +1,152 @@
+require "rails_helper"
+
+# Issue #124 — les tarifs viennent de la base d'abord, des constantes en repli.
+RSpec.describe "Tarifs paramétrés (Pricing::Rates)" do
+  # Draft composite : hébergement + camping + van + salle + repas + terrasse +
+  # pizza party + chien. Il touche TOUTES les familles de tarifs paramétrées.
+  def composite_draft
+    lodging = Lodging.find_by(name: "La Hulotte") ||
+              Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+
+    Reservations::Draft.new(
+      lodging_id: lodging.id,
+      arrival_date: Date.new(2026, 9, 7),   # lundi → tarifs semaine
+      departure_date: Date.new(2026, 9, 10),
+      dogs_count: 1,
+      campings: [{ kind: "tente", people: 3, nights: 2 }],
+      vans: [{ nights: 2 }],
+      halls: [{ kind: "grande_salle", date: "2026-09-08", period: "journee" }],
+      meals: [{ kind: "buffet", people: 4 }],
+      terrasses: [{ date: "2026-09-09", people: 5 }],
+      pizza_parties: [{ people: 6 }]
+    )
+  end
+
+  before { Pricing::Rates.reset! }
+
+  describe "invariance après le seed" do
+    it "produit exactement le même devis avant et après rates:seed_from_catalog" do
+      before_quote = PricingModel.quote(composite_draft)
+
+      Rates::SeedFromCatalog.new.run
+
+      after_quote = PricingModel.quote(composite_draft)
+
+      expect(after_quote.total_cents).to eq(before_quote.total_cents)
+      expect(after_quote.deposit_cents).to eq(before_quote.deposit_cents)
+      expect(after_quote.breakdown).to eq(before_quote.breakdown)
+    end
+
+    it "est idempotent : rejouer le seed ne crée aucun doublon" do
+      Rates::SeedFromCatalog.new.run
+      expect { Rates::SeedFromCatalog.new.run }.not_to change(Rate, :count)
+    end
+
+    it "matérialise toutes les familles de tarifs du catalogue" do
+      Rates::SeedFromCatalog.new.run
+
+      %w[
+        lodging.la_hulotte.first_night
+        lodging.le_grand_duc.package_7
+        hall.grande_salle.journee
+        hall_weekend.grande_salle.journee
+        hall.deux_salles.journee
+        camping.tente_per_person_night
+        van.per_night
+        terrace.per_person_day
+        hamac.simple
+        meal.repas_vege_midi.per_person
+        meal.buffet.per_person
+        pizza_party.base
+        pizza_party.per_person
+        dog.supplement
+        deposit.default_rate
+      ].each do |key|
+        expect(Rate.find_by(key: key)).to be_present, "clé manquante : #{key}"
+      end
+
+      expect(Rate.find_by(key: "deposit.default_rate").unit).to eq("percent")
+    end
+
+    it "ne réécrit pas un montant édité par l'équipe" do
+      Rates::SeedFromCatalog.new.run
+      Rate.find_by(key: "van.per_night").update!(amount_cents: 2_500)
+
+      Rates::SeedFromCatalog.new.run
+
+      expect(Rate.find_by(key: "van.per_night").amount_cents).to eq(2_500)
+    end
+  end
+
+  describe "un tarif modifié en base change le devis" do
+    before { Rates::SeedFromCatalog.new.run }
+
+    it "van : +10 €/nuit se répercute sur le total" do
+      base = PricingModel.quote(composite_draft).total_cents
+
+      Rate.find_by(key: "van.per_night").update!(amount_cents: 2_500)
+      Pricing::Rates.reset!
+
+      # 2 nuits × (25 − 15) € = +20 €
+      expect(PricingModel.quote(composite_draft).total_cents).to eq(base + 2_000)
+    end
+
+    it "hébergement : la première nuit paramétrée est utilisée" do
+      base = PricingModel.quote(composite_draft).total_cents
+
+      Rate.find_by(key: "lodging.la_hulotte.first_night").update!(amount_cents: 50_000)
+      Pricing::Rates.reset!
+
+      expect(PricingModel.quote(composite_draft).total_cents).to eq(base + 1_500)
+    end
+
+    it "salle : le tarif journée paramétré est utilisé" do
+      base = PricingModel.quote(composite_draft).total_cents
+
+      Rate.find_by(key: "hall.grande_salle.journee").update!(amount_cents: 30_000)
+      Pricing::Rates.reset!
+
+      expect(PricingModel.quote(composite_draft).total_cents).to eq(base + 1_000)
+    end
+
+    it "taux d'acompte : 30 % paramétré s'applique au devis" do
+      Rate.find_by(key: "deposit.default_rate").update!(amount_cents: 30)
+      Pricing::Rates.reset!
+
+      quote = PricingModel.quote(composite_draft)
+      expect(quote.deposit_rate).to eq(0.3)
+      expect(quote.deposit_cents)
+        .to eq(((quote.total_cents - quote.experiences_cents) * 0.3).round)
+    end
+
+    it "chien / camping / repas / terrasse / pizza suivent aussi la base" do
+      base = PricingModel.quote(composite_draft).total_cents
+
+      Rate.find_by(key: "dog.supplement").update!(amount_cents: 6_000)
+      Rate.find_by(key: "camping.tente_per_person_night").update!(amount_cents: 850)
+      Rate.find_by(key: "meal.buffet.per_person").update!(amount_cents: 1_300)
+      Rate.find_by(key: "terrace.per_person_day").update!(amount_cents: 350)
+      Rate.find_by(key: "pizza_party.per_person").update!(amount_cents: 800)
+      Pricing::Rates.reset!
+
+      delta = 1_000 +                # chien +10 €
+              (100 * 3 * 2) +        # camping +1 €/pers/nuit × 3 pers × 2 nuits
+              (100 * 4) +            # buffet +1 €/pers × 4
+              (100 * 5) +            # terrasse +1 €/pers × 5
+              (100 * 6)              # pizza +1 €/pers × 6
+      expect(PricingModel.quote(composite_draft).total_cents).to eq(base + delta)
+    end
+  end
+
+  describe "cache par requête" do
+    it "ne fait qu'un seul chargement des tarifs pour un devis composite" do
+      Rates::SeedFromCatalog.new.run
+      Pricing::Rates.reset!
+
+      allow(Pricing::Rates).to receive(:load_lookup).and_call_original
+      PricingModel.quote(composite_draft)
+
+      expect(Pricing::Rates).to have_received(:load_lookup).once
+    end
+  end
+end


### PR DESCRIPTION
Closes #124

## Ce que fait la PR

Les tarifs deviennent éditables depuis l'admin, **sans changer un seul prix** au passage.

- **Table `rates`** : `key` (unique), `amount_cents` (≥ 0), `label`, `unit` (`cents` | `percent`), horodatages. PaperTrail activé.
  `unit` a été ajouté au schéma proposé dans l'issue pour porter proprement le **taux d'acompte par défaut** (50 %), qui n'est pas un montant.
- **`Pricing::Rates`** : façade de lecture. Un seul `SELECT` par requête (mémoïsation via `ActiveSupport::CurrentAttributes`, remis à zéro par Rails à chaque requête/job).
- **`Pricing::Catalog`** : garde ses constantes (source du seed + filet de sécurité) et expose désormais des **accesseurs** qui lisent la base d'abord, la constante en repli. Tous les consommateurs (`PricingModel`, `Reservations::Draft`/`Builder`, les concerns repas/terrasse) passent par ces accesseurs.
- **`rake rates:seed_from_catalog`** (service `Rates::SeedFromCatalog`) : matérialise les **45 clés** du catalogue. Idempotent, et il **ne réécrit jamais** un montant déjà édité par l'équipe (`FORCE=1` pour forcer).
- **Écran Paramètres > Tarifs** : nouvelle entrée de sous-nav juste après « Expériences », liste groupée (Hébergements / Salles / Camping & van / Repas / Divers), édition en € (virgule tolérée) ou en %, validation ≥ 0, flash de confirmation.

Schéma de clés retenu : `lodging.<slug>.first_night|extra_night|package_<n>`, `hall.<espace>.<période>`, `hall_weekend.<espace>.<période>`, `camping.tente_per_person_night`, `van.per_night`, `terrace.per_person_day`, `hamac.simple|double`, `meal.<formule>.per_person`, `pizza_party.base|per_person`, `dog.supplement`, `deposit.default_rate`. Il laisse la place aux futurs tarifs 2 h / 2 jours / dégressifs sans migration.

## Vérification

- `bundle exec rspec` → **989 examples, 0 failures**, 16 pending (les pending préexistent sur `main`).
- Specs ajoutées : modèle (unicité, montant négatif, unité, PaperTrail, groupement), **invariance du devis avant/après seed** sur un draft composite (hébergement + camping + van + salle + repas + terrasse + pizza + chien), **tarif modifié en base → devis changé** (van, hébergement, salle, acompte, et le lot chien/camping/repas/terrasse/pizza), un seul chargement des tarifs par devis, request specs de l'écran (liste, mise à jour €, mise à jour %, refus négatif, refus non numérique, auth requise).
- `rake rates:seed_from_catalog` joué en dev : `45 tarifs — 45 créés`.
- Pas de linter dans le repo (ni RuboCop, ni script `lint` dans `package.json`, le seul workflow CI est `agent-ready-gate.yml`) — rien à faire côté lint.

## 📸 Aperçu

**Pas de capture d'écran, et c'est un trou assumé.** L'écran est derrière Devise, donc Chrome headless seul ne peut pas l'atteindre ; et le chemin Capybara est cassé sur cette machine — le repo épingle `webdrivers 5.2.0` + `selenium-webdriver 4.5.0`, qui interrogent l'ancien endpoint `chromedriver.storage.googleapis.com` (404 pour Chrome 150) et sont antérieurs à Selenium Manager. Il n'existe par ailleurs aucun `spec/system` dans le repo. Débloquer ça = bumper `selenium-webdriver` et retirer `webdrivers` — hors périmètre de cette issue.

## À valider à la main

- L'écran **Paramètres > Tarifs** avec l'œil : groupement, libellés, ordre.
- Que le seed tourne bien en production **avant** toute édition (sinon l'écran affiche l'état vide avec la consigne).
- Le libellé de chaque tarif (ils sont dérivés du catalogue, pas repris de la page publique les4sources.be).

## Hors périmètre (inchangé, comme demandé)

Remise « 2 salles » (chantier séparé — les clés `hall.deux_salles.*` sont bien seedées et éditables), tarifs 2 h / 2 jours / dégressifs, synchronisation avec le site public, et **aucun montant historique** : les prix déjà persistés sur les bookings/séjours ne sont jamais relus depuis `rates`.
