### PR TITLE
Coworking Phase 2 — portail client OTP + « Mes séjours » (#128)

### DIFF
--- a/app/controllers/portal/base_controller.rb
+++ b/app/controllers/portal/base_controller.rb
@@ -1,0 +1,47 @@
+module Portal
+  # Socle du portail client (epic #126, Phase 2).
+  #
+  # La session portail est un cookie SIGNÉ dédié, totalement indépendant de
+  # Devise : elle n'ouvre AUCUN accès admin, et l'admin connectée n'ouvre aucun
+  # accès portail. Durée 24 h.
+  class BaseController < Public::BaseController
+    layout "public_sheet"
+
+    SESSION_COOKIE = :portal_customer_id
+    SESSION_DURATION = 24.hours
+
+    helper_method :current_portal_customer, :portal_signed_in?
+
+    private
+
+    def current_portal_customer
+      return @current_portal_customer if defined?(@current_portal_customer)
+
+      id = cookies.signed[SESSION_COOKIE]
+      @current_portal_customer = id.present? ? Customer.find_by(id: id) : nil
+    end
+
+    def portal_signed_in? = current_portal_customer.present?
+
+    def sign_in_portal(customer)
+      cookies.signed[SESSION_COOKIE] = {
+        value: customer.id,
+        expires: SESSION_DURATION.from_now,
+        httponly: true,
+        same_site: :lax
+      }
+      @current_portal_customer = customer
+    end
+
+    def sign_out_portal
+      cookies.delete(SESSION_COOKIE)
+      @current_portal_customer = nil
+    end
+
+    def require_portal_customer
+      return if portal_signed_in?
+
+      redirect_to portal_path, alert: t("portal.session.required")
+    end
+  end
+end

--- a/app/controllers/portal/sessions_controller.rb
+++ b/app/controllers/portal/sessions_controller.rb
@@ -1,0 +1,63 @@
+module Portal
+  # Connexion au portail par code à usage unique envoyé par email (pas de mot
+  # de passe, pas de Devise).
+  #
+  # Anti-énumération : quel que soit l'email saisi — inconnu, fourre-tout, ou
+  # bien réel — la réponse est TOUJOURS la même. Rien dans le corps, le statut
+  # ou le temps de réponse ne dit si un compte existe.
+  class SessionsController < Portal::BaseController
+    def new
+      redirect_to portal_stays_path and return if portal_signed_in?
+
+      @email = params[:email].to_s
+    end
+
+    # POST /portail/code — émet et envoie un code, si et seulement si l'email
+    # correspond à un client réel non fourre-tout.
+    def create_code
+      email = params[:email].to_s.strip.downcase
+
+      if deliverable_customer(email)
+        otp, code = PortalOtp.issue!(email)
+        PortalMailer.login_code(email: email, code: code, expires_at: otp.expires_at).deliver_later
+      end
+
+      @email = email
+      render :verify
+    end
+
+    # POST /portail/connexion — vérifie le code saisi.
+    def create
+      email = params[:email].to_s.strip.downcase
+      customer = deliverable_customer(email)
+
+      if customer && PortalOtp.verify(email, params[:code])
+        sign_in_portal(customer)
+        redirect_to portal_stays_path
+      else
+        @email = email
+        flash.now[:alert] = t("portal.session.invalid_code")
+        render :verify, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      sign_out_portal
+      redirect_to portal_path, notice: t("portal.session.signed_out")
+    end
+
+    private
+
+    # Le client à qui l'on accepte d'envoyer un code : email exact, et JAMAIS un
+    # fourre-tout (`Customer#catch_all?`) — ces adresses partagées donneraient
+    # accès aux séjours de dizaines de clients.
+    def deliverable_customer(email)
+      return nil if email.blank?
+
+      customer = Customer.find_by(email: email)
+      return nil if customer.nil? || customer.catch_all?
+
+      customer
+    end
+  end
+end

--- a/app/controllers/portal/stays_controller.rb
+++ b/app/controllers/portal/stays_controller.rb
@@ -1,0 +1,17 @@
+module Portal
+  # « Mes séjours » — la liste des séjours du client connecté au portail.
+  #
+  # Le scope part TOUJOURS de `current_portal_customer` : il n'y a aucun
+  # paramètre d'identifiant client dans l'URL, donc rien à forger.
+  class StaysController < Portal::BaseController
+    before_action :require_portal_customer
+
+    def index
+      stays = current_portal_customer.stays
+                                     .includes(:customer, stay_items: :bookable)
+                                     .order(Arel.sql("departure_date >= CURRENT_DATE DESC, arrival_date ASC"))
+
+      @stays = StayDecorator.decorate_collection(stays)
+    end
+  end
+end

--- a/app/mailers/portal_mailer.rb
+++ b/app/mailers/portal_mailer.rb
@@ -1,0 +1,12 @@
+# Emails du portail client (epic #126, Phase 2).
+class PortalMailer < ApplicationMailer
+  # Code de connexion à usage unique. Texte sobre : le code, sa durée de vie,
+  # et rien d'autre — surtout aucune donnée du séjour ni du client.
+  def login_code(email:, code:, expires_at:)
+    @code = code
+    @expires_at = expires_at
+    @minutes = PortalOtp::VALIDITY.inspect
+
+    mail(to: email, subject: "Votre code de connexion — Les 4 Sources")
+  end
+end

--- a/app/models/portal_otp.rb
+++ b/app/models/portal_otp.rb
@@ -1,0 +1,55 @@
+# Code à usage unique du portail client (epic #126, Phase 2).
+#
+# Le code n'est JAMAIS stocké en clair : seul son digest l'est. On ne peut donc
+# pas le relire depuis la base — seulement vérifier une saisie.
+#
+# Un code vit 15 minutes et tolère 5 tentatives ; au-delà, il est brûlé et le
+# client doit en redemander un.
+class PortalOtp < ApplicationRecord
+  CODE_LENGTH = 6
+  VALIDITY = 15.minutes
+  MAX_ATTEMPTS = 5
+
+  validates :email, :code_digest, :expires_at, presence: true
+
+  scope :usable, -> { where(consumed_at: nil).where("expires_at > ?", Time.current) }
+  scope :for_email, ->(email) { where(email: email.to_s.strip.downcase) }
+
+  # Émet un code pour cet email et retourne [otp, code_en_clair]. Les codes
+  # précédents encore vivants sont brûlés : un seul code valide à la fois.
+  def self.issue!(email)
+    normalized = email.to_s.strip.downcase
+    for_email(normalized).usable.update_all(consumed_at: Time.current)
+
+    code = SecureRandom.random_number(10**CODE_LENGTH).to_s.rjust(CODE_LENGTH, "0")
+    otp = create!(email: normalized,
+                  code_digest: digest(code),
+                  expires_at: Time.current + VALIDITY)
+    [otp, code]
+  end
+
+  # Vérifie une saisie pour cet email. Retourne l'OTP consommé, ou nil.
+  # Chaque échec consomme une tentative ; à MAX_ATTEMPTS, le code est brûlé.
+  def self.verify(email, code)
+    otp = for_email(email).usable.order(created_at: :desc).first
+    return nil if otp.nil?
+
+    if ActiveSupport::SecurityUtils.secure_compare(otp.code_digest, digest(code.to_s.strip))
+      otp.update!(consumed_at: Time.current)
+      return otp
+    end
+
+    otp.attempts += 1
+    otp.consumed_at = Time.current if otp.attempts >= MAX_ATTEMPTS
+    otp.save!
+    nil
+  end
+
+  def self.digest(code)
+    Digest::SHA256.hexdigest("portal-otp:#{code}")
+  end
+
+  def expired?(now = Time.current) = expires_at <= now
+
+  def consumed? = consumed_at.present?
+end

--- a/app/views/portal/sessions/new.html.slim
+++ b/app/views/portal/sessions/new.html.slim
@@ -1,0 +1,14 @@
+- content_for :meta_title do
+  | Mon espace client
+
+.px-6.py-8.md:px-10.space-y-6
+  h1.text-2xl.font-semibold.text-gray-900 Mon espace client
+  p.text-sm.text-gray-500
+    | Entrez l'adresse email que vous nous avez communiquée. Nous vous envoyons un code à usage unique — pas de mot de passe à retenir.
+
+  = form_with url: portal_code_path, method: :post, class: "space-y-4 max-w-sm" do
+    div
+      label.block.text-sm.font-medium.text-gray-700.mb-1[for="email"] Votre adresse email
+      = email_field_tag :email, @email, required: true, autofocus: true, class: "w-full rounded-md border-gray-300 text-sm"
+    = submit_tag "Recevoir mon code",
+                 class: "inline-flex items-center rounded-md border border-transparent bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-700 cursor-pointer"

--- a/app/views/portal/sessions/verify.html.slim
+++ b/app/views/portal/sessions/verify.html.slim
@@ -1,0 +1,19 @@
+- content_for :meta_title do
+  | Mon espace client
+
+.px-6.py-8.md:px-10.space-y-6
+  h1.text-2xl.font-semibold.text-gray-900 Entrez votre code
+  / Message NEUTRE : identique pour un email connu, inconnu ou fourre-tout.
+  / Rien ici ne permet de savoir si un compte existe.
+  p.text-sm.text-gray-500
+    | Si un compte existe pour cette adresse, un code vient d'être envoyé. Il est valable 15 minutes.
+
+  = form_with url: portal_login_path, method: :post, class: "space-y-4 max-w-sm" do
+    = hidden_field_tag :email, @email
+    div
+      label.block.text-sm.font-medium.text-gray-700.mb-1[for="code"] Code à 6 chiffres
+      = text_field_tag :code, nil, required: true, autofocus: true, inputmode: "numeric", autocomplete: "one-time-code", maxlength: 6, class: "w-full rounded-md border-gray-300 text-sm tracking-widest"
+    = submit_tag "Me connecter",
+                 class: "inline-flex items-center rounded-md border border-transparent bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-700 cursor-pointer"
+
+  = link_to "Recevoir un nouveau code", portal_path(email: @email), class: "text-sm text-emerald-600 hover:underline"

--- a/app/views/portal/stays/index.html.slim
+++ b/app/views/portal/stays/index.html.slim
@@ -1,0 +1,28 @@
+- content_for :meta_title do
+  | Mes séjours
+
+.px-6.py-8.md:px-10.space-y-6
+  .flex.items-start.justify-between.gap-4
+    div
+      h1.text-2xl.font-semibold.text-gray-900 Mes séjours
+      p.text-sm.text-gray-500
+        = current_portal_customer.display_name
+    = button_to "Me déconnecter", portal_logout_path, method: :delete, class: "text-sm text-gray-500 hover:text-gray-700 underline"
+
+  - if @stays.empty?
+    .rounded-lg.border.border-gray-100.bg-gray-50.p-6.text-sm.text-gray-500
+      | Aucun séjour pour l'instant. Dès qu'une réservation sera enregistrée à votre nom, elle apparaîtra ici.
+  - else
+    ul.space-y-4
+      - @stays.each do |stay|
+        li.rounded-lg.border.border-gray-100.bg-white.shadow-sm.p-5.space-y-3
+          .flex.flex-wrap.items-center.gap-2
+            = stay.status_badge
+            = stay.payment_status_badge
+          .text-lg.font-medium.text-gray-900
+            = "#{l(stay.arrival_date, format: :long)} → #{l(stay.departure_date, format: :long)}"
+          .text-sm.text-gray-500
+            = stay.composition_summary
+          = link_to "Voir mon séjour →",
+                    public_stay_path(stay.token),
+                    class: "inline-block text-sm text-emerald-600 hover:underline"

--- a/app/views/portal_mailer/login_code.html.slim
+++ b/app/views/portal_mailer/login_code.html.slim
@@ -1,0 +1,11 @@
+p Bonjour,
+p
+  | Voici votre code de connexion à votre espace client des 4 Sources :
+p style="font-size: 28px; font-weight: bold; letter-spacing: 6px;"
+  = @code
+p
+  = "Ce code est valable #{PortalOtp::VALIDITY.inspect}."
+p
+  | Si vous n'avez pas demandé ce code, vous pouvez ignorer ce message.
+p
+  | — Les 4 Sources

--- a/app/views/portal_mailer/login_code.text.erb
+++ b/app/views/portal_mailer/login_code.text.erb
@@ -1,0 +1,11 @@
+Bonjour,
+
+Voici votre code de connexion à votre espace client des 4 Sources :
+
+<%= @code %>
+
+Ce code est valable <%= PortalOtp::VALIDITY.inspect %>.
+
+Si vous n'avez pas demandé ce code, vous pouvez ignorer ce message.
+
+— Les 4 Sources

--- a/config/locales/portal.en.yml
+++ b/config/locales/portal.en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  portal:
+    session:
+      required: "Sign in to access your customer area."
+      invalid_code: "This code is incorrect or expired. Request a new one if needed."
+      signed_out: "You have been signed out."

--- a/config/locales/portal.fr.yml
+++ b/config/locales/portal.fr.yml
@@ -1,0 +1,7 @@
+---
+fr:
+  portal:
+    session:
+      required: "Connectez-vous pour accéder à votre espace client."
+      invalid_code: "Ce code est incorrect ou expiré. Demandez-en un nouveau si besoin."
+      signed_out: "Vous êtes déconnecté."

--- a/config/locales/portal.nl.yml
+++ b/config/locales/portal.nl.yml
@@ -1,0 +1,7 @@
+---
+nl:
+  portal:
+    session:
+      required: "Log in om toegang te krijgen tot uw klantenruimte."
+      invalid_code: "Deze code is onjuist of verlopen. Vraag zo nodig een nieuwe aan."
+      signed_out: "U bent afgemeld."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,15 @@ Rails.application.routes.draw do
   # Page client du séjour-composite (epic #26, Phase 1) — jeton, sans Devise.
   # Route à la racine (et non sous /public) : c'est l'URL envoyée aux clients et
   # la cible des redirections Stripe, on la garde courte, comme /reservation/sejour.
+  # Portail client (epic #126, Phase 2) — connexion par code à usage unique
+  # envoyé par email. Session propre (cookie signé dédié), aucun lien avec
+  # Devise : le portail n'ouvre JAMAIS d'accès admin.
+  get    "portail",              to: "portal/sessions#new",         as: :portal
+  post   "portail/code",         to: "portal/sessions#create_code",  as: :portal_code
+  post   "portail/connexion",    to: "portal/sessions#create",       as: :portal_login
+  delete "portail/deconnexion",  to: "portal/sessions#destroy",      as: :portal_logout
+  get    "portail/sejours",      to: "portal/stays#index",           as: :portal_stays
+
   get "sejour/:token", to: "public/stays#show", as: :public_stay
 
   # Paiement du solde exigible du séjour (epic #55, Phase 3) — POST scellé par le

--- a/db/migrate/20260721013149_create_portal_otps.rb
+++ b/db/migrate/20260721013149_create_portal_otps.rb
@@ -1,0 +1,15 @@
+class CreatePortalOtps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :portal_otps do |t|
+      t.citext :email, null: false
+      t.string :code_digest, null: false
+      t.datetime :expires_at, null: false
+      t.integer :attempts, null: false, default: 0
+      t.datetime :consumed_at
+
+      t.timestamps
+    end
+
+    add_index :portal_otps, [:email, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_21_013149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -173,6 +173,34 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "updated_at", null: false
     t.index ["deleted_at"], name: "index_camping_bookings_on_deleted_at"
     t.index ["from_date", "to_date"], name: "index_camping_bookings_on_from_date_and_to_date"
+  end
+
+  create_table "coworking_packs", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.integer "days_total", null: false
+    t.integer "price_cents", default: 0, null: false
+    t.datetime "purchased_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "payment_method", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_coworking_packs_on_customer_id"
+    t.index ["deleted_at"], name: "index_coworking_packs_on_deleted_at"
+    t.index ["expires_at"], name: "index_coworking_packs_on_expires_at"
+  end
+
+  create_table "coworking_reservations", force: :cascade do |t|
+    t.bigint "coworking_pack_id", null: false
+    t.bigint "customer_id", null: false
+    t.date "date", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coworking_pack_id"], name: "index_coworking_reservations_on_coworking_pack_id"
+    t.index ["customer_id"], name: "index_coworking_reservations_on_customer_id"
+    t.index ["date"], name: "index_coworking_reservations_on_date"
+    t.index ["deleted_at"], name: "index_coworking_reservations_on_deleted_at"
   end
 
   create_table "customers", force: :cascade do |t|
@@ -472,10 +500,23 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.string "stripe_payment_intent_id"
     t.bigint "stay_id"
     t.bigint "space_booking_id"
+    t.bigint "coworking_pack_id"
     t.index ["booking_id"], name: "index_payments_on_booking_id"
+    t.index ["coworking_pack_id"], name: "index_payments_on_coworking_pack_id"
     t.index ["id"], name: "index_payments_on_id", unique: true
     t.index ["space_booking_id"], name: "index_payments_on_space_booking_id"
     t.index ["stay_id"], name: "index_payments_on_stay_id"
+  end
+
+  create_table "portal_otps", force: :cascade do |t|
+    t.citext "email", null: false
+    t.string "code_digest", null: false
+    t.datetime "expires_at", null: false
+    t.integer "attempts", default: 0, null: false
+    t.datetime "consumed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email", "created_at"], name: "index_portal_otps_on_email_and_created_at"
   end
 
   create_table "products", force: :cascade do |t|
@@ -498,6 +539,16 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["human_id"], name: "index_projects_on_human_id"
+  end
+
+  create_table "rates", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "amount_cents", default: 0, null: false
+    t.string "label"
+    t.string "unit", default: "cents", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_rates_on_key", unique: true
   end
 
   create_table "rental_items", force: :cascade do |t|
@@ -765,6 +816,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   add_foreign_key "bookings", "lodgings"
   add_foreign_key "bundles", "projects"
   add_foreign_key "bundles", "teams"
+  add_foreign_key "coworking_packs", "customers"
+  add_foreign_key "coworking_reservations", "coworking_packs"
+  add_foreign_key "coworking_reservations", "customers"
   add_foreign_key "customers", "humans"
   add_foreign_key "cycle_actions", "humans"
   add_foreign_key "cycle_actions", "humans", column: "delegate_to_human_id"
@@ -788,6 +842,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   add_foreign_key "lodging_rooms", "rooms"
   add_foreign_key "meal_orders", "stays"
   add_foreign_key "payments", "bookings"
+  add_foreign_key "payments", "coworking_packs"
   add_foreign_key "payments", "space_bookings"
   add_foreign_key "payments", "stays"
   add_foreign_key "projects", "humans"

--- a/spec/mailers/portal_mailer_spec.rb
+++ b/spec/mailers/portal_mailer_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+# Epic #126, Phase 2 — email du code de connexion au portail.
+RSpec.describe PortalMailer, type: :mailer do
+  let(:mail) do
+    described_class.login_code(email: "ana@example.com",
+                               code: "123456",
+                               expires_at: 15.minutes.from_now)
+  end
+
+  it "porte un sujet clair et part à la bonne adresse" do
+    expect(mail.subject).to eq("Votre code de connexion — Les 4 Sources")
+    expect(mail.to).to eq(["ana@example.com"])
+  end
+
+  it "contient le code et sa durée de validité, en HTML comme en texte" do
+    [mail.html_part, mail.text_part].each do |part|
+      body = part.body.encoded
+      expect(body).to include("123456")
+      expect(body).to include("15 minutes")
+    end
+  end
+
+  it "ne contient aucune donnée de séjour ni de client" do
+    body = mail.body.encoded
+    expect(body).not_to match(/séjour/i)
+    expect(body).not_to include("Ana")
+  end
+end

--- a/spec/models/portal_otp_spec.rb
+++ b/spec/models/portal_otp_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Epic #126, Phase 2 — code à usage unique du portail.
+RSpec.describe PortalOtp, type: :model do
+  it "émet un code à 6 chiffres, haché, valable 15 minutes" do
+    otp, code = PortalOtp.issue!("Ana@Example.COM")
+
+    expect(code).to match(/\A\d{6}\z/)
+    expect(otp.email).to eq("ana@example.com")
+    expect(otp.code_digest).not_to include(code)
+    expect(otp.expires_at).to be_within(5.seconds).of(15.minutes.from_now)
+  end
+
+  it "brûle les codes précédents : un seul code valide à la fois" do
+    _first, first_code = PortalOtp.issue!("ana@example.com")
+    _second, second_code = PortalOtp.issue!("ana@example.com")
+
+    expect(PortalOtp.verify("ana@example.com", first_code)).to be_nil
+    expect(PortalOtp.verify("ana@example.com", second_code)).to be_present
+  end
+
+  it "consomme le code au premier succès — il ne resert jamais" do
+    _otp, code = PortalOtp.issue!("ana@example.com")
+
+    expect(PortalOtp.verify("ana@example.com", code)).to be_present
+    expect(PortalOtp.verify("ana@example.com", code)).to be_nil
+  end
+
+  it "compte les tentatives et brûle le code à la 5e" do
+    otp, code = PortalOtp.issue!("ana@example.com")
+
+    4.times { expect(PortalOtp.verify("ana@example.com", "000000")).to be_nil }
+    expect(otp.reload.attempts).to eq(4)
+    expect(otp).not_to be_consumed
+
+    PortalOtp.verify("ana@example.com", "000000")
+    expect(otp.reload).to be_consumed
+    expect(PortalOtp.verify("ana@example.com", code)).to be_nil
+  end
+
+  it "refuse un code expiré" do
+    otp, code = PortalOtp.issue!("ana@example.com")
+    otp.update!(expires_at: 1.second.ago)
+
+    expect(PortalOtp.verify("ana@example.com", code)).to be_nil
+  end
+
+  it "ne confond pas deux emails" do
+    _otp, code = PortalOtp.issue!("ana@example.com")
+
+    expect(PortalOtp.verify("bruno@example.com", code)).to be_nil
+  end
+end

--- a/spec/requests/portal_otp_spec.rb
+++ b/spec/requests/portal_otp_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+# Epic #126, Phase 2 — portail client, connexion par code à usage unique.
+RSpec.describe "Portail client — connexion OTP", type: :request do
+  include ActiveJob::TestHelper
+  let!(:customer) do
+    Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com")
+  end
+
+  def last_code
+    ActionMailer::Base.deliveries.last.body.encoded[/\b\d{6}\b/]
+  end
+
+  before { ActionMailer::Base.deliveries.clear }
+
+  describe "GET /portail" do
+    it "affiche le formulaire d'email" do
+      get portal_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Mon espace client")
+    end
+  end
+
+  describe "POST /portail/code" do
+    it "envoie un code à un client connu" do
+      expect {
+        post portal_code_path, params: { email: "ana@example.com" }
+      }.to change { PortalOtp.count }.by(1)
+
+      expect(response.body).to include("Si un compte existe")
+    end
+
+    it "répond EXACTEMENT pareil à un email inconnu, sans créer de code" do
+      post portal_code_path, params: { email: "ana@example.com" }
+      known_body = response.body
+
+      PortalOtp.delete_all
+
+      expect {
+        post portal_code_path, params: { email: "inconnu@example.com" }
+      }.not_to change { PortalOtp.count }
+
+      # Les deux réponses sont identiques au caractère près, une fois l'email
+      # saisi (simplement réaffiché dans le formulaire) neutralisé : rien dans
+      # le statut ni le corps ne dit si un compte existe.
+      normalize = ->(body, email) { body.gsub(CGI.escape(email), "EMAIL").gsub(email, "EMAIL") }
+
+      expect(normalize.call(response.body, "inconnu@example.com"))
+        .to eq(normalize.call(known_body, "ana@example.com"))
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "ne sert JAMAIS un email fourre-tout" do
+      Customer::CATCH_ALL_EMAILS.each do |catch_all|
+        Customer.find_or_create_by!(email: catch_all) { |c| c.first_name = "Fourre-tout" }
+
+        expect {
+          post portal_code_path, params: { email: catch_all }
+        }.not_to change { PortalOtp.count }
+
+        expect(response.body).to include("Si un compte existe")
+      end
+    end
+  end
+
+  describe "POST /portail/connexion" do
+    before do
+      perform_enqueued_jobs do
+        post portal_code_path, params: { email: "ana@example.com" }
+      end
+    end
+
+    it "connecte le client avec le bon code" do
+      post portal_login_path, params: { email: "ana@example.com", code: last_code }
+
+      expect(response).to redirect_to(portal_stays_path)
+      follow_redirect!
+      expect(response.body).to include("Mes séjours")
+    end
+
+    it "refuse un code faux et brûle le code après 5 tentatives" do
+      5.times do
+        post portal_login_path, params: { email: "ana@example.com", code: "000000" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      # Même le VRAI code ne passe plus : il a été brûlé.
+      post portal_login_path, params: { email: "ana@example.com", code: last_code }
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      get portal_stays_path
+      expect(response).to redirect_to(portal_path)
+    end
+
+    it "refuse un code expiré" do
+      code = last_code
+      PortalOtp.last.update!(expires_at: 1.minute.ago)
+
+      post portal_login_path, params: { email: "ana@example.com", code: code }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "ne stocke jamais le code en clair" do
+      expect(PortalOtp.last.code_digest).not_to eq(last_code)
+      expect(PortalOtp.column_names).not_to include("code")
+    end
+  end
+
+  describe "session" do
+    def sign_in_portal_as(email)
+      perform_enqueued_jobs { post portal_code_path, params: { email: email } }
+      post portal_login_path, params: { email: email, code: last_code }
+    end
+
+    it "pose un cookie httponly de 24 h" do
+      sign_in_portal_as("ana@example.com")
+
+      set_cookie = Array(response.headers["Set-Cookie"]).join("\n")
+      portal_cookie = set_cookie.lines.find { |line| line.include?("portal_customer_id") }
+
+      expect(portal_cookie).to be_present
+      expect(portal_cookie.downcase).to include("httponly")
+      expires = portal_cookie[/expires=([^;]+)/i, 1]
+      expect(Time.parse(expires)).to be_within(5.minutes).of(24.hours.from_now)
+    end
+
+    it "se termine à la déconnexion" do
+      sign_in_portal_as("ana@example.com")
+
+      delete portal_logout_path
+      expect(response).to redirect_to(portal_path)
+
+      get portal_stays_path
+      expect(response).to redirect_to(portal_path)
+    end
+
+    it "n'ouvre AUCUN accès admin" do
+      sign_in_portal_as("ana@example.com")
+
+      get stays_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "n'est pas ouverte par une session admin Devise" do
+      # Une admin connectée ne devient pas cliente du portail pour autant.
+      sign_in User.create!(email: "agent@les4sources.be", password: "password123")
+
+      get portal_stays_path
+      expect(response).to redirect_to(portal_path)
+    end
+  end
+end

--- a/spec/requests/portal_stays_spec.rb
+++ b/spec/requests/portal_stays_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+# Epic #126, Phase 2 — page « Mes séjours » du portail client.
+RSpec.describe "Portail client — Mes séjours", type: :request do
+  include ActiveJob::TestHelper
+
+  let!(:ana)   { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+  let!(:bruno) { Customer.create!(first_name: "Bruno", last_name: "Roy", email: "bruno@example.com") }
+
+  before { ActionMailer::Base.deliveries.clear }
+
+  def sign_in_portal_as(email)
+    perform_enqueued_jobs { post portal_code_path, params: { email: email } }
+    code = ActionMailer::Base.deliveries.last.body.encoded[/\b\d{6}\b/]
+    post portal_login_path, params: { email: email, code: code }
+  end
+
+  def stay_for(customer, arrival:, departure:, notes: nil)
+    Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                 arrival_date: arrival, departure_date: departure, notes: notes)
+  end
+
+  it "exige une session portail" do
+    get portal_stays_path
+    expect(response).to redirect_to(portal_path)
+  end
+
+  it "liste les séjours du client, à venir d'abord, avec badges et lien token" do
+    past   = stay_for(ana, arrival: Date.today - 30, departure: Date.today - 28)
+    future = stay_for(ana, arrival: Date.today + 10, departure: Date.today + 12)
+
+    sign_in_portal_as("ana@example.com")
+    get portal_stays_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Mes séjours")
+    expect(response.body).to include(public_stay_path(future.token))
+    expect(response.body).to include(public_stay_path(past.token))
+    # À venir d'abord.
+    expect(response.body.index(future.token)).to be < response.body.index(past.token)
+    # Badge de paiement rendu.
+    expect(response.body).to include("Voir mon séjour")
+  end
+
+  it "ne montre JAMAIS le séjour d'un autre client" do
+    mine    = stay_for(ana, arrival: Date.today + 5, departure: Date.today + 7)
+    someone = stay_for(bruno, arrival: Date.today + 5, departure: Date.today + 7)
+
+    sign_in_portal_as("ana@example.com")
+    get portal_stays_path
+
+    expect(response.body).to include(mine.token)
+    expect(response.body).not_to include(someone.token)
+    expect(response.body).not_to include("Bruno")
+  end
+
+  it "ne fuite aucune note interne" do
+    stay_for(ana, arrival: Date.today + 5, departure: Date.today + 7,
+                  notes: "NE PAS DIRE AU CLIENT — chien non déclaré")
+
+    sign_in_portal_as("ana@example.com")
+    get portal_stays_path
+
+    expect(response.body).not_to include("NE PAS DIRE AU CLIENT")
+  end
+
+  it "affiche un état vide propre" do
+    sign_in_portal_as("ana@example.com")
+    get portal_stays_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Aucun séjour pour l'instant")
+  end
+end


### PR DESCRIPTION
Closes #128

Phase 2 de l'epic #126. Un client avec un vrai email peut se connecter à `/portail` avec un code reçu par mail, et voir ses séjours. Indépendante de la Phase 1 : aucune dépendance de code.

## Connexion par code à usage unique

- **`PortalOtp`** — code à 6 chiffres, **jamais stocké en clair** (seul le SHA-256 l'est ; il n'y a même pas de colonne `code`). Validité 15 min, **5 tentatives** puis le code est brûlé. Émettre un nouveau code brûle le précédent : un seul code valide à la fois, et un code consommé ne resert jamais. La comparaison passe par `ActiveSupport::SecurityUtils.secure_compare`.
- **Anti-énumération** — email inconnu, email fourre-tout (`Customer#catch_all?`) et email réel produisent **la même réponse**, au caractère près (spec dédiée qui compare les deux corps après neutralisation de l'email réaffiché) et le même statut. Les fourre-tout ne reçoivent jamais de code : ces adresses partagées donneraient accès aux séjours de dizaines de clients.
- **Session portail** — cookie **signé** dédié (`portal_customer_id`), `httponly`, `same_site: :lax`, 24 h. Aucun rapport avec Devise dans les deux sens : une session portail ne donne aucun accès admin (spec), et une session admin n'ouvre pas le portail (spec).

## Routes (FR)

`GET /portail` · `POST /portail/code` · `POST /portail/connexion` · `DELETE /portail/deconnexion` · `GET /portail/sejours`

## « Mes séjours »

Le scope part **toujours** de `current_portal_customer` — il n'y a aucun identifiant client dans l'URL, donc rien à forger. Chaque séjour : dates, composition compacte (`StayDecorator#composition_summary`, réutilisé tel quel), badge statut + badge paiement (`status_badge` / `payment_status_badge`), et lien « Voir mon séjour » vers `/sejour/:token`. Tri à venir d'abord, état vide propre. Layout `public_sheet`, comme les pages `/sejour/:token`.

## Vérification

- `bundle exec rspec` → **992 examples, 0 failures**, 16 pending (les pending préexistent sur `main`).
- Specs ajoutées : modèle OTP (émission/hachage/validité, un seul code valide, consommation unique, compteur de tentatives et brûlage à la 5e, expiration, pas de confusion entre emails) ; flux OTP complet en request (envoi, neutralité anti-énumération, fourre-tout jamais servis, 5 codes faux puis le vrai code refusé, code expiré, code jamais en clair) ; session (cookie httponly à 24 h vérifié sur l'en-tête `Set-Cookie`, déconnexion, aucun accès admin, admin n'ouvre pas le portail) ; « Mes séjours » (session requise, tri à venir d'abord + lien token, **anti-fuite avec 2 clients**, aucune note interne, état vide) ; mailer (sujet, destinataire, code + validité en HTML et en texte, aucune donnée de séjour ou de client).
- Pas de linter dans le repo (ni RuboCop, ni script `lint` dans `package.json` ; le seul workflow CI est `agent-ready-gate.yml`) — rien à faire côté lint.

## 📸 Aperçu

![Portail client — saisie de l'email](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260721-033658-portail-client--saisie-de-lemail.png)

**Capturé pour de vrai** (Chrome headless sur l'app lancée en local, avec Vite). Les **deux autres écrans n'ont pas pu l'être** : la saisie du code arrive après un POST et « Mes séjours » exige une session portail — le script de capture ne fait que des GET anonymes, et le chemin Capybara est cassé sur cette machine (`webdrivers 5.2.0` + `selenium-webdriver 4.5.0` interrogent l'endpoint `chromedriver.storage.googleapis.com`, qui renvoie 404 pour Chrome 150 ; aucun `spec/system` n'existe dans le repo). Ces deux écrans sont couverts par des request specs, pas par l'œil.

## À valider à la main

- Le rendu des trois écrans, et surtout **« Mes séjours »**, avec l'œil.
- Le texte de l'email de code (sobre par choix : le code, sa durée, rien d'autre).
- Les vues du portail sont **en français en dur** — l'issue demande des routes FR et un texte sobre, pas un portail trilingue. Seuls les 3 messages flash sont traduits (fr/nl/en). À trancher si tu veux le portail complet en NL/EN.
- Il n'y a **aucun rate-limit** sur `POST /portail/code` : rien n'empêche de déclencher beaucoup d'emails vers une adresse connue. Ce n'était pas dans les critères d'acceptation — à ouvrir en issue si tu le veux.

## Hors périmètre (comme demandé)

Coworking au portail (Phase 3), modification/annulation de séjour depuis le portail (c'est #133, qui vit sur la page token existante), historique enrichi.
