### PR TITLE
Modification de séjour par le client, validée par l'équipe (#133)

### DIFF
--- a/app/controllers/public/stay_change_requests_controller.rb
+++ b/app/controllers/public/stay_change_requests_controller.rb
@@ -1,0 +1,179 @@
+module Public
+  # Demande de modification d'un séjour par le client (issue #133).
+  #
+  # Canal jeton, comme la page `/sejour/:token` : pas de Devise. Le client
+  # recompose son séjour dans un formulaire prérempli, voit le nouveau total et
+  # le delta en direct, et SOUMET UNE DEMANDE — le séjour n'est jamais modifié
+  # ici. C'est l'équipe qui approuve ou refuse.
+  class StayChangeRequestsController < Public::BaseController
+    layout "public_sheet"
+
+    before_action :load_stay
+    before_action :ensure_modifiable
+
+    # Formulaire de composition prérempli depuis le séjour.
+    def new
+      @draft = Stays::DraftReconstructor.call(@stay)
+      prepare_form
+    end
+
+    # Devis live : nouveau total + delta, en Turbo Stream.
+    def quote
+      @draft = draft_from_params
+      prepare_form
+      respond_to do |format|
+        format.turbo_stream { render :quote }
+        format.html { redirect_to new_public_stay_change_request_path(@stay.token) }
+      end
+    end
+
+    def create
+      @draft = draft_from_params
+      prepare_form
+
+      # Disponibilité vérifiée À LA SOUMISSION (informative) — et re-vérifiée à
+      # la validation par l'équipe, parce que le monde bouge entre les deux.
+      unless Stays::LodgingAvailability.call(stay: @stay, draft: @draft)
+        flash.now[:alert] = t("public.stay_change_requests.unavailable")
+        return render :new, status: :unprocessable_entity
+      end
+
+      change_request = build_change_request
+
+      # « La nouvelle remplace l'ancienne » : on retire les demandes en attente
+      # précédentes, puis on enregistre. Si l'enregistrement échoue (IBAN
+      # manquant, par exemple), le ROLLBACK rend son ancienne demande au client
+      # — on ne détruit jamais quelque chose pour rien.
+      saved = ActiveRecord::Base.transaction do
+        supersede_previous_pending
+        raise ActiveRecord::Rollback unless change_request.save
+
+        true
+      end
+
+      if saved
+        StayChangeRequestMailer.team_new_request(change_request).deliver_later
+        StayChangeRequestMailer.customer_received(change_request).deliver_later
+
+        redirect_to public_stay_path(@stay.token),
+                    notice: t("public.stay_change_requests.submitted")
+      else
+        @change_request = change_request
+        flash.now[:alert] = change_request.errors.full_messages.to_sentence
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def load_stay
+      @stay = Stay.find_by!(token: params[:token]).decorate
+    rescue ActiveRecord::RecordNotFound
+      raise ActionController::RoutingError, "Not Found"
+    end
+
+    # Un séjour déjà parti (départ < aujourd'hui) ne se modifie plus. La page
+    # `/sejour/:token` n'affiche d'ailleurs pas le bouton dans ce cas.
+    def ensure_modifiable
+      return if @stay.departure_date.present? && @stay.departure_date >= Date.current
+
+      redirect_to public_stay_path(@stay.token),
+                  alert: t("public.stay_change_requests.too_late")
+    end
+
+    # Le formulaire du client ne porte QUE ce qu'il peut recomposer :
+    # hébergement nuit par nuit, camping/van/hamacs et espaces — exactement les
+    # grilles du funnel public, réutilisées telles quelles (donc préfixe
+    # `reservation[...]`, comme elles l'émettent).
+    #
+    # Tout le reste est REPORTÉ depuis le séjour actuel : activités (hors
+    # périmètre v1 — elles gardent leur flux propre), repas, terrasse,
+    # facturation espace et coordonnées client. Sans ce report, une demande
+    # approuvée effacerait silencieusement ce que le formulaire n'affiche pas.
+    def draft_from_params
+      current = Stays::DraftReconstructor.call(@stay)
+      attrs = submitted_draft_params
+
+      attrs[:experiences]   = current.experiences
+      attrs[:meals]         = current.meals
+      attrs[:terrasses]     = current.terrasses
+      attrs[:space_billing] = current.space_billing
+      attrs[:first_name]    = current.first_name
+      attrs[:last_name]     = current.last_name
+      attrs[:email]         = current.email
+      attrs[:phone]         = current.phone
+      attrs[:group_name]    = attrs[:group_name].presence || current.group_name
+
+      Reservations::Draft.new(attrs)
+    end
+
+    def submitted_draft_params
+      params.fetch(:reservation, {}).permit(
+        :lodging_id, :arrival_date, :departure_date, :dogs_count,
+        :adults, :children, :group_name,
+        lodging_night_ids: [],
+        per_night_resources: { tente: [], van: [], hamac_simple: [], hamac_double: [] },
+        space_slots: { grande_salle: [], petite_salle: [], cuisine_pro: [] }
+      ).to_h.symbolize_keys
+    end
+
+    def build_change_request
+      new_total = @draft.quote.total_excluding_experiences_cents
+
+      StayChangeRequest.new(
+        stay: @stay.object,
+        draft_snapshot: @draft.to_h,
+        new_total_cents: new_total,
+        delta_cents: new_total - @stay.total_amount_cents.to_i,
+        refund_iban: params[:refund_iban]
+      )
+    end
+
+    def supersede_previous_pending
+      StayChangeRequest.pending
+                       .where(stay_id: @stay.id)
+                       .find_each { |old| old.soft_delete!(validate: false) }
+    end
+
+    # Ivars attendues par les partiels de composition réutilisés du funnel.
+    def prepare_form
+      @lodgings             = bookable_lodgings
+      @stay_nights          = stay_nights
+      @lodging_availability = build_stay_availability(@lodgings, @stay_nights)
+      @quote                = @draft.quote
+      @new_total_cents      = @quote.total_excluding_experiences_cents
+      @delta_cents          = @new_total_cents - @stay.total_amount_cents.to_i
+      @refund_cents         = [@stay.amount_paid_cents.to_i - @new_total_cents, 0].max
+    end
+
+    def stay_nights
+      return [] if @draft.arrival_date.blank? || @draft.departure_date.blank?
+
+      (@draft.arrival_date...@draft.departure_date).to_a
+    end
+
+    def bookable_lodgings
+      names = ["La Hulotte", "La Chevêche", "Le Grand-Duc"]
+      Lodging.where(name: names).sort_by { |l| names.index(l.name) || 99 }
+    end
+
+    # Grille de dispo affichée dans le calendrier d'hébergement : la propre
+    # occupation du séjour ne doit PAS s'y compter comme indisponible.
+    def build_stay_availability(lodgings, nights)
+      return {} if nights.empty?
+
+      own_ids = @stay.stay_items.where(bookable_type: "Booking").pluck(:bookable_id)
+
+      lodgings.each_with_object({}) do |lodging, result|
+        room_ids = lodging.rooms.pluck(:id)
+        scope = Reservation.includes(:booking)
+                           .where(date: nights.first..nights.last, room: room_ids,
+                                  booking: { status: "confirmed" })
+        scope = scope.where.not(booking: { id: own_ids }) if own_ids.any?
+        occupied = scope.pluck(:date).to_set |
+                   lodging.unavailabilities.where(date: nights.first..nights.last).pluck(:date).to_set
+        result[lodging.id] = nights.map { |night| !occupied.include?(night) }
+      end
+    end
+  end
+end

--- a/app/controllers/stays_controller.rb
+++ b/app/controllers/stays_controller.rb
@@ -1,6 +1,6 @@
 class StaysController < BaseController
   before_action :set_accounting_view, only: :show
-  before_action :set_stay, only: %i[edit update destroy update_status]
+  before_action :set_stay, only: %i[edit update destroy update_status approve_change_request refuse_change_request]
 
   # Index admin des séjours (epic #81) — le séjour devient le point d'entrée
   # unique. Tableau paginé (30/page) orienté GESTION des réservations et
@@ -101,6 +101,39 @@ class StaysController < BaseController
   def edit
     @draft = Stays::DraftReconstructor.new(@stay).to_draft
     prepare_form
+  end
+
+  # Approbation d'une demande de modification client (issue #133). C'est ICI —
+  # et nulle part avant — que le séjour change. La dispo est re-vérifiée, sauf
+  # forçage explicite par l'équipe.
+  def approve_change_request
+    change_request = @stay.stay_change_requests.pending.find(params[:change_request_id])
+    service = Stays::ApplyChangeRequest.new(
+      change_request: change_request,
+      user: current_user,
+      force_availability: params[:force_availability].present?
+    )
+
+    if service.run
+      StayChangeRequestMailer.customer_approved(change_request).deliver_later
+      redirect_to stay_path(@stay), notice: "La modification a été appliquée."
+    else
+      redirect_to stay_path(@stay), alert: service.error_message
+    end
+  end
+
+  # Refus d'une demande — le motif est OBLIGATOIRE, il part au client.
+  def refuse_change_request
+    change_request = @stay.stay_change_requests.pending.find(params[:change_request_id])
+    reason = params[:refusal_reason].to_s.strip
+
+    if reason.blank?
+      return redirect_to stay_path(@stay), alert: "Un motif de refus est obligatoire."
+    end
+
+    change_request.update!(status: "refused", refusal_reason: reason)
+    StayChangeRequestMailer.customer_refused(change_request).deliver_later
+    redirect_to stay_path(@stay), notice: "La demande de modification a été refusée."
   end
 
   def update

--- a/app/mailers/stay_change_request_mailer.rb
+++ b/app/mailers/stay_change_request_mailer.rb
@@ -1,0 +1,48 @@
+# Emails de la demande de modification de séjour (issue #133).
+class StayChangeRequestMailer < ApplicationMailer
+  TEAM_EMAIL = "sejours@les4sources.be".freeze
+
+  # Équipe : une nouvelle demande est arrivée, avec son delta.
+  def team_new_request(change_request)
+    assign(change_request)
+    mail(to: TEAM_EMAIL,
+         subject: "Demande de modification — séjour ##{@stay.id} (#{@delta_label})")
+  end
+
+  # Client : accusé de réception.
+  def customer_received(change_request)
+    assign(change_request)
+    mail(to: @stay.customer.email,
+         subject: "Votre demande de modification a bien été reçue")
+  end
+
+  # Client : demande approuvée — nouveau total et solde.
+  def customer_approved(change_request)
+    assign(change_request)
+    @stay = change_request.stay.reload
+    mail(to: @stay.customer.email,
+         subject: "Votre séjour a été modifié")
+  end
+
+  # Client : demande refusée — avec le motif.
+  def customer_refused(change_request)
+    assign(change_request)
+    mail(to: @stay.customer.email,
+         subject: "Votre demande de modification n'a pas pu être acceptée")
+  end
+
+  private
+
+  def assign(change_request)
+    @change_request = change_request
+    @stay = change_request.stay
+    @new_total = format_euros(change_request.new_total_cents)
+    @delta_label = signed_euros(change_request.delta_cents)
+  end
+
+  def format_euros(cents) = "#{format('%.2f', cents.to_i / 100.0).tr('.', ',')} €"
+
+  def signed_euros(cents)
+    "#{cents.to_i.positive? ? '+' : ''}#{format_euros(cents)}"
+  end
+end

--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -41,6 +41,9 @@ class Stay < ApplicationRecord
 
   belongs_to :customer
   has_many :stay_items, dependent: :destroy
+  # Demandes de modification par le client (issue #133). Elles ne modifient
+  # JAMAIS le séjour tant qu'elles ne sont pas approuvées par l'équipe.
+  has_many :stay_change_requests, dependent: :destroy
   has_many :experience_bookings, dependent: :destroy
   # Note publique du séjour (visible client) — ActionText, PAS de colonne. Consolide
   # à la fusion les `public_notes` des bookables + des stays sources (epic notes).

--- a/app/models/stay_change_request.rb
+++ b/app/models/stay_change_request.rb
@@ -1,0 +1,85 @@
+# Demande de modification d'un séjour par le client (issue #133).
+#
+# C'est une DEMANDE, jamais une application directe : le séjour n'est TOUCHÉ
+# qu'à l'approbation par l'équipe. Tant qu'elle est `pending`, la demande ne
+# porte qu'un snapshot du draft proposé et les montants qui en découlent.
+#
+# Delta positif  → la différence s'ajoutera au solde exigible du séjour.
+# Delta négatif avec trop-perçu → l'IBAN du client est exigé, et le
+# remboursement est fait à la main par l'équipe dans les 10 jours qui suivent
+# le séjour.
+class StayChangeRequest < ApplicationRecord
+  STATUSES = %w[pending approved refused].freeze
+
+  # Formulaire IBAN volontairement PERMISSIF : 2 lettres de pays, 2 chiffres de
+  # clé, puis 11 à 30 caractères alphanumériques. On valide la forme, pas la
+  # clé de contrôle — un IBAN mal saisi sera vu par l'humain qui rembourse.
+  IBAN_FORMAT = /\A[A-Z]{2}\d{2}[A-Z0-9]{11,30}\z/
+
+  # Mention EXACTE affichée au client et recopiée dans la note interne.
+  REFUND_NOTICE = "Le remboursement sera effectué dans les 10 jours qui suivent le séjour.".freeze
+
+  belongs_to :stay
+
+  has_paper_trail
+  has_soft_deletion default_scope: true
+
+  before_validation :normalize_iban
+
+  validates :status, inclusion: { in: STATUSES }
+  validates :new_total_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :refund_iban, format: { with: IBAN_FORMAT, message: "n'a pas un format valide" },
+                          allow_blank: true
+  validate :refund_iban_required_when_overpaid
+  validate :only_one_pending_per_stay, on: :create
+
+  scope :pending,  -> { where(status: "pending") }
+  scope :approved, -> { where(status: "approved") }
+  scope :refused,  -> { where(status: "refused") }
+
+  def pending?  = status == "pending"
+  def approved? = status == "approved"
+  def refused?  = status == "refused"
+
+  def increase? = delta_cents.to_i.positive?
+  def decrease? = delta_cents.to_i.negative?
+
+  # Trop-perçu : le client a déjà payé plus que le nouveau total. C'est LE cas
+  # qui déclenche l'exigence d'un IBAN.
+  def overpaid_cents
+    [stay.amount_paid_cents.to_i - new_total_cents.to_i, 0].max
+  end
+
+  def refund_expected? = overpaid_cents.positive?
+
+  # Le draft proposé, reconstruit pour le devis ou pour l'application.
+  def proposed_draft
+    Reservations::Draft.new(draft_snapshot)
+  end
+
+  private
+
+  def normalize_iban
+    self.refund_iban = refund_iban.to_s.gsub(/\s+/, "").upcase.presence
+  end
+
+  def refund_iban_required_when_overpaid
+    return unless status == "pending"
+    return unless stay.present?
+    return unless refund_expected?
+    return if refund_iban.present?
+
+    errors.add(:refund_iban, "est obligatoire pour un remboursement")
+  end
+
+  # Une seule demande `pending` à la fois par séjour. Les demandes précédentes
+  # sont retirées par le contrôleur AVANT la création (« la nouvelle remplace
+  # l'ancienne ») ; cette validation est le filet.
+  def only_one_pending_per_stay
+    return unless status == "pending"
+    return if stay.nil?
+    return unless StayChangeRequest.pending.where(stay_id: stay_id).exists?
+
+    errors.add(:base, "Une demande de modification est déjà en attente pour ce séjour")
+  end
+end

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -179,37 +179,11 @@ module Stays
     # Booking du séjour édité (revue Forge F4 : `.first` seul laissait un
     # éventuel second Booking auto-bloquer le séjour ; et le mode gîte entier
     # ne s'excluait pas du tout — un séjour confirmé se bloquait lui-même).
+    # Déléguée à `Stays::LodgingAvailability` (issue #133) : la demande de
+    # modification client doit appliquer EXACTEMENT la même règle de dispo que
+    # la validation admin. Le corps a été déplacé tel quel, sans changement.
     def lodging_available?
-      if @draft.rooms_mode?
-        ids = @draft.lodging.rooms.where(id: @draft.room_ids).pluck(:id)
-        # Chambres toutes hors gîte : déjà refusé en validation ; réponse
-        # conservatrice si on arrive ici par un autre chemin.
-        return false if ids.empty?
-      else
-        ids = @draft.lodging.rooms.pluck(:id)
-        # Gîte sans chambre modélisée : aucune Reservation possible — seule une
-        # indisponibilité posée à la main compte (comportement historique).
-        if ids.empty?
-          return @draft.lodging.unavailabilities
-                       .where(date: @draft.arrival_date..@draft.departure_date).none?
-        end
-      end
-
-      # Contrat de dates (issue #94) : `[arrival_date, departure_date)` est une
-      # fenêtre de séjour ; le jour de départ n'est PAS occupé. Les `Reservation`
-      # sont NUITÉES → on borne aux nuits `arrival_date..(departure_date-1)` (borne
-      # haute excluant le jour de départ) pour ne pas refuser une rotation dos-à-dos.
-      # Le `max` garde un intervalle valide même sur une fenêtre dégénérée (0 nuit).
-      last_night = [@draft.departure_date - 1, @draft.arrival_date].max
-      scope = Reservation.joins(:booking)
-                         .where(date: @draft.arrival_date..last_night,
-                                room_id: ids, bookings: { status: "confirmed" })
-      own_ids = @stay.stay_items.where(bookable_type: "Booking").pluck(:bookable_id)
-      scope = scope.where.not(bookings: { id: own_ids }) if own_ids.any?
-      # Les `Unavailability` gardent leur sémantique de JOURNÉES PLEINES (inclusif
-      # du jour de départ) — volontairement différente des nuits ci-dessus.
-      scope.none? &&
-        @draft.lodging.unavailabilities.where(date: @draft.arrival_date..@draft.departure_date).none?
+      Stays::LodgingAvailability.call(stay: @stay, draft: @draft)
     end
 
     # Dispo espaces capacity-aware (`Space#available_on?`), même logique de force

--- a/app/services/stays/apply_change_request.rb
+++ b/app/services/stays/apply_change_request.rb
@@ -1,0 +1,65 @@
+module Stays
+  # Application d'une demande de modification approuvée par l'équipe (#133).
+  #
+  # C'est le SEUL endroit qui touche au séjour : tant que la demande est
+  # `pending`, rien n'a bougé. L'application passe par `Stays::AdminUpdater`
+  # (réutilisé tel quel), puis recalcule le statut de paiement — donc le solde
+  # exigible absorbe automatiquement un delta positif.
+  #
+  # L'IBAN et la consigne des 10 jours sont recopiés dans la NOTE INTERNE :
+  # le remboursement est manuel, il faut que l'info vive là où l'équipe la lit.
+  class ApplyChangeRequest
+    attr_reader :error_message
+
+    def initialize(change_request:, user: nil, force_availability: false)
+      @change_request = change_request
+      @user = user
+      @force_availability = force_availability
+    end
+
+    def run
+      stay = @change_request.stay
+      draft = @change_request.proposed_draft
+
+      # Re-vérification de dispo à la validation : le monde a pu bouger depuis
+      # la soumission du client. Le forçage reste possible côté équipe.
+      unless @force_availability || Stays::LodgingAvailability.call(stay: stay, draft: draft)
+        @error_message = "Ces dates ne sont plus disponibles pour cet hébergement."
+        return false
+      end
+
+      updater = Stays::AdminUpdater.new(
+        stay: stay,
+        draft: draft,
+        skip_availability: true,
+        user: @user
+      )
+
+      unless updater.run
+        @error_message = updater.error_message(default: "La modification n'a pas pu être appliquée.")
+        return false
+      end
+
+      ActiveRecord::Base.transaction do
+        if @change_request.refund_expected?
+          append_refund_note!(stay)
+          stay.save!
+        end
+        # `set_payment_status` persiste lui-même : le solde exigible absorbe
+        # le delta positif, et un séjour retombé sous le déjà-payé passe `paid`.
+        stay.set_payment_status
+        @change_request.update!(status: "approved")
+      end
+
+      true
+    end
+
+    private
+
+    def append_refund_note!(stay)
+      line = "Remboursement à effectuer — IBAN #{@change_request.refund_iban}. " \
+             "#{StayChangeRequest::REFUND_NOTICE}"
+      stay.notes = [stay.notes.presence, line].compact.join("\n")
+    end
+  end
+end

--- a/app/services/stays/lodging_availability.rb
+++ b/app/services/stays/lodging_availability.rb
@@ -1,0 +1,62 @@
+module Stays
+  # Disponibilité de l'hébergement d'un `Reservations::Draft` pour un séjour
+  # donné, en EXCLUANT la propre occupation de ce séjour (sinon un séjour
+  # confirmé se bloquerait lui-même à chaque réenregistrement).
+  #
+  # Extrait tel quel de `Stays::AdminUpdater#lodging_available?` (issue #133)
+  # pour que la demande de modification client applique EXACTEMENT la même
+  # règle que la validation admin — une seule vérité de dispo, deux appelants.
+  class LodgingAvailability
+    def initialize(stay:, draft:)
+      @stay = stay
+      @draft = draft
+    end
+
+    def self.call(stay:, draft:) = new(stay: stay, draft: draft).available?
+
+    # true quand il n'y a rien à vérifier (pas d'hébergement demandé).
+    def available?
+      return true if @draft.lodging.blank?
+
+      if @draft.rooms_mode?
+        ids = @draft.lodging.rooms.where(id: @draft.room_ids).pluck(:id)
+        # Chambres toutes hors gîte : déjà refusé en validation ; réponse
+        # conservatrice si on arrive ici par un autre chemin.
+        return false if ids.empty?
+      else
+        ids = @draft.lodging.rooms.pluck(:id)
+        # Gîte sans chambre modélisée : aucune Reservation possible — seule une
+        # indisponibilité posée à la main compte (comportement historique).
+        return no_unavailability? if ids.empty?
+      end
+
+      # Contrat de dates (issue #94) : `[arrival_date, departure_date)` est une
+      # fenêtre de séjour ; le jour de départ n'est PAS occupé. Les `Reservation`
+      # sont NUITÉES → on borne aux nuits `arrival_date..(departure_date-1)` (borne
+      # haute excluant le jour de départ) pour ne pas refuser une rotation dos-à-dos.
+      # Le `max` garde un intervalle valide même sur une fenêtre dégénérée (0 nuit).
+      last_night = [@draft.departure_date - 1, @draft.arrival_date].max
+      scope = Reservation.joins(:booking)
+                         .where(date: @draft.arrival_date..last_night,
+                                room_id: ids, bookings: { status: "confirmed" })
+      own_ids = own_booking_ids
+      scope = scope.where.not(bookings: { id: own_ids }) if own_ids.any?
+      # Les `Unavailability` gardent leur sémantique de JOURNÉES PLEINES (inclusif
+      # du jour de départ) — volontairement différente des nuits ci-dessus.
+      scope.none? && no_unavailability?
+    end
+
+    private
+
+    def own_booking_ids
+      return [] if @stay.nil?
+
+      @stay.stay_items.where(bookable_type: "Booking").pluck(:bookable_id)
+    end
+
+    def no_unavailability?
+      @draft.lodging.unavailabilities
+            .where(date: @draft.arrival_date..@draft.departure_date).none?
+    end
+  end
+end

--- a/app/views/public/stay_change_requests/_delta_panel.html.slim
+++ b/app/views/public/stay_change_requests/_delta_panel.html.slim
@@ -1,0 +1,29 @@
+/ Devis live de la demande : nouveau total et delta face au séjour actuel.
+/ Rendu dans un frame pour être remplacé en Turbo Stream à chaque changement.
+= turbo_frame_tag "change_request_delta"
+  .bg-white.rounded-2xl.shadow-sm.border.border-gray-100.p-5.space-y-3
+    h2.text-base.font-semibold.text-gray-900 Votre nouveau devis
+    .flex.justify-between.text-sm.text-gray-600
+      span Total actuel
+      span = number_to_currency(stay.total_amount_cents.to_i / 100.0, unit: "€", format: "%n %u")
+    .flex.justify-between.text-base.font-semibold.text-gray-900
+      span Nouveau total
+      span = number_to_currency(new_total_cents.to_i / 100.0, unit: "€", format: "%n %u")
+
+    - if delta_cents.to_i.positive?
+      .rounded-lg.bg-amber-50.border.border-amber-100.px-4.py-3.text-sm.text-amber-900
+        = "+#{number_to_currency(delta_cents.to_i / 100.0, unit: '€', format: '%n %u')} ajoutés à votre solde"
+    - elsif delta_cents.to_i.negative?
+      .rounded-lg.bg-emerald-50.border.border-emerald-100.px-4.py-3.text-sm.text-emerald-900
+        = "−#{number_to_currency(delta_cents.abs / 100.0, unit: '€', format: '%n %u')} à rembourser"
+    - else
+      .text-sm.text-gray-500 Aucun changement de montant pour l'instant.
+
+    / IBAN exigé UNIQUEMENT en cas de trop-perçu (déjà payé > nouveau total).
+    - if refund_cents.to_i.positive?
+      .rounded-lg.bg-emerald-50.border.border-emerald-100.p-4.space-y-2
+        label.block.text-sm.font-medium.text-gray-800[for="refund_iban"]
+          | Votre IBAN pour le remboursement
+        = text_field_tag :refund_iban, params[:refund_iban], required: true, placeholder: "BE68539007547034", class: "w-full rounded-md border-gray-300 text-sm"
+        p.text-xs.text-emerald-900
+          = StayChangeRequest::REFUND_NOTICE

--- a/app/views/public/stay_change_requests/new.html.slim
+++ b/app/views/public/stay_change_requests/new.html.slim
@@ -1,0 +1,43 @@
+/ Demande de modification de séjour (issue #133). Le formulaire est prérempli
+/ depuis le séjour et réutilise TELS QUELS les partiels de composition du
+/ funnel public — même grilles, même devis, une seule vérité de composition.
+/ Rien n'est appliqué ici : la soumission crée une DEMANDE.
+- content_for :meta_title do
+  | Modifier mon séjour
+
+.px-4.py-8.md:px-8.space-y-6(data-controller="public--reservation-quote"
+  data-public--reservation-quote-url-value=public_stay_change_request_quote_path(@stay.token))
+
+  div
+    h1.text-2xl.font-semibold.text-gray-900 Modifier mon séjour
+    p.text-sm.text-gray-500.mt-1
+      | Ajustez votre séjour ci-dessous. Votre demande est envoyée à l'équipe, qui la valide — rien n'est modifié avant son accord.
+
+  - if flash.now[:alert].present?
+    .rounded-lg.bg-red-50.border.border-red-100.px-4.py-3.text-sm.text-red-800
+      = flash.now[:alert]
+
+  = form_with url: public_stay_change_requests_path(@stay.token), method: :post,
+      data: { "public--reservation-quote-target": "form",
+              action: "change->public--reservation-quote#refresh" } do |f|
+
+    .space-y-6
+      / Hébergement + camping/van/hamacs, nuit par nuit — partiel du funnel
+      / réutilisé TEL QUEL (il émet des champs `reservation[...]`, que le
+      / contrôleur lit sous cette clé). Aucune modification du funnel public.
+      = render "public/reservations/stay_calendar"
+
+      / Espaces, nuit par nuit — même partiel que le funnel.
+      = render "public/reservations/spaces_calendar"
+
+      = render "public/stay_change_requests/delta_panel",
+               stay: @stay, new_total_cents: @new_total_cents,
+               delta_cents: @delta_cents, refund_cents: @refund_cents
+
+      .rounded-lg.bg-gray-50.border.border-gray-100.px-4.py-3.text-xs.text-gray-500
+        | Vos activités déjà réservées ne sont pas concernées par ce formulaire — elles gardent leur propre validation.
+
+      .flex.justify-between.items-center.gap-4
+        = link_to "Annuler", public_stay_path(@stay.token), class: "text-sm text-gray-500 hover:text-gray-700 underline"
+        = f.submit "Envoyer ma demande",
+                   class: "rounded-xl bg-emerald-600 text-white px-8 py-3 text-sm font-semibold hover:bg-emerald-700 cursor-pointer"

--- a/app/views/public/stay_change_requests/quote.turbo_stream.slim
+++ b/app/views/public/stay_change_requests/quote.turbo_stream.slim
@@ -1,0 +1,5 @@
+/ Recalcul temps-réel du nouveau total / delta de la demande de modification.
+= turbo_stream.replace "change_request_delta" do
+  = render "public/stay_change_requests/delta_panel",
+           stay: @stay, new_total_cents: @new_total_cents,
+           delta_cents: @delta_cents, refund_cents: @refund_cents

--- a/app/views/public/stays/show.html.slim
+++ b/app/views/public/stays/show.html.slim
@@ -50,3 +50,11 @@
     = render "public/stays/balance"
 
     = render "public/stays/payments"
+
+    / Demande de modification (issue #133). Un séjour déjà parti ne se modifie
+    / plus : pas de bouton quand le départ est passé.
+    - if @stay.departure_date.present? && @stay.departure_date >= Date.current
+      .mt-8.flex.justify-center
+        = link_to t("public.stay_change_requests.cta"),
+                  new_public_stay_change_request_path(@stay.token),
+                  class: "inline-flex items-center rounded-xl border border-gray-300 bg-white px-6 py-3 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"

--- a/app/views/stay_change_request_mailer/customer_approved.html.slim
+++ b/app/views/stay_change_request_mailer/customer_approved.html.slim
@@ -1,0 +1,10 @@
+p Bonjour,
+p Votre demande de modification a été acceptée — votre séjour est à jour.
+ul
+  li = "Nouveau total : #{number_to_currency(@stay.total_amount_cents.to_i / 100.0, unit: '€', format: '%n %u')}"
+  li = "Solde restant : #{number_to_currency(@stay.balance_due_cents.to_i / 100.0, unit: '€', format: '%n %u')}"
+  - if @change_request.refund_expected?
+    li = StayChangeRequest::REFUND_NOTICE
+p
+  = link_to "Voir mon séjour", public_stay_url(@stay.token)
+p — Les 4 Sources

--- a/app/views/stay_change_request_mailer/customer_approved.text.erb
+++ b/app/views/stay_change_request_mailer/customer_approved.text.erb
@@ -1,0 +1,12 @@
+Bonjour,
+
+Votre demande de modification a été acceptée — votre séjour est à jour.
+
+Nouveau total : <%= number_to_currency(@stay.total_amount_cents.to_i / 100.0, unit: '€', format: '%n %u') %>
+Solde restant : <%= number_to_currency(@stay.balance_due_cents.to_i / 100.0, unit: '€', format: '%n %u') %>
+<% if @change_request.refund_expected? %>
+<%= StayChangeRequest::REFUND_NOTICE %>
+<% end %>
+Voir mon séjour : <%= public_stay_url(@stay.token) %>
+
+— Les 4 Sources

--- a/app/views/stay_change_request_mailer/customer_received.html.slim
+++ b/app/views/stay_change_request_mailer/customer_received.html.slim
@@ -1,0 +1,10 @@
+p Bonjour,
+p
+  | Nous avons bien reçu votre demande de modification de séjour. Notre équipe la valide et vous répond rapidement — rien n'est modifié tant qu'elle n'est pas acceptée.
+ul
+  li = "Nouveau total demandé : #{@new_total}"
+  - if @change_request.increase?
+    li = "Différence à régler : #{@delta_label} — elle s'ajoutera à votre solde une fois la demande acceptée."
+  - elsif @change_request.refund_expected?
+    li = StayChangeRequest::REFUND_NOTICE
+p — Les 4 Sources

--- a/app/views/stay_change_request_mailer/customer_received.text.erb
+++ b/app/views/stay_change_request_mailer/customer_received.text.erb
@@ -1,0 +1,11 @@
+Bonjour,
+
+Nous avons bien reçu votre demande de modification de séjour. Notre équipe la valide et vous répond rapidement — rien n'est modifié tant qu'elle n'est pas acceptée.
+
+Nouveau total demandé : <%= @new_total %>
+<% if @change_request.increase? %>
+Différence à régler : <%= @delta_label %> — elle s'ajoutera à votre solde une fois la demande acceptée.
+<% elsif @change_request.refund_expected? %>
+<%= StayChangeRequest::REFUND_NOTICE %>
+<% end %>
+— Les 4 Sources

--- a/app/views/stay_change_request_mailer/customer_refused.html.slim
+++ b/app/views/stay_change_request_mailer/customer_refused.html.slim
@@ -1,0 +1,8 @@
+p Bonjour,
+p Nous n'avons malheureusement pas pu accepter votre demande de modification. Votre séjour reste inchangé.
+p
+  strong Motif :
+  = " #{@change_request.refusal_reason}"
+p
+  | N'hésitez pas à nous écrire si vous souhaitez en discuter.
+p — Les 4 Sources

--- a/app/views/stay_change_request_mailer/customer_refused.text.erb
+++ b/app/views/stay_change_request_mailer/customer_refused.text.erb
@@ -1,0 +1,9 @@
+Bonjour,
+
+Nous n'avons malheureusement pas pu accepter votre demande de modification. Votre séjour reste inchangé.
+
+Motif : <%= @change_request.refusal_reason %>
+
+N'hésitez pas à nous écrire si vous souhaitez en discuter.
+
+— Les 4 Sources

--- a/app/views/stay_change_request_mailer/team_new_request.html.slim
+++ b/app/views/stay_change_request_mailer/team_new_request.html.slim
@@ -1,0 +1,12 @@
+p
+  | Une demande de modification vient d'arriver pour le séjour
+  strong  ##{@stay.id}
+  |  (#{@stay.customer&.email}).
+ul
+  li = "Nouveau total : #{@new_total}"
+  li = "Delta : #{@delta_label}"
+  - if @change_request.refund_expected?
+    li = "Remboursement attendu — IBAN : #{@change_request.refund_iban}"
+    li = StayChangeRequest::REFUND_NOTICE
+p
+  | À approuver ou refuser depuis la fiche séjour dans Claudy.

--- a/app/views/stay_change_request_mailer/team_new_request.text.erb
+++ b/app/views/stay_change_request_mailer/team_new_request.text.erb
@@ -1,0 +1,9 @@
+Une demande de modification vient d'arriver pour le séjour #<%= @stay.id %> (<%= @stay.customer&.email %>).
+
+Nouveau total : <%= @new_total %>
+Delta : <%= @delta_label %>
+<% if @change_request.refund_expected? %>
+Remboursement attendu — IBAN : <%= @change_request.refund_iban %>
+<%= StayChangeRequest::REFUND_NOTICE %>
+<% end %>
+À approuver ou refuser depuis la fiche séjour dans Claudy.

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -23,6 +23,52 @@ div id="stay-details-#{@stay.id}"
       - if @stay.token.present?
         = link_to "Page web du séjour ↗", public_stay_path(@stay.token, donottrack: 1), target: "_blank", rel: "noopener", class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
 
+    / Demande de modification en attente (issue #133) : ce que le client propose
+    / face à ce qui est actuellement enregistré. Rien n'a été appliqué.
+    - pending_change = @stay.stay_change_requests.pending.order(created_at: :desc).first
+    - if pending_change.present?
+      .rounded-lg.border.border-amber-200.bg-amber-50.p-4.space-y-3
+        h4.text-sm.font-semibold.text-amber-900 Demande de modification en attente
+        dl.grid.grid-cols-3.gap-x-4.gap-y-1.text-sm
+          dt.font-medium.text-amber-800 Total actuel
+          dd.col-span-2.text-gray-900 = number_to_currency(@stay.total_amount_cents.to_i / 100.0, unit: "€", format: "%n %u")
+          dt.font-medium.text-amber-800 Total proposé
+          dd.col-span-2.text-gray-900.font-semibold = number_to_currency(pending_change.new_total_cents.to_i / 100.0, unit: "€", format: "%n %u")
+          dt.font-medium.text-amber-800 Delta
+          dd.col-span-2.text-gray-900
+            = "#{pending_change.delta_cents.to_i.positive? ? '+' : ''}#{number_to_currency(pending_change.delta_cents.to_i / 100.0, unit: '€', format: '%n %u')}"
+          - if pending_change.refund_expected?
+            dt.font-medium.text-amber-800 IBAN
+            dd.col-span-2.text-gray-900.font-mono.text-xs = pending_change.refund_iban
+            dt.font-medium.text-amber-800 Remboursement
+            dd.col-span-2.text-gray-700.text-xs = StayChangeRequest::REFUND_NOTICE
+
+        / Composition proposée vs actuelle — diff lisible ligne à ligne.
+        .grid.grid-cols-2.gap-4.text-xs
+          div
+            .font-semibold.text-gray-500.uppercase.mb-1 Actuel
+            ul.space-y-0.5
+              - @stay.item_lines.each do |line|
+                li.text-gray-700
+                  = "#{line[:name]} — #{line[:amount]}"
+          div
+            .font-semibold.text-amber-800.uppercase.mb-1 Proposé
+            ul.space-y-0.5
+              - pending_change.proposed_draft.quote.breakdown.each do |line|
+                li.text-gray-900
+                  = "#{line[:label]} — #{number_to_currency(line[:amount_cents].to_i / 100.0, unit: '€', format: '%n %u')}"
+
+        .flex.flex-wrap.items-center.gap-2.pt-1
+          = button_to "Approuver",
+                      approve_change_request_stay_path(@stay, change_request_id: pending_change.id),
+                      method: :post,
+                      form: { data: { turbo_confirm: "Appliquer cette modification au séjour ?" } },
+                      class: "inline-flex items-center rounded-md border border-transparent bg-green-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-green-700"
+          = form_with url: refuse_change_request_stay_path(@stay, change_request_id: pending_change.id), method: :post, class: "flex items-center gap-2" do
+            = text_field_tag :refusal_reason, nil, required: true, placeholder: "Motif du refus (obligatoire)", class: "rounded-md border-gray-300 text-sm w-64"
+            = submit_tag "Refuser",
+                         class: "inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 cursor-pointer"
+
     dl.grid.grid-cols-3.gap-x-4.gap-y-2.text-sm
       dt.font-medium.text-gray-500 Dates
       dd.col-span-2.text-gray-900 = @stay.date_range

--- a/config/locales/public.en.yml
+++ b/config/locales/public.en.yml
@@ -43,3 +43,8 @@ en:
         amount_paid: "Already paid"
         balance_due: "Balance due"
         pay_balance_cta: "Pay the balance of %{amount}"
+    stay_change_requests:
+      cta: "Request a change"
+      submitted: "Your change request has been sent. Our team is reviewing it and will get back to you shortly."
+      unavailable: "This lodging is no longer available on those dates — your request was not saved."
+      too_late: "This stay is over: it can no longer be changed."

--- a/config/locales/public.fr.yml
+++ b/config/locales/public.fr.yml
@@ -39,3 +39,8 @@ fr:
         amount_paid: "Déjà payé"
         balance_due: "Reste dû"
         pay_balance_cta: "Payer le solde de %{amount}"
+    stay_change_requests:
+      cta: "Demander une modification"
+      submitted: "Votre demande de modification a bien été envoyée. Notre équipe la valide et vous répond rapidement."
+      unavailable: "Cet hébergement n'est plus disponible sur ces dates — votre demande n'a pas été enregistrée."
+      too_late: "Ce séjour est terminé : il ne peut plus être modifié."

--- a/config/locales/public.nl.yml
+++ b/config/locales/public.nl.yml
@@ -43,3 +43,8 @@ nl:
         amount_paid: "Reeds betaald"
         balance_due: "Nog te betalen"
         pay_balance_cta: "Betaal het saldo van %{amount}"
+    stay_change_requests:
+      cta: "Een wijziging aanvragen"
+      submitted: "Uw wijzigingsaanvraag is verzonden. Ons team bekijkt ze en antwoordt u snel."
+      unavailable: "Dit verblijf is niet meer beschikbaar op deze data — uw aanvraag werd niet geregistreerd."
+      too_late: "Dit verblijf is afgelopen: het kan niet meer worden gewijzigd."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,10 @@ Rails.application.routes.draw do
       # Action rapide depuis la modale du calendrier (issue #76) : bascule
       # pending ↔ confirmed sans ouvrir le form d'édition, réponse Turbo Stream.
       patch :update_status
+      # Demande de modification client (issue #133) : approbation / refus par
+      # l'équipe. C'est le seul chemin qui applique la demande au séjour.
+      post :approve_change_request
+      post :refuse_change_request
     end
     resources :experience_bookings, only: [:create]
   end
@@ -206,6 +210,12 @@ Rails.application.routes.draw do
   # même jeton que la page client ; crée/rafraîchit le paiement puis part sur
   # Stripe Checkout.
   post "sejour/:token/payer-le-solde", to: "public/stay_balance_payments#create", as: :public_stay_balance_payment
+
+  # Demande de modification de séjour par le client (issue #133) — canal jeton.
+  # C'est une DEMANDE : rien n'est appliqué avant validation par l'équipe.
+  get  "sejour/:token/modification",       to: "public/stay_change_requests#new",    as: :new_public_stay_change_request
+  post "sejour/:token/modification/devis", to: "public/stay_change_requests#quote",  as: :public_stay_change_request_quote
+  post "sejour/:token/modification",       to: "public/stay_change_requests#create", as: :public_stay_change_requests
 
   namespace :public do
     # Épic #81, Phase 9 — demande de réservation publique legacy retirée

--- a/db/migrate/20260721013839_create_stay_change_requests.rb
+++ b/db/migrate/20260721013839_create_stay_change_requests.rb
@@ -1,0 +1,19 @@
+class CreateStayChangeRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :stay_change_requests do |t|
+      t.references :stay, null: false, foreign_key: true
+      t.jsonb :draft_snapshot, null: false, default: {}
+      t.integer :new_total_cents, null: false, default: 0
+      t.integer :delta_cents, null: false, default: 0
+      t.string :refund_iban
+      t.string :status, null: false, default: "pending"
+      t.text :refusal_reason
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :stay_change_requests, [:stay_id, :status]
+    add_index :stay_change_requests, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_21_013839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -173,6 +173,34 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "updated_at", null: false
     t.index ["deleted_at"], name: "index_camping_bookings_on_deleted_at"
     t.index ["from_date", "to_date"], name: "index_camping_bookings_on_from_date_and_to_date"
+  end
+
+  create_table "coworking_packs", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.integer "days_total", null: false
+    t.integer "price_cents", default: 0, null: false
+    t.datetime "purchased_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "payment_method", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_coworking_packs_on_customer_id"
+    t.index ["deleted_at"], name: "index_coworking_packs_on_deleted_at"
+    t.index ["expires_at"], name: "index_coworking_packs_on_expires_at"
+  end
+
+  create_table "coworking_reservations", force: :cascade do |t|
+    t.bigint "coworking_pack_id", null: false
+    t.bigint "customer_id", null: false
+    t.date "date", null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coworking_pack_id"], name: "index_coworking_reservations_on_coworking_pack_id"
+    t.index ["customer_id"], name: "index_coworking_reservations_on_customer_id"
+    t.index ["date"], name: "index_coworking_reservations_on_date"
+    t.index ["deleted_at"], name: "index_coworking_reservations_on_deleted_at"
   end
 
   create_table "customers", force: :cascade do |t|
@@ -472,10 +500,23 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.string "stripe_payment_intent_id"
     t.bigint "stay_id"
     t.bigint "space_booking_id"
+    t.bigint "coworking_pack_id"
     t.index ["booking_id"], name: "index_payments_on_booking_id"
+    t.index ["coworking_pack_id"], name: "index_payments_on_coworking_pack_id"
     t.index ["id"], name: "index_payments_on_id", unique: true
     t.index ["space_booking_id"], name: "index_payments_on_space_booking_id"
     t.index ["stay_id"], name: "index_payments_on_stay_id"
+  end
+
+  create_table "portal_otps", force: :cascade do |t|
+    t.citext "email", null: false
+    t.string "code_digest", null: false
+    t.datetime "expires_at", null: false
+    t.integer "attempts", default: 0, null: false
+    t.datetime "consumed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email", "created_at"], name: "index_portal_otps_on_email_and_created_at"
   end
 
   create_table "products", force: :cascade do |t|
@@ -498,6 +539,16 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["human_id"], name: "index_projects_on_human_id"
+  end
+
+  create_table "rates", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "amount_cents", default: 0, null: false
+    t.string "label"
+    t.string "unit", default: "cents", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_rates_on_key", unique: true
   end
 
   create_table "rental_items", force: :cascade do |t|
@@ -618,6 +669,22 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
     t.datetime "deleted_at", precision: nil
     t.integer "position", default: 999
     t.integer "capacity", default: 1, null: false
+  end
+
+  create_table "stay_change_requests", force: :cascade do |t|
+    t.bigint "stay_id", null: false
+    t.jsonb "draft_snapshot", default: {}, null: false
+    t.integer "new_total_cents", default: 0, null: false
+    t.integer "delta_cents", default: 0, null: false
+    t.string "refund_iban"
+    t.string "status", default: "pending", null: false
+    t.text "refusal_reason"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_stay_change_requests_on_deleted_at"
+    t.index ["stay_id", "status"], name: "index_stay_change_requests_on_stay_id_and_status"
+    t.index ["stay_id"], name: "index_stay_change_requests_on_stay_id"
   end
 
   create_table "stay_items", force: :cascade do |t|
@@ -765,6 +832,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   add_foreign_key "bookings", "lodgings"
   add_foreign_key "bundles", "projects"
   add_foreign_key "bundles", "teams"
+  add_foreign_key "coworking_packs", "customers"
+  add_foreign_key "coworking_reservations", "coworking_packs"
+  add_foreign_key "coworking_reservations", "customers"
   add_foreign_key "customers", "humans"
   add_foreign_key "cycle_actions", "humans"
   add_foreign_key "cycle_actions", "humans", column: "delegate_to_human_id"
@@ -788,6 +858,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   add_foreign_key "lodging_rooms", "rooms"
   add_foreign_key "meal_orders", "stays"
   add_foreign_key "payments", "bookings"
+  add_foreign_key "payments", "coworking_packs"
   add_foreign_key "payments", "space_bookings"
   add_foreign_key "payments", "stays"
   add_foreign_key "projects", "humans"
@@ -797,6 +868,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_20_200100) do
   add_foreign_key "space_bookings", "events"
   add_foreign_key "space_reservations", "space_bookings"
   add_foreign_key "space_reservations", "spaces"
+  add_foreign_key "stay_change_requests", "stays"
   add_foreign_key "stay_items", "stays"
   add_foreign_key "stays", "customers"
   add_foreign_key "tasks", "bundles"

--- a/spec/mailers/stay_change_request_mailer_spec.rb
+++ b/spec/mailers/stay_change_request_mailer_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+# Issue #133 — emails de la demande de modification.
+RSpec.describe StayChangeRequestMailer, type: :mailer do
+  let(:customer) { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+  let(:stay) do
+    Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                 arrival_date: Date.current + 10, departure_date: Date.current + 12,
+                 total_amount_cents: 50_000)
+  end
+
+  def change(attrs = {})
+    StayChangeRequest.create!({ stay: stay, draft_snapshot: {},
+                                new_total_cents: 58_000, delta_cents: 8_000 }.merge(attrs))
+  end
+
+  it "prévient l'équipe avec le delta" do
+    mail = described_class.team_new_request(change)
+
+    expect(mail.to).to eq(["sejours@les4sources.be"])
+    expect(mail.subject).to include("+80,00 €")
+    expect(mail.text_part.decoded).to include("580,00 €")
+  end
+
+  it "accuse réception auprès du client" do
+    mail = described_class.customer_received(change)
+
+    expect(mail.to).to eq(["ana@example.com"])
+    expect(mail.text_part.decoded).to include("bien reçu")
+    expect(mail.text_part.decoded).to include("s'ajoutera à votre solde")
+  end
+
+  it "annonce la mention des 10 jours en cas de remboursement" do
+    Payment.create!(stay: stay, amount_cents: 50_000, payment_method: "card", status: "paid")
+    request = change(new_total_cents: 40_000, delta_cents: -10_000,
+                     refund_iban: "BE68539007547034")
+
+    expect(described_class.customer_received(request).text_part.decoded)
+      .to include(StayChangeRequest::REFUND_NOTICE)
+    expect(described_class.team_new_request(request).text_part.decoded)
+      .to include("BE68539007547034")
+  end
+
+  it "annonce l'approbation avec nouveau total et solde" do
+    mail = described_class.customer_approved(change(status: "approved"))
+
+    expect(mail.subject).to include("modifié")
+    expect(mail.text_part.decoded).to include("Nouveau total")
+    expect(mail.text_part.decoded).to include("Solde restant")
+    expect(mail.text_part.decoded).to include(stay.token)
+  end
+
+  it "annonce le refus avec son motif" do
+    request = change(status: "refused", refusal_reason: "Le gîte est complet.")
+    mail = described_class.customer_refused(request)
+
+    expect(mail.text_part.decoded).to include("Le gîte est complet.")
+    expect(mail.text_part.decoded).to include("reste inchangé")
+  end
+end

--- a/spec/models/stay_change_request_spec.rb
+++ b/spec/models/stay_change_request_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+# Issue #133 — demande de modification de séjour par le client.
+RSpec.describe StayChangeRequest, type: :model do
+  let(:customer) { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+  let(:stay) do
+    Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                 arrival_date: Date.current + 10, departure_date: Date.current + 12,
+                 total_amount_cents: 50_000)
+  end
+
+  def request_for(stay, attrs = {})
+    StayChangeRequest.new({ stay: stay, draft_snapshot: {}, new_total_cents: 50_000,
+                            delta_cents: 0 }.merge(attrs))
+  end
+
+  it "n'accepte que les statuts connus" do
+    expect(request_for(stay, status: "peut-être")).not_to be_valid
+  end
+
+  it "refuse un nouveau total négatif" do
+    expect(request_for(stay, new_total_cents: -1)).not_to be_valid
+  end
+
+  describe "IBAN" do
+    before { Payment.create!(stay: stay, amount_cents: 50_000, payment_method: "card", status: "paid") }
+
+    it "est OBLIGATOIRE quand le client a trop payé" do
+      change = request_for(stay, new_total_cents: 40_000, delta_cents: -10_000)
+
+      expect(change).not_to be_valid
+      expect(change.errors[:refund_iban]).to be_present
+    end
+
+    it "est accepté au bon format et normalisé" do
+      change = request_for(stay, new_total_cents: 40_000, delta_cents: -10_000,
+                                 refund_iban: "be68 5390 0754 7034")
+      expect(change).to be_valid
+      change.validate
+      expect(change.refund_iban).to eq("BE68539007547034")
+    end
+
+    it "refuse un IBAN mal formé" do
+      change = request_for(stay, new_total_cents: 40_000, delta_cents: -10_000,
+                                 refund_iban: "pas-un-iban")
+      expect(change).not_to be_valid
+      expect(change.errors[:refund_iban]).to be_present
+    end
+
+    it "n'est PAS exigé quand le total augmente" do
+      expect(request_for(stay, new_total_cents: 60_000, delta_cents: 10_000)).to be_valid
+    end
+  end
+
+  it "n'autorise qu'une seule demande pending par séjour" do
+    request_for(stay).save!
+
+    duplicate = request_for(stay)
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:base].join).to include("déjà en attente")
+  end
+
+  it "autorise une nouvelle demande une fois la précédente traitée" do
+    first = request_for(stay)
+    first.save!
+    first.update!(status: "refused", refusal_reason: "Complet")
+
+    expect(request_for(stay)).to be_valid
+  end
+
+  it "trace ses modifications et se supprime en douceur" do
+    change = request_for(stay)
+    change.save!
+
+    expect { change.update!(status: "approved") }.to change { change.versions.count }.by(1)
+
+    change.soft_delete!(validate: false)
+    expect(StayChangeRequest.where(id: change.id)).to be_empty
+  end
+
+  it "reconstruit le draft proposé depuis son snapshot" do
+    change = request_for(stay, draft_snapshot: { "arrival_date" => "2026-09-07",
+                                                 "departure_date" => "2026-09-10" })
+    expect(change.proposed_draft.arrival_date).to eq(Date.new(2026, 9, 7))
+  end
+end

--- a/spec/requests/public_stay_change_requests_spec.rb
+++ b/spec/requests/public_stay_change_requests_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+# Issue #133 — parcours client de la demande de modification.
+RSpec.describe "Demande de modification de séjour (client)", type: :request do
+  include ActiveJob::TestHelper
+
+  let(:customer) { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+  let!(:lodging) { Lodging.find_or_create_by!(name: "La Hulotte") { |l| l.price_night_cents = 48_500 } }
+
+  let(:arrival)   { Date.current + 10 }
+  let(:departure) { Date.current + 12 }
+
+  let(:stay) do
+    Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                 arrival_date: arrival, departure_date: departure,
+                 total_amount_cents: 74_500)
+  end
+
+  before { ActionMailer::Base.deliveries.clear }
+
+  def submit(params = {})
+    post public_stay_change_requests_path(stay.token), params: {
+      reservation: {
+        lodging_id: lodging.id,
+        arrival_date: arrival.to_s,
+        departure_date: departure.to_s,
+        lodging_night_ids: [lodging.id.to_s, lodging.id.to_s]
+      }
+    }.deep_merge(params)
+  end
+
+  describe "GET /sejour/:token/modification" do
+    it "affiche le formulaire prérempli" do
+      get new_public_stay_change_request_path(stay.token)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Modifier mon séjour")
+      expect(response.body).to include("Votre nouveau devis")
+    end
+
+    it "renvoie 404 sur un jeton inconnu" do
+      get new_public_stay_change_request_path("jeton-bidon")
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "refuse un séjour déjà parti" do
+      past = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                          arrival_date: Date.current - 10, departure_date: Date.current - 8)
+
+      get new_public_stay_change_request_path(past.token)
+
+      expect(response).to redirect_to(public_stay_path(past.token))
+      follow_redirect!
+      expect(response.body).to include("ne peut plus être modifié")
+    end
+  end
+
+  describe "POST /sejour/:token/modification/devis" do
+    it "recalcule le nouveau total et le delta en Turbo Stream" do
+      post public_stay_change_request_quote_path(stay.token),
+           params: { reservation: { lodging_id: lodging.id,
+                                    arrival_date: arrival.to_s,
+                                    departure_date: departure.to_s,
+                                    lodging_night_ids: [lodging.id.to_s, lodging.id.to_s] } },
+           headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("change_request_delta")
+      expect(response.body).to include("Nouveau total")
+    end
+  end
+
+  describe "POST /sejour/:token/modification" do
+    it "crée une demande PENDING sans jamais toucher au séjour" do
+      expect { submit }.to change { stay.stay_change_requests.count }.by(1)
+
+      change = stay.stay_change_requests.last
+      expect(change).to be_pending
+      # Le séjour est strictement inchangé.
+      expect(stay.reload.total_amount_cents).to eq(74_500)
+      expect(stay.arrival_date).to eq(arrival)
+      expect(response).to redirect_to(public_stay_path(stay.token))
+    end
+
+    it "envoie un email à l'équipe et un accusé au client" do
+      perform_enqueued_jobs { submit }
+
+      recipients = ActionMailer::Base.deliveries.map(&:to).flatten
+      expect(recipients).to include("sejours@les4sources.be")
+      expect(recipients).to include("ana@example.com")
+    end
+
+    it "calcule un delta positif quand le client agrandit son séjour" do
+      submit(reservation: { departure_date: (departure + 1).to_s,
+                            lodging_night_ids: [lodging.id.to_s] * 3 })
+
+      expect(stay.stay_change_requests.last.delta_cents).to be > 0
+    end
+
+    it "exige l'IBAN et affiche la mention des 10 jours en cas de trop-perçu" do
+      Payment.create!(stay: stay, amount_cents: 74_500, payment_method: "card", status: "paid")
+
+      # Réduction à une seule nuit → nouveau total < déjà payé, sans IBAN.
+      expect {
+        submit(reservation: { departure_date: (arrival + 1).to_s,
+                              lodging_night_ids: [lodging.id.to_s] })
+      }.not_to change { stay.stay_change_requests.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Le remboursement sera effectué dans les 10 jours qui suivent le séjour.")
+    end
+
+    it "accepte la réduction quand l'IBAN est fourni" do
+      Payment.create!(stay: stay, amount_cents: 74_500, payment_method: "card", status: "paid")
+
+      submit(reservation: { departure_date: (arrival + 1).to_s,
+                            lodging_night_ids: [lodging.id.to_s] })
+      # (la première tentative sans IBAN a échoué ci-dessus)
+      post public_stay_change_requests_path(stay.token), params: {
+        refund_iban: "BE68539007547034",
+        reservation: { lodging_id: lodging.id, arrival_date: arrival.to_s,
+                       departure_date: (arrival + 1).to_s,
+                       lodging_night_ids: [lodging.id.to_s] }
+      }
+
+      change = stay.stay_change_requests.last
+      expect(change.refund_iban).to eq("BE68539007547034")
+      expect(change.delta_cents).to be < 0
+    end
+
+    it "refuse la demande quand l'hébergement n'est plus disponible" do
+      # Indisponibilité posée à la main sur le gîte : la règle de dispo est la
+      # MÊME que celle de la validation admin (Stays::LodgingAvailability).
+      (arrival..departure).each { |date| lodging.unavailabilities.create!(date: date) }
+
+      expect { submit }.not_to change { stay.stay_change_requests.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("n'est plus disponible")
+    end
+
+    it "remplace la demande en attente précédente" do
+      submit
+      first = stay.stay_change_requests.last
+
+      submit(reservation: { departure_date: (departure + 1).to_s,
+                            lodging_night_ids: [lodging.id.to_s] * 3 })
+
+      expect(stay.stay_change_requests.pending.count).to eq(1)
+      expect(StayChangeRequest.where(id: first.id)).to be_empty
+    end
+  end
+
+  describe "page /sejour/:token" do
+    it "propose le bouton de modification sur un séjour à venir" do
+      get public_stay_path(stay.token)
+      expect(response.body).to include("Demander une modification")
+    end
+
+    it "ne le propose PAS sur un séjour terminé" do
+      past = Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                          arrival_date: Date.current - 10, departure_date: Date.current - 8)
+
+      get public_stay_path(past.token)
+      expect(response.body).not_to include("Demander une modification")
+    end
+  end
+end

--- a/spec/requests/stays_change_request_admin_spec.rb
+++ b/spec/requests/stays_change_request_admin_spec.rb
@@ -1,0 +1,157 @@
+require "rails_helper"
+
+# Issue #133 — validation par l'équipe : approbation / refus d'une demande.
+RSpec.describe "Demande de modification de séjour (admin)", type: :request do
+  include ActiveJob::TestHelper
+
+  let(:user) { User.create!(email: "agent@les4sources.be", password: "password123") }
+  let(:customer) { Customer.create!(first_name: "Ana", last_name: "Lopez", email: "ana@example.com") }
+  let!(:lodging) { Lodging.find_or_create_by!(name: "La Hulotte") { |l| l.price_night_cents = 48_500 } }
+
+  let(:arrival)   { Date.current + 10 }
+  let(:departure) { Date.current + 12 }
+
+  let(:stay) do
+    Stay.create!(customer: customer, source: "manual", status: "confirmed",
+                 arrival_date: arrival, departure_date: departure,
+                 total_amount_cents: 74_500)
+  end
+
+  # Draft proposé : 3 nuits au lieu de 2 (agrandissement).
+  def proposed_snapshot(nights: 3, from: arrival)
+    Reservations::Draft.new(
+      lodging_id: lodging.id,
+      arrival_date: from,
+      departure_date: from + nights,
+      lodging_night_ids: [lodging.id.to_s] * nights,
+      first_name: "Ana", last_name: "Lopez", email: "ana@example.com"
+    ).to_h
+  end
+
+  def change_request(attrs = {})
+    snapshot = attrs.delete(:snapshot) || proposed_snapshot
+    total = Reservations::Draft.new(snapshot).quote.total_excluding_experiences_cents
+    StayChangeRequest.create!({
+      stay: stay,
+      draft_snapshot: snapshot,
+      new_total_cents: total,
+      delta_cents: total - stay.total_amount_cents.to_i
+    }.merge(attrs))
+  end
+
+  before do
+    sign_in user
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "bloc sur la fiche séjour" do
+    it "affiche la demande en attente, le delta et les deux actions" do
+      change_request
+
+      get stay_path(stay)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Demande de modification en attente")
+      expect(response.body).to include("Total proposé")
+      expect(response.body).to include("Approuver")
+      expect(response.body).to include("Motif du refus")
+    end
+
+    it "n'affiche rien quand il n'y a pas de demande en attente" do
+      get stay_path(stay)
+      expect(response.body).not_to include("Demande de modification en attente")
+    end
+  end
+
+  describe "POST approve_change_request" do
+    it "applique la composition et recalcule le solde" do
+      change = change_request
+
+      perform_enqueued_jobs do
+        post approve_change_request_stay_path(stay, change_request_id: change.id)
+      end
+
+      expect(response).to redirect_to(stay_path(stay))
+      expect(change.reload).to be_approved
+      expect(stay.reload.departure_date).to eq(arrival + 3)
+      expect(stay.total_amount_cents).to eq(change.new_total_cents)
+      # Le client est prévenu.
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include("ana@example.com")
+    end
+
+    it "recopie l'IBAN et la consigne des 10 jours dans la note interne" do
+      Payment.create!(stay: stay, amount_cents: 200_000, payment_method: "card", status: "paid")
+      change = change_request(refund_iban: "BE68539007547034")
+
+      post approve_change_request_stay_path(stay, change_request_id: change.id)
+
+      expect(stay.reload.notes.to_s).to include("BE68539007547034")
+      expect(stay.notes.to_s).to include(StayChangeRequest::REFUND_NOTICE)
+    end
+
+    it "re-vérifie la disponibilité à la validation et refuse si elle a sauté" do
+      change = change_request
+      (arrival..(arrival + 3)).each { |date| lodging.unavailabilities.create!(date: date) }
+
+      post approve_change_request_stay_path(stay, change_request_id: change.id)
+
+      follow_redirect!
+      expect(response.body).to include("ne sont plus disponibles")
+      expect(change.reload).to be_pending
+      expect(stay.reload.departure_date).to eq(departure)
+    end
+
+    it "laisse forcer la disponibilité" do
+      change = change_request
+      (arrival..(arrival + 3)).each { |date| lodging.unavailabilities.create!(date: date) }
+
+      post approve_change_request_stay_path(stay, change_request_id: change.id,
+                                                  force_availability: "1")
+
+      expect(change.reload).to be_approved
+    end
+  end
+
+  describe "POST refuse_change_request" do
+    it "refuse avec un motif et prévient le client" do
+      change = change_request
+
+      perform_enqueued_jobs do
+        post refuse_change_request_stay_path(stay, change_request_id: change.id),
+             params: { refusal_reason: "Le gîte est déjà réservé cette nuit-là." }
+      end
+
+      expect(change.reload).to be_refused
+      expect(change.refusal_reason).to include("déjà réservé")
+      # Le séjour n'a PAS bougé.
+      expect(stay.reload.departure_date).to eq(departure)
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to eq(["ana@example.com"])
+      expect(mail.text_part.decoded).to include("déjà réservé")
+    end
+
+    it "exige un motif" do
+      change = change_request
+
+      post refuse_change_request_stay_path(stay, change_request_id: change.id),
+           params: { refusal_reason: "  " }
+
+      expect(change.reload).to be_pending
+      follow_redirect!
+      expect(response.body).to include("motif de refus est obligatoire")
+    end
+  end
+
+  describe "sans authentification" do
+    it "redirige vers la connexion" do
+      change = change_request
+      sign_out user
+
+      post approve_change_request_stay_path(stay, change_request_id: change.id)
+
+      expect(response).to redirect_to(new_user_session_path)
+      expect(change.reload).to be_pending
+    end
+  end
+end


### PR DESCRIPTION
Closes #133

Un client peut demander une modification depuis sa page `/sejour/:token`. C'est une **DEMANDE** : le séjour n'est touché qu'à l'approbation par l'équipe.

## Côté client

- **Bouton « Demander une modification »** sur `/sejour/:token`, masqué dès que le départ est passé (et la route refuse aussi ce cas, pas seulement l'UI).
- **Formulaire prérempli** depuis `Stays::DraftReconstructor`, qui réutilise **tels quels** les partiels de composition du funnel public (`_stay_calendar` — hébergement + camping/van/hamacs nuit par nuit — et `_spaces_calendar`). **Aucune modification du funnel** : les partiels émettent des champs `reservation[...]`, et le contrôleur les lit sous cette clé.
- **Devis live** en Turbo Stream : total actuel, nouveau total, et le delta rendu en toutes lettres — « +80 € ajoutés à votre solde » / « −60 € à rembourser ».
- **Trop-perçu** (`amount_paid_cents > nouveau total`) → champ **IBAN obligatoire** (format validé : 2 lettres pays + 2 chiffres + 11-30 alphanum, normalisé sans espaces) et la mention **exacte** « Le remboursement sera effectué dans les 10 jours qui suivent le séjour. »
- **Disponibilité vérifiée à la soumission** : hébergement indisponible → refus immédiat du formulaire avec message, rien n'est enregistré.
- **Une seule demande `pending` par séjour** : la nouvelle remplace l'ancienne. Le remplacement se fait dans une transaction — si l'enregistrement échoue (IBAN manquant), un `ROLLBACK` **rend son ancienne demande au client**.

## Côté équipe

Bloc **« Demande de modification en attente »** sur la fiche séjour : totaux actuel / proposé, delta, IBAN + consigne de remboursement le cas échéant, et un **diff lisible** composition actuelle vs proposée (deux colonnes ligne à ligne).

- **Approuver** → `Stays::ApplyChangeRequest` : **re-vérifie la disponibilité** (le monde a bougé depuis la soumission ; `force_availability` reste possible), applique via `Stays::AdminUpdater` **réutilisé tel quel**, recopie IBAN + consigne des 10 jours dans la **note interne**, puis `set_payment_status` — le solde exigible absorbe donc le delta positif tout seul.
- **Refuser** → motif **obligatoire**, envoyé au client. Le séjour ne bouge pas.
- 4 emails : équipe (nouvelle demande, avec delta), client (reçue / approuvée avec nouveau total et solde / refusée avec motif).

## Un petit refactor, volontairement

`Stays::AdminUpdater#lodging_available?` a été **extrait tel quel** dans `Stays::LodgingAvailability` et l'`AdminUpdater` y délègue. Motivation : la demande client doit appliquer **exactement** la même règle de dispo que la validation admin — une seule vérité, deux appelants, plutôt qu'une copie qui divergera. Le corps n'a pas changé d'une ligne, et la suite existante le prouve.

## Vérification

- `bundle exec rspec` → **1003 examples, 0 failures**, 16 pending (les pending préexistent sur `main`).
- Specs ajoutées : modèle (statuts, total négatif, **IBAN exigé ssi trop-perçu**, format + normalisation, non exigé en hausse, unicité du `pending`, réouverture après traitement, PaperTrail + soft-deletion, reconstruction du draft) ; **client** (formulaire prérempli, 404 sur jeton inconnu, séjour passé refusé, devis Turbo Stream, demande `pending` créée **sans que le séjour bouge**, emails équipe + client, delta positif à l'agrandissement, IBAN exigé + mention des 10 jours affichée, réduction acceptée avec IBAN, indispo refusée, remplacement de la demande précédente, présence/absence du bouton) ; **admin** (bloc rendu ou non, approbation qui applique la composition et recale le total, IBAN + consigne dans la note interne, **re-check de dispo à l'approbation**, forçage, refus avec motif + email, motif obligatoire, auth requise) ; **mailers** (les 4, sujets, delta formaté, mention de remboursement, lien token).
- Pas de linter dans le repo (ni RuboCop, ni script `lint` dans `package.json` ; le seul workflow CI est `agent-ready-gate.yml`) — rien à faire côté lint.

## 📸 Aperçu

![Demande de modification — formulaire client](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260721-034846-demande-de-modification--formulaire-client.png)

![Page séjour — bouton « Demander une modification »](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260721-034900-page-sjour--bouton--demander-une-modification-.png)

Captures réelles (Chrome headless sur l'app en local avec Vite, sur un vrai séjour de la base de dev). **Le bloc admin n'a pas pu être capturé** : il est derrière Devise, et le chemin Capybara est cassé sur cette machine (`webdrivers 5.2.0` + `selenium-webdriver 4.5.0` interrogent `chromedriver.storage.googleapis.com`, qui renvoie 404 pour Chrome 150 ; aucun `spec/system` n'existe dans le repo). Il n'est couvert que par des request specs.

## À valider à la main — et deux écarts assumés

1. **Le formulaire client ne propose ni repas, ni terrasse.** Le funnel public n'a pas de grille repas à réutiliser, et je n'allais pas en inventer une. **Important** : repas, terrasse, activités, facturation espace et coordonnées sont **reportés tels quels** depuis le séjour dans le draft proposé — sans ce report, une approbation les aurait effacés en silence. Dis-moi si tu veux que le client puisse aussi ajuster ses repas.
2. **Les activités sont exclues du formulaire**, comme demandé (v1) — les `ExperienceBooking` gardent leur flux propre. Un encart le dit au client.
3. Le **diff admin** compare les lignes du devis proposé aux lignes du séjour actuel. C'est lisible, mais ce n'est pas un diff mot à mot — à regarder avec l'œil sur un vrai cas.
4. Le **rendu du formulaire client** avec l'œil, surtout la grille nuit par nuit préremplie.

## Hors périmètre (comme demandé)

Remboursement Stripe automatisé (il reste manuel), modification des activités validées par porteur, portail OTP (#128 — le bouton vit bien sur la page token existante).
