### PR TITLE
Coworking Phase 1 — modèle packs/réservations + admin + calendrier (#127)

### DIFF
--- a/app/controllers/coworking_packs_controller.rb
+++ b/app/controllers/coworking_packs_controller.rb
@@ -1,0 +1,62 @@
+# Admin des packs de coworking (epic #126, Phase 1).
+#
+# L'équipe achète un pack pour un client existant, puis pose ou annule ses
+# journées. Elle n'est PAS soumise aux règles du portail client (pas de limite
+# d'heure) : seules les règles de domaine (capacité 3, lun-ven, expiration,
+# crédits) s'appliquent.
+class CoworkingPacksController < BaseController
+  before_action :get_pack, only: [:show, :destroy]
+
+  breadcrumb "Coworking", :coworking_packs_path, match: :exact
+
+  def index
+    @packs = CoworkingPack.includes(:customer, :payments, :coworking_reservations).ordered
+  end
+
+  def show
+    breadcrumb @pack.customer.display_name, coworking_pack_path(@pack)
+    @reservations = @pack.coworking_reservations.ordered
+    @reservation = CoworkingReservation.new(coworking_pack: @pack)
+  end
+
+  def new
+    @pack = CoworkingPack.new
+  end
+
+  def create
+    service = Coworking::CreatePack.new
+    if service.run(customer_id: pack_params[:customer_id],
+                   days_total: pack_params[:days_total],
+                   payment_method: pack_params[:payment_method])
+      redirect_to coworking_pack_path(service.pack),
+                  notice: "Le pack de #{service.pack.days_total} journée(s) a été créé."
+    else
+      @pack = service.pack
+      flash.now[:alert] = service.error_message
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @pack.soft_delete!(validate: false)
+    redirect_to coworking_packs_path, notice: "Le pack a été supprimé."
+  end
+
+  private
+
+  def get_pack
+    @pack = CoworkingPack.find(params[:id])
+  end
+
+  def pack_params
+    params.require(:coworking_pack).permit(:customer_id, :days_total, :payment_method)
+  end
+
+  def set_presenters
+    @menu_presenter = Components::MenuPresenter.new(
+      active_primary: "settings",
+      active_secondary: "coworking"
+    )
+    @settings_view = true
+  end
+end

--- a/app/controllers/coworking_reservations_controller.rb
+++ b/app/controllers/coworking_reservations_controller.rb
@@ -1,0 +1,38 @@
+# Pose et annulation des journées de coworking d'un pack (epic #126, Phase 1).
+# Réservé à l'équipe : aucune règle d'heure limite ici (Phase 3 côté portail).
+class CoworkingReservationsController < BaseController
+  before_action :get_pack
+
+  def create
+    reservation = @pack.coworking_reservations.new(date: params.dig(:coworking_reservation, :date))
+
+    if reservation.save
+      redirect_to coworking_pack_path(@pack),
+                  notice: "La journée du #{I18n.l(reservation.date, format: :long)} a été réservée."
+    else
+      redirect_to coworking_pack_path(@pack),
+                  alert: reservation.errors.full_messages.to_sentence,
+                  status: :see_other
+    end
+  end
+
+  def destroy
+    reservation = @pack.coworking_reservations.find(params[:id])
+    reservation.soft_delete!(validate: false)
+    redirect_to coworking_pack_path(@pack), notice: "La journée a été annulée."
+  end
+
+  private
+
+  def get_pack
+    @pack = CoworkingPack.find(params[:coworking_pack_id])
+  end
+
+  def set_presenters
+    @menu_presenter = Components::MenuPresenter.new(
+      active_primary: "settings",
+      active_secondary: "coworking"
+    )
+    @settings_view = true
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -45,6 +45,14 @@ class PagesController < BaseController
           .where.not(status: ["declined", "canceled"])
           .where("from_date < ? AND to_date > ?", @last.to_date, @first.to_date)
       )
+      # Coworking (epic #126, Phase 1) — domaine INDÉPENDANT des séjours : un
+      # bloc agrégé par jour (« 💻 Coworking N/3 »), jamais rattaché à un stay
+      # et donc jamais sélectionnable par le mode fusion.
+      @grouped_coworking_reservations = CoworkingReservation
+        .includes(:customer)
+        .between(@first.to_date, @last.to_date)
+        .to_a
+        .group_by(&:date)
       @grouped_van_bookings = nights_grouped_by_day(
         VanBooking
           .includes(stay: :customer)

--- a/app/controllers/public/calendars_controller.rb
+++ b/app/controllers/public/calendars_controller.rb
@@ -1,7 +1,11 @@
 class Public::CalendarsController < Public::BaseController
   layout "public"
 
-  CALENDAR_SPACE_NAMES = ["Grande Salle", "Petite Salle", "Cuisine professionnelle", "Coworking", "Bois"].freeze
+  # « Coworking » a été RETIRÉ de ce calendrier (amendement Michael 2026-07-21,
+  # epic #126) : les 3 bureaux vivent désormais dans le domaine coworking
+  # (`CoworkingPack` / `CoworkingReservation`), qui en est l'unique source de
+  # vérité. L'historique `SpaceBooking` de l'espace reste intact et lisible.
+  CALENDAR_SPACE_NAMES = ["Grande Salle", "Petite Salle", "Cuisine professionnelle", "Bois"].freeze
 
   def lodgings
     set_dates

--- a/app/models/coworking_pack.rb
+++ b/app/models/coworking_pack.rb
@@ -1,0 +1,65 @@
+# Pack de journées de coworking (epic #126, Phase 1).
+#
+# Le coworking n'est PAS un séjour : c'est un domaine indépendant. Un client
+# achète un pack de 1/5/10/20 journées, valable 12 mois, et pose ensuite ses
+# journées (`CoworkingReservation`) dans la limite de ses crédits.
+#
+# Le statut de paiement est DÉRIVÉ des `Payment` ancrés sur le pack — le pack ne
+# porte aucune colonne de statut, pour qu'il n'y ait jamais deux vérités.
+class CoworkingPack < ApplicationRecord
+  DAYS_OPTIONS = [1, 5, 10, 20].freeze
+  PAYMENT_METHODS = %w[card bank_transfer cash].freeze
+  VALIDITY_MONTHS = 12
+
+  belongs_to :customer
+  has_many :coworking_reservations, dependent: :destroy
+  has_many :payments, dependent: :nullify
+
+  has_paper_trail
+  has_soft_deletion default_scope: true
+
+  validates :days_total, inclusion: { in: DAYS_OPTIONS }
+  validates :price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :payment_method, inclusion: { in: PAYMENT_METHODS }
+  validates :purchased_at, :expires_at, presence: true
+
+  before_validation :set_defaults, on: :create
+
+  scope :ordered, -> { order(purchased_at: :desc) }
+  scope :active, -> { where("expires_at >= ?", Time.current) }
+
+  # Journées déjà posées (réservations vivantes — la soft-deletion les retire).
+  def days_used = coworking_reservations.count
+
+  def days_remaining = days_total - days_used
+
+  def credits_left? = days_remaining.positive?
+
+  def expired?(on = Date.current)
+    expires_at.to_date < on
+  end
+
+  # Statut de paiement DÉRIVÉ : "paid" dès que les paiements encaissés couvrent
+  # le prix du pack, "pending" s'il existe un paiement en attente, sinon "unpaid".
+  def payment_status
+    return "paid" if payments.paid.sum(:amount_cents) >= price_cents && price_cents.positive?
+    return "paid" if price_cents.zero? && payments.paid.any?
+    return "pending" if payments.pending.any?
+
+    "unpaid"
+  end
+
+  def paid? = payment_status == "paid"
+
+  # Le paiement par carte est encaissé immédiatement (hors ligne en Phase 1) ;
+  # virement et espèces créent un `Payment` en attente à la création du pack.
+  def deferred_payment? = payment_method != "card"
+
+  private
+
+  def set_defaults
+    self.purchased_at ||= Time.current
+    self.expires_at ||= purchased_at + VALIDITY_MONTHS.months
+    self.price_cents = Pricing::Catalog.coworking_pack_cents(days_total) if price_cents.to_i.zero?
+  end
+end

--- a/app/models/coworking_reservation.rb
+++ b/app/models/coworking_reservation.rb
@@ -1,0 +1,83 @@
+# Une journée de coworking posée sur un pack (epic #126, Phase 1).
+#
+# Trois bureaux au total : la capacité est GLOBALE (3 réservations vivantes par
+# jour, toutes clientes confondues), pas par ressource nommée — on ne réserve
+# pas « le bureau 2 ».
+#
+# Le domaine est indépendant du canal `SpaceBooking` de l'espace « Coworking »
+# historique : aucun `SpaceReservation` n'est créé ni consulté ici.
+class CoworkingReservation < ApplicationRecord
+  DAILY_CAPACITY = 3
+
+  belongs_to :coworking_pack
+  belongs_to :customer
+
+  has_paper_trail
+  has_soft_deletion default_scope: true
+
+  validates :date, presence: true
+  validate :date_is_a_weekday
+  validate :pack_not_expired
+  validate :pack_has_credits, on: :create
+  validate :daily_capacity_available
+  validate :not_already_booked_by_pack
+
+  before_validation :denormalize_customer
+
+  scope :ordered, -> { order(date: :asc) }
+  scope :on, ->(date) { where(date: date) }
+  scope :between, ->(from, to) { where(date: from..to) }
+
+  # Occupation d'un jour donné, tous packs confondus.
+  def self.count_on(date) = on(date).count
+
+  def self.remaining_on(date) = [DAILY_CAPACITY - count_on(date), 0].max
+
+  private
+
+  def denormalize_customer
+    self.customer ||= coworking_pack&.customer
+  end
+
+  def date_is_a_weekday
+    return if date.blank?
+    return if (1..5).cover?(date.wday)
+
+    errors.add(:date, "doit être un jour de semaine (lundi à vendredi)")
+  end
+
+  def pack_not_expired
+    return if date.blank? || coworking_pack.nil?
+    return unless coworking_pack.expired?(date)
+
+    errors.add(:coworking_pack, "est expiré à cette date")
+  end
+
+  def pack_has_credits
+    return if coworking_pack.nil?
+    return if coworking_pack.credits_left?
+
+    errors.add(:coworking_pack, "n'a plus de journée disponible")
+  end
+
+  def daily_capacity_available
+    return if date.blank?
+
+    taken = self.class.on(date).where.not(id: id).count
+    return if taken < DAILY_CAPACITY
+
+    errors.add(:date, "est complet (#{DAILY_CAPACITY} bureaux déjà réservés)")
+  end
+
+  def not_already_booked_by_pack
+    return if date.blank? || coworking_pack_id.blank?
+
+    duplicate = self.class.on(date)
+                    .where(coworking_pack_id: coworking_pack_id)
+                    .where.not(id: id)
+                    .exists?
+    return unless duplicate
+
+    errors.add(:date, "est déjà réservé pour ce pack")
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -27,7 +27,13 @@ class Payment < ApplicationRecord
   # `belongs_to` — un Payment sans stay_id est désormais invalide. Les données
   # legacy déjà persistées sans stay ne sont pas re-validées (pas de re-save),
   # et sont rattrapées par `rake payments:backfill_stay_from_booking`.
-  belongs_to :stay
+  #
+  # Coworking (epic #126, Phase 1) : un paiement peut désormais s'ancrer sur un
+  # `CoworkingPack` au lieu d'un séjour — le coworking n'est PAS un séjour.
+  # L'invariant du verrouillage Phase 4 devient donc « stay_id OU
+  # coworking_pack_id » : un paiement sans ancre reste invalide.
+  belongs_to :stay, optional: true
+  belongs_to :coworking_pack, optional: true
 
   # Provenance de facturation des espaces (facturation espaces → paiements).
   # Optionnel : seuls les Payment issus de la rake `space_bookings:billing_to_payments`
@@ -44,6 +50,7 @@ class Payment < ApplicationRecord
 
   validates :amount, numericality: { greater_than: 0.0 }
   validates :payment_method, presence: true
+  validate :anchored_on_stay_or_coworking_pack
 
   scope :paid, -> { where(status: "paid") }
   scope :pending, -> { where(status: "pending") }
@@ -54,5 +61,19 @@ class Payment < ApplicationRecord
 
   def pending?
     self.status == "pending"
+  end
+
+  private
+
+  # Un paiement doit toujours savoir CE QU'IL PAIE : un séjour, ou un pack de
+  # coworking. Jamais rien, jamais les deux.
+  def anchored_on_stay_or_coworking_pack
+    return if stay_id.present? ^ coworking_pack_id.present?
+
+    if stay_id.present?
+      errors.add(:base, "Un paiement ne peut pas porter à la fois un séjour et un pack de coworking")
+    else
+      errors.add(:stay, "doit être renseigné (ou un pack de coworking)")
+    end
   end
 end

--- a/app/services/coworking/create_pack.rb
+++ b/app/services/coworking/create_pack.rb
@@ -1,0 +1,40 @@
+module Coworking
+  # Achat d'un pack de coworking par l'équipe, pour un client existant
+  # (epic #126, Phase 1).
+  #
+  # Le prix vient du barème (`Pricing::Catalog.coworking_pack_cents`), jamais du
+  # formulaire. Virement et espèces créent immédiatement un `Payment` en attente
+  # ancré sur le pack — c'est ce paiement qui porte le statut, pas le pack.
+  class CreatePack
+    attr_reader :pack, :error_message
+
+    def run(customer_id:, days_total:, payment_method:)
+      @pack = CoworkingPack.new(
+        customer_id: customer_id,
+        days_total: days_total.to_i,
+        payment_method: payment_method.to_s
+      )
+
+      ActiveRecord::Base.transaction do
+        @pack.save!
+        create_pending_payment! if @pack.deferred_payment?
+      end
+
+      true
+    rescue ActiveRecord::RecordInvalid => e
+      @error_message = e.record.errors.full_messages.to_sentence
+      false
+    end
+
+    private
+
+    def create_pending_payment!
+      Payment.create!(
+        coworking_pack: @pack,
+        amount_cents: @pack.price_cents,
+        payment_method: @pack.payment_method,
+        status: "pending"
+      )
+    end
+  end
+end

--- a/app/services/pricing/catalog.rb
+++ b/app/services/pricing/catalog.rb
@@ -137,6 +137,34 @@ module Pricing
     PIZZA_PARTY_BASE_CENTS = 4_000
     PIZZA_PARTY_PER_PERSON_CENTS = 700
 
+    # Packs de coworking (epic #126, Phase 1) : prix par nombre de journées.
+    COWORKING_PACKS = {
+      1  =>  2_000, # 20 €
+      5  =>  8_000, # 80 €
+      10 => 16_000, # 160 €
+      20 => 30_000  # 300 €
+    }.freeze
+
+    # Prix d'un pack de coworking. La table `rates` (issue #124) gagne quand
+    # elle existe et porte la clé ; sinon on retombe sur la constante ci-dessus.
+    def coworking_pack_cents(days)
+      fallback = COWORKING_PACKS[days.to_i]
+      return nil if fallback.nil?
+
+      configured_cents("coworking.pack_#{days.to_i}") || fallback
+    end
+
+    # Lecture défensive de la table `rates` : elle n'existe pas forcément encore
+    # (l'issue #124 est un chantier parallèle), donc on ne la suppose jamais.
+    def configured_cents(key)
+      return nil unless defined?(Rate) && Rate.table_exists?
+
+      Rate.find_by(key: key)&.amount_cents
+    rescue ActiveRecord::StatementInvalid, ActiveRecord::NoDatabaseError,
+           ActiveRecord::ConnectionNotEstablished
+      nil
+    end
+
     def lodging_rate(name)
       LODGING_RATES[name]
     end

--- a/app/views/coworking_packs/_payment_badge.html.slim
+++ b/app/views/coworking_packs/_payment_badge.html.slim
@@ -1,0 +1,5 @@
+/ Badge de statut de paiement d'un pack — DÉRIVÉ des Payment ancrés dessus.
+- classes = { "paid" => "bg-green-100 text-green-700", "pending" => "bg-amber-100 text-amber-700", "unpaid" => "bg-gray-100 text-gray-600" }
+- labels  = { "paid" => "payé", "pending" => "en attente", "unpaid" => "non payé" }
+span class="px-2 py-0.5 text-xs rounded #{classes[pack.payment_status]}"
+  = labels[pack.payment_status]

--- a/app/views/coworking_packs/index.html.slim
+++ b/app/views/coworking_packs/index.html.slim
@@ -1,0 +1,46 @@
+- content_for :page_header do
+  = render "layouts/components/page_header",
+           title: "Coworking",
+           links: [ \
+             link_to("➕ Nouveau pack", new_coworking_pack_path, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2") \
+           ]
+
+- if @packs.empty?
+  .p-6.text-sm.text-gray-500.bg-white.rounded-lg.border.border-gray-100
+    | Aucun pack de coworking pour l'instant.
+- else
+  .overflow-x-auto.relative
+    table.w-full.text-sm.text-left.text-gray-500
+      thead.text-xs.text-gray-700.uppercase.bg-gray-50
+        tr
+          th.py-3.px-6[scope="col"]
+            | Client
+          th.py-3.px-6[scope="col"]
+            | Pack
+          th.py-3.px-6[scope="col"]
+            | Jours restants
+          th.py-3.px-6[scope="col"]
+            | Expire le
+          th.py-3.px-6[scope="col"]
+            | Paiement
+      tbody
+        - @packs.each do |pack|
+          tr.border-b.bg-white
+            td.py-3.px-6.font-medium.text-gray-900[scope="row"]
+              = link_to pack.customer.display_name,
+                        coworking_pack_path(pack),
+                        class: "text-blue-500 border-b-2 border-blue-200 hover:text-blue-700"
+            td.py-3.px-6
+              = "#{pack.days_total} journée#{'s' if pack.days_total > 1}"
+              span.text-gray-400.ml-1
+                = number_to_currency(pack.price_cents / 100.0, unit: "€", format: "%n %u")
+            td.py-3.px-6
+              = pack.days_remaining
+              span.text-gray-400.text-xs.ml-1
+                = "/ #{pack.days_total}"
+            td.py-3.px-6
+              = l(pack.expires_at.to_date, format: :long)
+              - if pack.expired?
+                span.ml-2.px-2.py-0.5.text-xs.rounded.bg-red-100.text-red-700 expiré
+            td.py-3.px-6
+              = render "coworking_packs/payment_badge", pack: pack

--- a/app/views/coworking_packs/new.html.slim
+++ b/app/views/coworking_packs/new.html.slim
@@ -1,0 +1,31 @@
+- content_for :page_header do
+  = render "layouts/components/page_header",
+           title: "Nouveau pack de coworking"
+
+.max-w-xl.bg-white.rounded-lg.border.border-gray-100.p-6
+  = form_with model: @pack, url: coworking_packs_path, method: :post, class: "space-y-5" do |f|
+    div
+      = f.label :customer_id, "Client", class: "block text-sm font-medium text-gray-700 mb-1"
+      = f.collection_select :customer_id,
+                            Customer.order(:first_name, :last_name, :email),
+                            :id,
+                            :display_name,
+                            { prompt: "Choisir un client" },
+                            class: "w-full rounded-md border-gray-300 text-sm"
+    div
+      = f.label :days_total, "Pack", class: "block text-sm font-medium text-gray-700 mb-1"
+      = f.select :days_total,
+                 CoworkingPack::DAYS_OPTIONS.map { |d| ["#{d} journée#{'s' if d > 1} — #{number_to_currency(Pricing::Catalog.coworking_pack_cents(d) / 100.0, unit: '€', format: '%n %u')}", d] },
+                 {},
+                 class: "w-full rounded-md border-gray-300 text-sm"
+    div
+      = f.label :payment_method, "Moyen de paiement", class: "block text-sm font-medium text-gray-700 mb-1"
+      = f.select :payment_method,
+                 [["Carte", "card"], ["Virement", "bank_transfer"], ["Espèces", "cash"]],
+                 {},
+                 class: "w-full rounded-md border-gray-300 text-sm"
+      p.text-xs.text-gray-400.mt-1
+        | Virement et espèces créent un paiement en attente sur le pack.
+    div
+      = f.submit "Créer le pack",
+                 class: "inline-flex items-center rounded-md border border-transparent bg-4s-main px-4 py-2 text-sm font-medium text-white shadow-sm hover:opacity-90 cursor-pointer"

--- a/app/views/coworking_packs/show.html.slim
+++ b/app/views/coworking_packs/show.html.slim
@@ -1,0 +1,71 @@
+- content_for :page_header do
+  = render "layouts/components/page_header",
+           title: "Coworking — #{@pack.customer.display_name}",
+           links: [ \
+             button_to("🗑️ Supprimer le pack", coworking_pack_path(@pack), method: :delete, form: { data: { turbo_confirm: "Supprimer ce pack et ses journées ?" } }, class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50") \
+           ]
+
+.grid.gap-6.lg:grid-cols-3
+  .lg:col-span-1.space-y-4
+    .bg-white.rounded-lg.border.border-gray-100.p-5.space-y-3
+      div
+        .text-xs.uppercase.text-gray-400 Pack
+        .text-gray-900
+          = "#{@pack.days_total} journée#{'s' if @pack.days_total > 1}"
+          span.text-gray-400.ml-1
+            = number_to_currency(@pack.price_cents / 100.0, unit: "€", format: "%n %u")
+      div
+        .text-xs.uppercase.text-gray-400 Jours restants
+        .text-2xl.font-semibold.text-gray-900
+          = @pack.days_remaining
+      div
+        .text-xs.uppercase.text-gray-400 Expiration
+        .text-gray-900
+          = l(@pack.expires_at.to_date, format: :long)
+          - if @pack.expired?
+            span.ml-2.px-2.py-0.5.text-xs.rounded.bg-red-100.text-red-700 expiré
+      div
+        .text-xs.uppercase.text-gray-400 Paiement
+        div
+          = render "coworking_packs/payment_badge", pack: @pack
+
+    .bg-white.rounded-lg.border.border-gray-100.p-5
+      h3.text-sm.font-semibold.text-gray-700.mb-3 Réserver une journée
+      - if @pack.credits_left? && !@pack.expired?
+        = form_with model: CoworkingReservation.new, url: coworking_pack_coworking_reservations_path(@pack), method: :post, class: "flex items-center gap-2" do |f|
+          = f.date_field :date, class: "rounded-md border-gray-300 text-sm"
+          = f.submit "Réserver",
+                     class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 cursor-pointer"
+        p.text-xs.text-gray-400.mt-2
+          | Lundi à vendredi, 3 bureaux maximum par jour.
+      - else
+        p.text-sm.text-gray-500
+          = @pack.expired? ? "Ce pack est expiré." : "Plus aucune journée disponible sur ce pack."
+
+  .lg:col-span-2
+    .bg-white.rounded-lg.border.border-gray-100.overflow-hidden
+      table.w-full.text-sm.text-left.text-gray-500
+        thead.text-xs.text-gray-700.uppercase.bg-gray-50
+          tr
+            th.py-3.px-6[scope="col"]
+              | Journée réservée
+            th.py-3.px-6[scope="col"]
+              | Occupation du jour
+            th.w-32.py-3.px-6[scope="col"]
+        tbody
+          - if @reservations.empty?
+            tr
+              td.py-4.px-6.text-gray-400[colspan="3"]
+                | Aucune journée réservée pour l'instant.
+          - @reservations.each do |reservation|
+            tr.border-b.bg-white
+              td.py-3.px-6.text-gray-900
+                = l(reservation.date, format: :long)
+              td.py-3.px-6
+                = "#{CoworkingReservation.count_on(reservation.date)}/#{CoworkingReservation::DAILY_CAPACITY}"
+              td.py-3.px-6
+                = button_to "Annuler",
+                            coworking_pack_coworking_reservation_path(@pack, reservation),
+                            method: :delete,
+                            form: { data: { turbo_confirm: "Annuler cette journée ?" } },
+                            class: "text-xs text-red-600 hover:underline"

--- a/app/views/layouts/components/_navbar.html.slim
+++ b/app/views/layouts/components/_navbar.html.slim
@@ -201,6 +201,10 @@ nav.bg-white.shadow-sm.lg:px-6
                       spaces_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'spaces' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
           li
+            = link_to "Coworking",
+                      coworking_packs_path,
+                      class: "px-3 py-1.5 rounded-md transition-colors #{controller_name.start_with?('coworking') ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"
+          li
             = link_to "Objets à louer",
                       rental_items_path,
                       class: "px-3 py-1.5 rounded-md transition-colors #{controller_name == 'rental_items' ? 'text-4s-main bg-teal-50 font-medium' : 'text-gray-500 hover:text-4s-main hover:bg-teal-50/60'}"

--- a/app/views/pages/calendar/_day_bookings.html.slim
+++ b/app/views/pages/calendar/_day_bookings.html.slim
@@ -55,3 +55,15 @@
         = van.group_name.presence || van.name.presence || "Van"
       .text-xs.text-gray-500
         | 🚐 #{van.vehicles} véhicule#{"s" if van.vehicles.to_i > 1}
+
+/ 5) Coworking (epic #126, Phase 1) — domaine INDÉPENDANT des séjours : un seul
+/ bloc agrégé par jour, style distinct (indigo), sans `data-stay-id` : le mode
+/ fusion du calendrier ne peut donc jamais le sélectionner.
+- coworking_day = (@grouped_coworking_reservations || {})[date] || []
+- if coworking_day.any?
+  div(class="relative flex mt-2 py-1 px-2 min-w-0 shadow border-l-4" style="border-left-color: #4f46e5; background-color: #eef2ff;" data-coworking-day-entry=date.to_s title="#{coworking_day.map { |r| r.customer&.display_name }.compact.join(', ')}")
+    .block.min-w-0.w-full
+      strong.block.min-w-0.break-words.text-gray-700
+        = "💻 Coworking #{coworking_day.size}/#{CoworkingReservation::DAILY_CAPACITY}"
+      .text-xs.text-gray-500.break-words
+        = coworking_day.map { |r| r.customer&.display_name }.compact.join(", ")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,11 @@ Rails.application.routes.draw do
       end
     end
   end
+  # Coworking (epic #126, Phase 1) — domaine indépendant des séjours : packs de
+  # journées achetés par un client, journées posées dans la limite des crédits.
+  resources :coworking_packs, only: [:index, :show, :new, :create, :destroy] do
+    resources :coworking_reservations, only: [:create, :destroy]
+  end
   resources :decisions
   get "organisation/decisions", to: "decisions#index", as: :organisation_decisions
   resources :experiences do

--- a/db/migrate/20260721012423_create_coworking_packs.rb
+++ b/db/migrate/20260721012423_create_coworking_packs.rb
@@ -1,0 +1,18 @@
+class CreateCoworkingPacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :coworking_packs do |t|
+      t.references :customer, null: false, foreign_key: true
+      t.integer :days_total, null: false
+      t.integer :price_cents, null: false, default: 0
+      t.datetime :purchased_at, null: false
+      t.datetime :expires_at, null: false
+      t.string :payment_method, null: false
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :coworking_packs, :deleted_at
+    add_index :coworking_packs, :expires_at
+  end
+end

--- a/db/migrate/20260721012424_create_coworking_reservations.rb
+++ b/db/migrate/20260721012424_create_coworking_reservations.rb
@@ -1,0 +1,15 @@
+class CreateCoworkingReservations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :coworking_reservations do |t|
+      t.references :coworking_pack, null: false, foreign_key: true
+      t.references :customer, null: false, foreign_key: true
+      t.date :date, null: false
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :coworking_reservations, :date
+    add_index :coworking_reservations, :deleted_at
+  end
+end

--- a/db/migrate/20260721012425_add_coworking_pack_to_payments.rb
+++ b/db/migrate/20260721012425_add_coworking_pack_to_payments.rb
@@ -1,0 +1,5 @@
+class AddCoworkingPackToPayments < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :payments, :coworking_pack, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_21_012425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -173,6 +173,34 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "updated_at", null: false
     t.index ["deleted_at"], name: "index_camping_bookings_on_deleted_at"
     t.index ["from_date", "to_date"], name: "index_camping_bookings_on_from_date_and_to_date"
+  end
+
+  create_table "coworking_packs", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.integer "days_total", null: false
+    t.integer "price_cents", default: 0, null: false
+    t.datetime "purchased_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "payment_method", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_coworking_packs_on_customer_id"
+    t.index ["deleted_at"], name: "index_coworking_packs_on_deleted_at"
+    t.index ["expires_at"], name: "index_coworking_packs_on_expires_at"
+  end
+
+  create_table "coworking_reservations", force: :cascade do |t|
+    t.bigint "coworking_pack_id", null: false
+    t.bigint "customer_id", null: false
+    t.date "date", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coworking_pack_id"], name: "index_coworking_reservations_on_coworking_pack_id"
+    t.index ["customer_id"], name: "index_coworking_reservations_on_customer_id"
+    t.index ["date"], name: "index_coworking_reservations_on_date"
+    t.index ["deleted_at"], name: "index_coworking_reservations_on_deleted_at"
   end
 
   create_table "customers", force: :cascade do |t|
@@ -472,7 +500,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.string "stripe_payment_intent_id"
     t.bigint "stay_id"
     t.bigint "space_booking_id"
+    t.bigint "coworking_pack_id"
     t.index ["booking_id"], name: "index_payments_on_booking_id"
+    t.index ["coworking_pack_id"], name: "index_payments_on_coworking_pack_id"
     t.index ["id"], name: "index_payments_on_id", unique: true
     t.index ["space_booking_id"], name: "index_payments_on_space_booking_id"
     t.index ["stay_id"], name: "index_payments_on_stay_id"
@@ -498,6 +528,16 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["human_id"], name: "index_projects_on_human_id"
+  end
+
+  create_table "rates", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "amount_cents", default: 0, null: false
+    t.string "label"
+    t.string "unit", default: "cents", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_rates_on_key", unique: true
   end
 
   create_table "rental_items", force: :cascade do |t|
@@ -765,6 +805,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   add_foreign_key "bookings", "lodgings"
   add_foreign_key "bundles", "projects"
   add_foreign_key "bundles", "teams"
+  add_foreign_key "coworking_packs", "customers"
+  add_foreign_key "coworking_reservations", "coworking_packs"
+  add_foreign_key "coworking_reservations", "customers"
   add_foreign_key "customers", "humans"
   add_foreign_key "cycle_actions", "humans"
   add_foreign_key "cycle_actions", "humans", column: "delegate_to_human_id"
@@ -788,6 +831,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   add_foreign_key "lodging_rooms", "rooms"
   add_foreign_key "meal_orders", "stays"
   add_foreign_key "payments", "bookings"
+  add_foreign_key "payments", "coworking_packs"
   add_foreign_key "payments", "space_bookings"
   add_foreign_key "payments", "stays"
   add_foreign_key "projects", "humans"

--- a/spec/models/coworking_pack_spec.rb
+++ b/spec/models/coworking_pack_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+# Epic #126, Phase 1 — packs de coworking.
+RSpec.describe CoworkingPack, type: :model do
+  let(:customer) { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+
+  def pack(attrs = {})
+    CoworkingPack.create!({ customer: customer, days_total: 5, payment_method: "card" }.merge(attrs))
+  end
+
+  it "prend le prix du barème et une validité de 12 mois" do
+    p = pack
+    expect(p.price_cents).to eq(8_000)
+    expect(p.expires_at.to_date).to eq(p.purchased_at.to_date + 12.months)
+  end
+
+  it "n'accepte que les tailles de pack du barème" do
+    expect(CoworkingPack.new(customer: customer, days_total: 3, payment_method: "card")).not_to be_valid
+  end
+
+  it "n'accepte que les moyens de paiement connus" do
+    expect(CoworkingPack.new(customer: customer, days_total: 5, payment_method: "bitcoin")).not_to be_valid
+  end
+
+  describe "#days_remaining" do
+    it "décompte les journées vivantes, pas celles annulées" do
+      p = pack(days_total: 5)
+      p.coworking_reservations.create!(date: Date.new(2026, 9, 7))
+      r = p.coworking_reservations.create!(date: Date.new(2026, 9, 8))
+
+      expect(p.reload.days_remaining).to eq(3)
+
+      r.soft_delete!(validate: false)
+      expect(p.reload.days_remaining).to eq(4)
+    end
+  end
+
+  describe "#payment_status" do
+    it "est unpaid sans paiement, pending avec un paiement en attente, paid une fois encaissé" do
+      p = pack(days_total: 5)
+      expect(p.payment_status).to eq("unpaid")
+
+      pending = Payment.create!(coworking_pack: p, amount_cents: 8_000,
+                                payment_method: "bank_transfer", status: "pending")
+      expect(p.reload.payment_status).to eq("pending")
+
+      pending.update!(status: "paid")
+      expect(p.reload.payment_status).to eq("paid")
+    end
+  end
+
+  it "sait s'il est expiré" do
+    p = pack
+    p.update!(expires_at: 1.day.ago)
+    expect(p).to be_expired
+  end
+
+  it "trace ses modifications avec PaperTrail et se supprime en douceur" do
+    p = pack
+    expect { p.update!(days_total: 10) }.to change { p.versions.count }.by(1)
+
+    p.soft_delete!(validate: false)
+    expect(CoworkingPack.where(id: p.id)).to be_empty
+    expect(CoworkingPack.unscoped.where(id: p.id)).to be_present
+  end
+end

--- a/spec/models/coworking_reservation_spec.rb
+++ b/spec/models/coworking_reservation_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+# Epic #126, Phase 1 — journées de coworking.
+RSpec.describe CoworkingReservation, type: :model do
+  # 2026-09-07 est un lundi.
+  let(:monday)   { Date.new(2026, 9, 7) }
+  let(:saturday) { Date.new(2026, 9, 12) }
+
+  def customer(suffix)
+    Customer.create!(first_name: "C#{suffix}", last_name: "Test", email: "c#{suffix}@example.com")
+  end
+
+  def pack(days: 20, owner: customer(SecureRandom.hex(4)))
+    CoworkingPack.create!(customer: owner, days_total: days, payment_method: "card")
+  end
+
+  it "dénormalise le client depuis le pack" do
+    p = pack
+    reservation = p.coworking_reservations.create!(date: monday)
+    expect(reservation.customer).to eq(p.customer)
+  end
+
+  it "refuse un samedi ou un dimanche" do
+    reservation = pack.coworking_reservations.new(date: saturday)
+    expect(reservation).not_to be_valid
+    expect(reservation.errors[:date].join).to include("lundi à vendredi")
+  end
+
+  it "refuse au-delà de la capacité GLOBALE de 3 bureaux par jour" do
+    3.times { pack.coworking_reservations.create!(date: monday) }
+
+    fourth = pack.coworking_reservations.new(date: monday)
+    expect(fourth).not_to be_valid
+    expect(fourth.errors[:date].join).to include("complet")
+  end
+
+  it "libère une place quand une journée est annulée" do
+    reservations = 3.times.map { pack.coworking_reservations.create!(date: monday) }
+    reservations.first.soft_delete!(validate: false)
+
+    expect(pack.coworking_reservations.new(date: monday)).to be_valid
+  end
+
+  it "refuse quand le pack n'a plus de crédit" do
+    p = pack(days: 1)
+    p.coworking_reservations.create!(date: monday)
+
+    second = p.coworking_reservations.new(date: monday + 1)
+    expect(second).not_to be_valid
+    expect(second.errors[:coworking_pack].join).to include("plus de journée")
+  end
+
+  it "refuse une date après l'expiration du pack" do
+    p = pack
+    p.update!(expires_at: monday - 1.day)
+
+    reservation = p.coworking_reservations.new(date: monday)
+    expect(reservation).not_to be_valid
+    expect(reservation.errors[:coworking_pack].join).to include("expiré")
+  end
+
+  it "refuse deux journées le même jour sur le même pack" do
+    p = pack
+    p.coworking_reservations.create!(date: monday)
+
+    expect(p.coworking_reservations.new(date: monday)).not_to be_valid
+  end
+
+  it "compte l'occupation d'un jour tous packs confondus" do
+    2.times { pack.coworking_reservations.create!(date: monday) }
+
+    expect(CoworkingReservation.count_on(monday)).to eq(2)
+    expect(CoworkingReservation.remaining_on(monday)).to eq(1)
+  end
+end

--- a/spec/models/payment_coworking_anchor_spec.rb
+++ b/spec/models/payment_coworking_anchor_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+# Epic #126, Phase 1 — l'invariant du verrouillage (epic #26, Phase 4) devient
+# « stay_id OU coworking_pack_id ».
+RSpec.describe "Payment — ancrage séjour ou pack de coworking", type: :model do
+  let(:customer) { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+  let(:stay) { Stay.create!(customer: customer, arrival_date: Date.new(2026, 9, 7), departure_date: Date.new(2026, 9, 9)) }
+  let(:pack) { CoworkingPack.create!(customer: customer, days_total: 5, payment_method: "bank_transfer") }
+
+  it "accepte un paiement ancré sur un séjour (sans pack)" do
+    payment = Payment.new(stay: stay, amount_cents: 5_000, payment_method: "card", status: "paid")
+    expect(payment).to be_valid
+  end
+
+  it "accepte un paiement ancré sur un pack de coworking (sans séjour)" do
+    payment = Payment.new(coworking_pack: pack, amount_cents: 8_000, payment_method: "bank_transfer", status: "pending")
+    expect(payment).to be_valid
+  end
+
+  it "refuse un paiement sans aucune ancre" do
+    payment = Payment.new(amount_cents: 5_000, payment_method: "card", status: "paid")
+    expect(payment).not_to be_valid
+    expect(payment.errors[:stay]).to be_present
+  end
+
+  it "refuse un paiement portant les deux ancres" do
+    payment = Payment.new(stay: stay, coworking_pack: pack, amount_cents: 5_000,
+                          payment_method: "card", status: "paid")
+    expect(payment).not_to be_valid
+  end
+end

--- a/spec/requests/calendar_coworking_block_spec.rb
+++ b/spec/requests/calendar_coworking_block_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+# Epic #126, Phase 1 — le coworking apparaît au calendrier dans un bloc DISTINCT
+# des séjours, et n'est jamais sélectionnable par le mode fusion.
+RSpec.describe "Calendrier — bloc coworking", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent-cwk@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  def pack_for(name)
+    customer = Customer.create!(first_name: name, last_name: "Test",
+                                email: "#{name.downcase}@example.com")
+    CoworkingPack.create!(customer: customer, days_total: 5, payment_method: "card")
+  end
+
+  it "rend « 💻 Coworking 2/3 » avec les noms, sans data-stay-id" do
+    day = Date.today.beginning_of_month.next_occurring(:tuesday)
+
+    pack_for("Ana").coworking_reservations.create!(date: day)
+    pack_for("Bruno").coworking_reservations.create!(date: day)
+
+    get "/", params: { start_date: day.to_s }
+    expect(response).to have_http_status(:ok)
+
+    expect(response.body).to include("💻 Coworking 2/3")
+    expect(response.body).to include("Ana")
+    expect(response.body).to include("Bruno")
+
+    # Le bloc coworking ne porte PAS de data-stay-id : le mode fusion (qui ne
+    # sélectionne que ces blocs-là) ne peut donc jamais l'attraper.
+    block = response.body[/data-coworking-day-entry="#{day}".*?💻 Coworking 2\/3/m]
+    expect(block).to be_present
+    expect(block).not_to include("data-stay-id")
+  end
+
+  it "n'affiche aucun bloc coworking un jour sans réservation" do
+    day = Date.today.beginning_of_month.next_occurring(:tuesday)
+
+    get "/", params: { start_date: day.to_s }
+
+    expect(response.body).not_to include("💻 Coworking")
+  end
+end

--- a/spec/requests/coworking_packs_spec.rb
+++ b/spec/requests/coworking_packs_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+# Epic #126, Phase 1 — admin des packs de coworking.
+RSpec.describe "Coworking (admin)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  let(:customer) { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+  let(:monday) { Date.new(2026, 9, 7) }
+
+  before { sign_in user }
+
+  describe "GET /coworking_packs" do
+    it "liste les packs avec jours restants, expiration et badge paiement" do
+      pack = CoworkingPack.create!(customer: customer, days_total: 10, payment_method: "card")
+      pack.coworking_reservations.create!(date: monday)
+
+      get coworking_packs_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Coworking")
+      expect(response.body).to include("Ana")
+      expect(response.body).to include("non payé")
+      # 9 journées restantes sur 10
+      expect(response.body).to include("/ 10")
+    end
+  end
+
+  describe "POST /coworking_packs" do
+    it "crée un pack payé par carte, sans paiement en attente" do
+      expect {
+        post coworking_packs_path, params: {
+          coworking_pack: { customer_id: customer.id, days_total: 5, payment_method: "card" }
+        }
+      }.to change(CoworkingPack, :count).by(1)
+
+      pack = CoworkingPack.last
+      expect(pack.price_cents).to eq(8_000)
+      expect(pack.payments).to be_empty
+      expect(response).to redirect_to(coworking_pack_path(pack))
+    end
+
+    it "crée un Payment en attente pour un virement" do
+      post coworking_packs_path, params: {
+        coworking_pack: { customer_id: customer.id, days_total: 20, payment_method: "bank_transfer" }
+      }
+
+      pack = CoworkingPack.last
+      expect(pack.payments.count).to eq(1)
+      payment = pack.payments.first
+      expect(payment.status).to eq("pending")
+      expect(payment.amount_cents).to eq(30_000)
+      expect(payment.stay_id).to be_nil
+      expect(pack.payment_status).to eq("pending")
+    end
+
+    it "refuse une taille de pack hors barème" do
+      expect {
+        post coworking_packs_path, params: {
+          coworking_pack: { customer_id: customer.id, days_total: 3, payment_method: "cash" }
+        }
+      }.not_to change(CoworkingPack, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "journées d'un pack" do
+    let(:pack) { CoworkingPack.create!(customer: customer, days_total: 5, payment_method: "card") }
+
+    it "pose une journée" do
+      expect {
+        post coworking_pack_coworking_reservations_path(pack),
+             params: { coworking_reservation: { date: monday.to_s } }
+      }.to change { pack.coworking_reservations.count }.by(1)
+
+      expect(response).to redirect_to(coworking_pack_path(pack))
+    end
+
+    it "refuse un week-end avec un message et sans rien créer" do
+      expect {
+        post coworking_pack_coworking_reservations_path(pack),
+             params: { coworking_reservation: { date: (monday + 5).to_s } }
+      }.not_to change { pack.coworking_reservations.count }
+
+      follow_redirect!
+      expect(response.body).to include("lundi à vendredi")
+    end
+
+    it "refuse un 4e bureau le même jour" do
+      3.times do
+        other = CoworkingPack.create!(
+          customer: Customer.create!(first_name: "X", last_name: SecureRandom.hex(3), email: "#{SecureRandom.hex(4)}@example.com"),
+          days_total: 5, payment_method: "card"
+        )
+        other.coworking_reservations.create!(date: monday)
+      end
+
+      expect {
+        post coworking_pack_coworking_reservations_path(pack),
+             params: { coworking_reservation: { date: monday.to_s } }
+      }.not_to change { pack.coworking_reservations.count }
+
+      follow_redirect!
+      expect(response.body).to include("complet")
+    end
+
+    it "annule une journée en douceur et rend le crédit" do
+      reservation = pack.coworking_reservations.create!(date: monday)
+
+      delete coworking_pack_coworking_reservation_path(pack, reservation)
+
+      expect(pack.reload.days_remaining).to eq(5)
+      expect(CoworkingReservation.unscoped.find(reservation.id).deleted_at).to be_present
+    end
+
+    it "supprime le pack en douceur" do
+      delete coworking_pack_path(pack)
+
+      expect(CoworkingPack.where(id: pack.id)).to be_empty
+      expect(response).to redirect_to(coworking_packs_path)
+    end
+  end
+
+  describe "sans authentification" do
+    it "redirige vers la connexion" do
+      sign_out user
+      get coworking_packs_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end

--- a/spec/requests/coworking_space_retired_spec.rb
+++ b/spec/requests/coworking_space_retired_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+# Amendement Michael 2026-07-21 (epic #126) : dès la livraison du domaine
+# coworking, l'espace « Coworking » (Space capacity 3) sort du canal espaces —
+# plus proposé nulle part à la composition ni à la réservation d'espaces. Son
+# historique `SpaceBooking` reste intact et lisible.
+RSpec.describe "Espace « Coworking » retiré du canal espaces", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  let!(:coworking_space) { Space.find_or_create_by!(code: "CWK") { |s| s.name = "Coworking"; s.capacity = 3 } }
+
+  it "n'est plus listé dans le calendrier public de disponibilités" do
+    expect(Public::CalendarsController::CALENDAR_SPACE_NAMES).not_to include("Coworking")
+
+    get public_calendrier_hebergements_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include(">Coworking<")
+  end
+
+  it "n'apparaît dans aucune grille de composition de séjour (admin ni public)" do
+    sign_in user
+
+    get new_stay_path
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("Coworking")
+
+    get compose_grids_stays_path, params: { arrival_date: "2026-09-07", departure_date: "2026-09-10" }
+    expect(response).to have_http_status(:ok)
+    # La grille d'espaces est bornée aux espaces facturables du barème.
+    expect(response.body).to include("Grande Salle")
+    expect(response.body).not_to include("Coworking")
+  end
+
+  it "laisse l'historique SpaceBooking de l'espace intact" do
+    booking = SpaceBooking.create!(firstname: "Ancien", group_name: "Ancien coworking",
+                                   from_date: Date.new(2026, 3, 3), to_date: Date.new(2026, 3, 4),
+                                   status: "confirmed")
+    reservation = SpaceReservation.create!(space: coworking_space,
+                                           space_booking: booking,
+                                           date: Date.new(2026, 3, 3))
+
+    expect(reservation.reload.space).to eq(coworking_space)
+    expect(coworking_space.reload).to be_persisted
+  end
+end


### PR DESCRIPTION
Closes #127

Phase 1 de l'epic #126. Le socle de données et l'outillage admin du coworking, **avant** le portail. Le coworking n'est pas un séjour : c'est un domaine à part, qui ne touche ni les séjours, ni le veto, ni la fusion.

## Modèles

- **`CoworkingPack`** — client, `days_total` (1/5/10/20), `price_cents` (pris au barème, jamais au formulaire), `purchased_at`, `expires_at` (+12 mois), `payment_method` (card/bank_transfer/cash). Soft-deletion + PaperTrail. `days_remaining` = `days_total` − réservations **vivantes** (une journée annulée rend son crédit).
  Le **statut de paiement est dérivé** des `Payment` ancrés dessus (`paid` / `pending` / `unpaid`) — le pack ne porte aucune colonne de statut, pour qu'il n'y ait jamais deux vérités.
- **`CoworkingReservation`** — pack, client (dénormalisé du pack), `date`. Validations : capacité **globale** ≤ 3/jour (réservations vivantes, tous packs confondus), lundi-vendredi, pack non expiré **à la date demandée**, crédits > 0, et pas deux fois le même jour sur le même pack. Soft-deletion + PaperTrail.
- **`Payment`** — nouvelle colonne `coworking_pack_id` (nullable + FK, même pattern que `space_booking_id`). L'invariant du verrouillage (epic #26, Phase 4) devient **« stay_id OU coworking_pack_id »** : `stay` redevient `optional`, et une validation dédiée refuse un paiement sans ancre **et** un paiement portant les deux.
- **Barème** — `Pricing::Catalog::COWORKING_PACKS` (20/80/160/300 €), lu depuis la table `rates` (#124) via `Pricing::Catalog.coworking_pack_cents`. La lecture est **défensive** : #124 n'est pas encore mergée, donc on ne suppose jamais l'existence de la table.

## Admin & calendrier

- Entrée **« Coworking »** dans la sous-nav Paramètres : liste des packs (client, pack + prix, jours restants, expiration + badge « expiré », badge paiement), page pack avec pose/annulation de journées, suppression douce.
- **L'admin n'est pas bridée** : aucune limite d'heure ici (c'est une règle de Phase 3, côté portail). Seules les règles de domaine s'appliquent.
- Virement / espèces → un `Payment` **pending** est créé sur le pack à sa création. Carte → aucun paiement (encaissement hors ligne en Phase 1).
- **Calendrier admin** : un bloc agrégé par jour, `💻 Coworking N/3`, avec les noms (visibles + en `title`), style indigo distinct des séjours. Il ne porte **pas** de `data-stay-id` — le mode fusion, qui ne sélectionne que ces blocs-là, ne peut donc jamais l'attraper.

## Amendement du 2026-07-21 (espace « Coworking » retiré du canal espaces)

Le nouveau domaine devient l'unique source de vérité des 3 bureaux. Concrètement, dans le code actuel :
- Les **grilles de composition** (admin et funnel public) sont déjà bornées aux 3 espaces facturables du barème (`grande_salle`, `petite_salle`, `cuisine_pro`) — « Coworking » n'y était donc déjà pas ; c'est désormais **couvert par une spec** pour que ça le reste.
- La **réservation d'espaces directe** n'existe plus (`space_bookings` n'a plus ni `new` ni `create` depuis l'epic #81, Phase 9).
- Le seul endroit qui l'exposait encore était le **calendrier public de disponibilités** (`Public::CalendarsController::CALENDAR_SPACE_NAMES`) : « Coworking » en a été retiré.
- L'historique `SpaceBooking` / `SpaceReservation` de l'espace reste **intact** (spec dédiée) ; l'espace lui-même n'est ni supprimé ni renommé.

## Vérification

- `bundle exec rspec` → **1000 examples, 0 failures**, 16 pending (les pending préexistent sur `main`).
- Specs ajoutées : modèle pack (barème, validité 12 mois, tailles/moyens de paiement, jours restants avec annulation, statut de paiement dérivé sur les 3 états, expiration, PaperTrail + soft-deletion) ; modèle réservation (dénormalisation, week-end refusé, capacité globale 3, place libérée par annulation, crédits épuisés, pack expiré, doublon, comptage du jour) ; ancrage `Payment` (séjour seul ✅, pack seul ✅, aucun ❌, les deux ❌) ; request specs admin (liste, création carte sans paiement, création virement avec `Payment` pending à 300 €, taille hors barème refusée, pose de journée, week-end refusé, 4e bureau refusé, annulation qui rend le crédit, suppression douce, auth requise) ; calendrier (« 💻 Coworking 2/3 » avec les noms et **sans** `data-stay-id`, absence de bloc un jour vide) ; amendement espace retiré.
- Pas de linter dans le repo (ni RuboCop, ni script `lint` dans `package.json` ; le seul workflow CI est `agent-ready-gate.yml`) — rien à faire côté lint.

## 📸 Aperçu

**Pas de capture, et c'est un trou assumé.** Les écrans sont derrière Devise, donc Chrome headless seul ne peut pas les atteindre ; et le chemin Capybara est cassé sur cette machine — le repo épingle `webdrivers 5.2.0` + `selenium-webdriver 4.5.0`, qui interrogent l'ancien endpoint `chromedriver.storage.googleapis.com` (404 pour Chrome 150) et sont antérieurs à Selenium Manager. Il n'existe par ailleurs aucun `spec/system` dans le repo. Débloquer ça = bumper `selenium-webdriver` et retirer `webdrivers` — hors périmètre.

## À valider à la main

- Les écrans **Paramètres > Coworking** (liste + page pack) et le **bloc calendrier** avec l'œil.
- Le **select client** de la création de pack liste tous les clients (341 en dev) sans autocomplete — si ça devient pénible, on branchera `customers#search` en Phase 2.
- Les prix des packs (20 / 80 / 160 / 300 €) sont ceux de l'issue — à confirmer.

## Points d'articulation avec les autres chantiers

- **#124 (Tarifs)** : les clés `coworking.pack_1|5|10|20` ne sont **pas** dans le seed `rates:seed_from_catalog` de la PR #134 (les deux branches sont parties de `main` en parallèle). Après merge des deux, il restera à ajouter ces 4 entrées au seed pour qu'elles soient éditables depuis l'écran Tarifs. Le repli sur les constantes fonctionne d'ici là.
- **#128 (Phase 2, portail OTP)** : indépendante, aucune dépendance de code.
