### PR TITLE
Hamacs : vraie persistance des locations sur le séjour (#138)

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -59,6 +59,14 @@ class PagesController < BaseController
           .where.not(status: ["declined", "canceled"])
           .where("from_date < ? AND to_date > ?", @last.to_date, @first.to_date)
       )
+      # Hamacs (issue #138) — même étalement par nuit que camping/van : ils
+      # comptent dans le bloc du séjour (chip 🛌) et dans la nuitée (💤).
+      @grouped_hamac_bookings = nights_grouped_by_day(
+        HamacBooking
+          .includes(stay: :customer)
+          .where.not(status: ["declined", "canceled"])
+          .where("from_date < ? AND to_date > ?", @last.to_date, @first.to_date)
+      )
     end
   end
 

--- a/app/decorators/stay_decorator.rb
+++ b/app/decorators/stay_decorator.rb
@@ -51,6 +51,11 @@ class StayDecorator < ApplicationDecorator
     bookables_of("VanBooking")
   end
 
+  # Locations de hamacs (issue #138) — une entrée par plage de nuits et par type.
+  def hamac_bookings
+    bookables_of("HamacBooking")
+  end
+
   def meals
     object.meal_orders.to_a
   end
@@ -58,7 +63,8 @@ class StayDecorator < ApplicationDecorator
   # Le séjour a-t-il au moins un élément de composition à afficher ?
   def any_composition?
     lodging_bookings.any? || space_bookings.any? || camping_bookings.any? ||
-      van_bookings.any? || meals.any? || object.experience_bookings.active.any?
+      van_bookings.any? || hamac_bookings.any? || meals.any? ||
+      object.experience_bookings.active.any?
   end
 
   # Résumé compact de la composition pour l'index Séjours : « 1 gîte · 2 espaces
@@ -72,6 +78,7 @@ class StayDecorator < ApplicationDecorator
       compo_part(space_bookings.size, "espace", "espaces"),
       compo_part(camping_bookings.size, "camping", "campings"),
       compo_part(van_bookings.size, "van", "vans"),
+      compo_part(hamac_bookings.sum { |h| h.count.to_i }, "hamac", "hamacs"),
       compo_part(active_experiences_count, "activité", "activités"),
       compo_part(object.meal_orders.size, "repas", "repas")
     ].compact
@@ -229,6 +236,8 @@ class StayDecorator < ApplicationDecorator
       bookable.kind == "terrasse" ? h.t("public.stays.items.terrace") : h.t("public.stays.items.camping")
     when VanBooking
       h.t("public.stays.items.van")
+    when HamacBooking
+      "#{h.t('public.stays.items.hamac')} — #{bookable.label} × #{bookable.count}"
     else
       h.t("public.stays.items.other")
     end

--- a/app/helpers/stays_composition_helper.rb
+++ b/app/helpers/stays_composition_helper.rb
@@ -4,11 +4,8 @@ module StaysCompositionHelper
   # icône par occurrence — une seule par type présent. Chaque icône porte un
   # `title` (tooltip natif) nommant la ressource.
   #
-  # HAMAC : aucune icône. Les hamacs ne sont PAS persistés côté séjour — ils
-  # n'existent que dans le devis B2C (`Reservations::Draft#hamacs`, pour le
-  # prix) ; `CampingBooking` ne persiste jamais que `kind: "tente"` et
-  # `RentalItem` n'est qu'un catalogue d'objets physiques (jamais rattaché à un
-  # Stay). Dès qu'un stockage hamac côté séjour existera, ajouter 🛌 ici.
+  # HAMAC : 🛌, depuis l'issue #138 — les hamacs sont désormais persistés sur le
+  # séjour (`HamacBooking` via `StayItem`), plus seulement présents dans le devis.
   #
   # PERFORMANCE : ne déclenche AUCUNE requête. S'appuie sur les associations
   # préchargées par `CustomersController#show` (stay_items→bookable,
@@ -21,6 +18,7 @@ module StaysCompositionHelper
     icons << composition_icon("🍳", "Cuisine")      if stay_has_kitchen?(stay)
     icons << composition_icon("🚐", "Van")          if stay_has_van?(stay)
     icons << composition_icon("⛺", "Tente")        if stay_has_tent?(stay)
+    icons << composition_icon("🛌", "Hamac")        if stay_has_hamac?(stay)
     icons << composition_icon("🪑", "Terrasse")     if stay_has_terrace?(stay)
     icons << composition_icon("🎯", "Activité")     if stay_has_activity?(stay)
     return if icons.empty?
@@ -66,6 +64,11 @@ module StaysCompositionHelper
   # "terrasse", décision Michael 2026-07-20) : on distingue par `kind`.
   def stay_has_tent?(stay)
     stay_items_of(stay, "CampingBooking").any? { |i| i.bookable&.kind != "terrasse" }
+  end
+
+  # Hamac = location persistée sur le séjour (issue #138).
+  def stay_has_hamac?(stay)
+    stay_items_of(stay, "HamacBooking").any?
   end
 
   # Terrasse = occupation de jour (kind "terrasse") — icône dédiée 🪑.

--- a/app/models/hamac_booking.rb
+++ b/app/models/hamac_booking.rb
@@ -1,0 +1,115 @@
+# == Schema Information
+#
+# Table name: hamac_bookings
+#
+#  id          :bigint           not null, primary key
+#  firstname   :string
+#  lastname    :string
+#  email       :string
+#  phone       :string
+#  group_name  :string
+#  from_date   :date
+#  to_date     :date
+#  kind        :string           default("simple"), not null
+#  count       :integer          default(1), not null
+#  status      :string
+#  price_cents :integer
+#  token       :string
+#  notes       :text
+#  deleted_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Location de HAMACS sur un séjour (issue #138). Jusqu'ici les hamacs n'existaient
+# que dans le devis (`Reservations::Draft#hamacs`, lignes `PricingModel`) : un
+# séjour avec hamacs payés ne les montrait ni en modale ni au calendrier, et rien
+# n'empêchait de sur-louer. Ce modèle les persiste HONNÊTEMENT, sur le pattern
+# camping/van par nuit : une réservation par PLAGE CONTIGUË de valeur constante,
+# fenêtre `[from_date, to_date)`, rattachée au séjour par un `StayItem` polymorphe.
+#
+# Différence avec camping/van : la capacité n'est PAS une constante du domaine
+# mais le STOCK physique du `RentalItem` correspondant (« Hamac simple » /
+# « Hamac double », colonne `stock`). Stock non renseigné (nil) = aucune limite —
+# on ne bloque jamais une réservation sur une donnée de catalogue absente.
+class HamacBooking < ApplicationRecord
+  KINDS = %w[simple double].freeze
+
+  # Nom du `RentalItem` porteur du stock ET du tarif de chaque type de hamac.
+  # Même table de correspondance que `Pricing::Catalog.hamac_rate`.
+  RENTAL_ITEM_NAMES = { "simple" => "Hamac simple", "double" => "Hamac double" }.freeze
+
+  LABELS = { "simple" => "Hamac simple", "double" => "Hamac double" }.freeze
+
+  # Inverse de la relation StayItem (mêmes conventions que CampingBooking).
+  has_one :stay_item, as: :bookable
+  has_one :stay, through: :stay_item
+
+  has_paper_trail
+  has_soft_deletion default_scope: true
+
+  monetize :price_cents, allow_nil: true
+
+  validates :kind, inclusion: { in: KINDS }
+  validates :count, numericality: { only_integer: true, greater_than: 0 }
+
+  before_create :generate_token
+
+  scope :confirmed, -> { where(status: "confirmed") }
+  # Réservations couvrant la nuit `date` (from <= date < to) — même convention
+  # `[from, to)` que `GlobalCapacityBookable`.
+  scope :covering, ->(date) { where("from_date <= ? AND to_date > ?", date, date) }
+  scope :of_kind, ->(kind) { where(kind: kind.to_s) }
+  scope :current_and_future, -> { where("to_date >= ?", Date.today).order(from_date: :asc) }
+
+  class << self
+    # Stock total de ce type de hamac = `RentalItem#stock`. nil quand l'article
+    # n'existe pas ou que son stock n'est pas renseigné → capacité non bornée.
+    def total_stock(kind)
+      RentalItem.find_by(name: RENTAL_ITEM_NAMES[kind.to_s])&.stock
+    end
+
+    # Unités déjà CONFIRMÉES pour la nuit `date` (toutes réservations vivantes
+    # confondues), en excluant éventuellement des réservations données (édition).
+    def units_reserved_on(kind, date, excluding_id: nil)
+      scope = of_kind(kind).confirmed.covering(date)
+      scope = scope.where.not(id: excluding_id) if excluding_id.present?
+      scope.sum(:count)
+    end
+
+    def remaining_on(kind, date, excluding_id: nil)
+      stock = total_stock(kind)
+      return nil if stock.nil?
+      [stock - units_reserved_on(kind, date, excluding_id: excluding_id), 0].max
+    end
+
+    # Première nuit en rupture de stock pour une demande, ou nil si tout passe
+    # (y compris quand le stock n'est pas renseigné).
+    def capacity_conflict_date(kind:, units:, from:, to:, excluding_id: nil)
+      stock = total_stock(kind)
+      return nil if stock.nil? || units.to_i < 1 || from.blank? || to.blank?
+
+      (from...to).find do |date|
+        units_reserved_on(kind, date, excluding_id: excluding_id) + units.to_i > stock
+      end
+    end
+
+    def label_for(kind)
+      LABELS.fetch(kind.to_s, "Hamac")
+    end
+  end
+
+  def confirmed? = status == "confirmed"
+  def pending?   = status == "pending"
+
+  def label = self.class.label_for(kind)
+
+  def name = "#{firstname} #{lastname}".strip
+
+  def generate_token
+    return if token.present?
+    loop do
+      self.token = SecureRandom.hex(8)
+      break unless HamacBooking.unscoped.exists?(token: token)
+    end
+  end
+end

--- a/app/models/stay_item.rb
+++ b/app/models/stay_item.rb
@@ -13,13 +13,13 @@
 class StayItem < ApplicationRecord
   belongs_to :stay
   # Polymorphic, extensible: Booking + SpaceBooking + CampingBooking + VanBooking
-  # today (epic #66, Phase 3). Les repas (MealOrder) n'occupent PAS le calendrier
+  # + HamacBooking (issue #138) aujourd'hui. Les repas (MealOrder) n'occupent PAS le calendrier
   # → rattachés en direct sur Stay, pas via StayItem.
   belongs_to :bookable, polymorphic: true
 
   has_paper_trail
   has_soft_deletion default_scope: true
 
-  validates :bookable_type, inclusion: { in: %w[Booking SpaceBooking CampingBooking VanBooking] }
+  validates :bookable_type, inclusion: { in: %w[Booking SpaceBooking CampingBooking VanBooking HamacBooking] }
   validates :bookable_id, uniqueness: { scope: [:stay_id, :bookable_type] }
 end

--- a/app/presenters/calendar/day_stay_blocks.rb
+++ b/app/presenters/calendar/day_stay_blocks.rb
@@ -14,7 +14,7 @@ module Calendar
     # Un bloc unifié : un séjour et ses composants présents ce jour-là.
     StayBlock = Struct.new(
       :stay, :booking_groups, :space_groups, :camping_bookings, :van_bookings,
-      :terrace_bookings,
+      :terrace_bookings, :hamac_bookings,
       keyword_init: true
     ) do
       # Le bookable « nommé » (Booking ou SpaceBooking, tous deux décorés et
@@ -27,15 +27,18 @@ module Calendar
       # Le séjour dort-il SUR PLACE la nuit de cette carte ? Vrai dès qu'un
       # composant NUITÉ est présent ce jour-là (chambres, camping, van) —
       # jamais pour une salle seule NI pour une TERRASSE (occupation de jour,
-      # pas une nuitée — décision Michael 2026-07-20).
+      # pas une nuitée — décision Michael 2026-07-20). Un HAMAC, lui, EST une
+      # nuitée (issue #138) : on y dort.
       def overnight?
-        booking_groups.any? || camping_bookings.any? || van_bookings.any?
+        booking_groups.any? || camping_bookings.any? || van_bookings.any? ||
+          hamac_bookings.any?
       end
 
       # Repli quand le séjour n'a que du camping / van / terrasse (pas de
       # bookable nommé).
       def fallback_bookable
-        camping_bookings.first || van_bookings.first || terrace_bookings.first
+        camping_bookings.first || van_bookings.first || hamac_bookings.first ||
+          terrace_bookings.first
       end
     end
 
@@ -45,11 +48,13 @@ module Calendar
     SpaceGroup = Struct.new(:space_booking, :space_reservations, keyword_init: true)
 
     def initialize(date, grouped_reservations:, grouped_space_reservations:,
-                   grouped_camping_bookings:, grouped_van_bookings:)
+                   grouped_camping_bookings:, grouped_van_bookings:,
+                   grouped_hamac_bookings: nil)
       @booking_groups = build_booking_groups(grouped_reservations && grouped_reservations[date])
       @space_groups   = build_space_groups(grouped_space_reservations && grouped_space_reservations[date])
       @camping        = Array(grouped_camping_bookings && grouped_camping_bookings[date])
       @van            = Array(grouped_van_bookings && grouped_van_bookings[date])
+      @hamac          = Array(grouped_hamac_bookings && grouped_hamac_bookings[date])
     end
 
     # Blocs unifiés (un par séjour), triés par id de séjour puis date d'arrivée
@@ -89,6 +94,12 @@ module Calendar
         (by_stay[van.stay.id] ||= new_block(van.stay)).van_bookings << van
       end
 
+      # Hamacs (issue #138) : chip dédiée sur le bloc du séjour, et nuitée (💤).
+      @hamac.each do |hamac|
+        next if hamac.stay.nil?
+        (by_stay[hamac.stay.id] ||= new_block(hamac.stay)).hamac_bookings << hamac
+      end
+
       by_stay.values.sort_by { |block| [block.stay.id.to_i, block.stay.arrival_date.to_s] }
     end
 
@@ -111,7 +122,8 @@ module Calendar
 
     def new_block(stay)
       StayBlock.new(stay: stay, booking_groups: [], space_groups: [],
-                    camping_bookings: [], van_bookings: [], terrace_bookings: [])
+                    camping_bookings: [], van_bookings: [], terrace_bookings: [],
+                    hamac_bookings: [])
     end
 
     # Réplique le regroupement historique des vues : trie par heure, regroupe par

--- a/app/services/concerns/hamac_composition.rb
+++ b/app/services/concerns/hamac_composition.rb
@@ -1,0 +1,156 @@
+# Composition HAMACS d'un séjour depuis un `Reservations::Draft` (issue #138).
+# Concern PARTAGÉ par `Reservations::Builder` (création) et `Stays::AdminUpdater`
+# (édition), sur le modèle exact de `CampingComposition` — dont il réutilise les
+# primitives `night_value_ranges` / `distribute_cents` (déclarées en dépendance
+# ci-dessous, pour ne pas dupliquer la découpe en plages ni la ventilation
+# largest-remainder).
+#
+# Décisions (issue #138, décision Michael 2026-07-22) :
+#   - Les hamacs sont PERSISTÉS, dans TOUS les canaux (funnel public ET admin) :
+#     jusqu'ici ils n'existaient que dans le devis, donc invisibles du séjour et
+#     sur-louables.
+#   - Grille par nuit `per_night_resources["hamac_simple"|"hamac_double"]` →
+#     une `HamacBooking` par PLAGE CONTIGUË de valeur constante, fenêtre
+#     `[from, to)` — comme camping/van, donc calendrier et totaux marchent sans
+#     traitement spécial.
+#   - Le montant vient du devis (`quote.hamac_cents`), VENTILÉ sur les plages au
+#     prorata `count × nuits` : ∑ plages == part hamac du devis (invariant).
+#   - Capacité = STOCK physique du `RentalItem` (nil = non borné).
+module HamacComposition
+  extend ActiveSupport::Concern
+
+  # `night_value_ranges`, `distribute_cents`, `draft_window_nights`,
+  # `draft_per_night_grid?` et `symbol` vivent dans CampingComposition.
+  include CampingComposition
+
+  # Clé de la grille `per_night_resources` pour un type de hamac.
+  GRID_KEYS = { "simple" => "hamac_simple", "double" => "hamac_double" }.freeze
+
+  private
+
+  # --- Lecture du draft ----------------------------------------------------
+
+  # Entrées hamac du draft, normalisées `{kind:, count:, nights:}`. Le Draft les
+  # dérive lui-même de la grille quand elle est présente ; sinon ce sont les
+  # entrées pleine-fenêtre (form legacy / emails).
+  def draft_hamac_entries(draft)
+    Array(draft.try(:hamacs)).map { |e| symbol(e) }
+                             .select { |e| HamacBooking::KINDS.include?(e[:kind].to_s) && e[:count].to_i.positive? }
+  end
+
+  def draft_has_hamacs?(draft)
+    draft_hamac_entries(draft).any?
+  end
+
+  # Plages contiguës pour un type de hamac, depuis la grille par nuit.
+  def hamac_night_ranges(draft, kind)
+    night_value_ranges(
+      draft.per_night_resources&.[](GRID_KEYS.fetch(kind.to_s)),
+      draft.arrival_date,
+      max_nights: draft_window_nights(draft)
+    )
+  end
+
+  # Toutes les plages hamac, par type : `{ "simple" => [...], "double" => [...] }`
+  # (types sans plage exclus).
+  def hamac_ranges_by_kind(draft)
+    HamacBooking::KINDS.each_with_object({}) do |kind, memo|
+      ranges = hamac_night_ranges(draft, kind)
+      memo[kind] = ranges if ranges.any?
+    end
+  end
+
+  # Repli pleine-fenêtre (grille absente) : une plage par type, agrégeant les
+  # entrées de ce type sur toute la fenêtre du séjour. Même forme de retour que
+  # `hamac_ranges_by_kind` pour que la persistance n'ait qu'un seul chemin.
+  def hamac_full_window_ranges_by_kind(draft)
+    return {} if draft.arrival_date.blank? || draft.departure_date.blank?
+    nights = draft_window_nights(draft).to_i
+    return {} if nights < 1
+
+    draft_hamac_entries(draft).group_by { |e| e[:kind].to_s }.transform_values do |entries|
+      count = entries.sum { |e| e[:count].to_i }
+      [{ from_date: draft.arrival_date, to_date: draft.departure_date,
+         nights: nights, value: count }]
+    end
+  end
+
+  # Source unique des plages à persister : grille si elle porte des hamacs,
+  # repli pleine-fenêtre sinon.
+  def hamac_ranges_for(draft)
+    grid = draft_per_night_grid?(draft) ? hamac_ranges_by_kind(draft) : {}
+    grid.any? ? grid : hamac_full_window_ranges_by_kind(draft)
+  end
+
+  # --- Stock (RentalItem) --------------------------------------------------
+
+  # Message d'avertissement si la demande dépasse le stock disponible une nuit
+  # donnée, sinon nil. `excluding_id` : réservations propres au séjour édité.
+  def hamac_stock_message(draft, excluding_id: nil)
+    hamac_ranges_for(draft).each do |kind, ranges|
+      ranges.each do |r|
+        date = HamacBooking.capacity_conflict_date(
+          kind: kind, units: r[:value], from: r[:from_date], to: r[:to_date],
+          excluding_id: excluding_id
+        )
+        next if date.nil?
+
+        stock = HamacBooking.total_stock(kind)
+        return "#{HamacBooking.label_for(kind)} : stock insuffisant le " \
+               "#{date.strftime('%-d/%m')} (#{stock} disponible#{'s' if stock.to_i > 1})."
+      end
+    end
+    nil
+  end
+
+  # --- Persistance ---------------------------------------------------------
+
+  # Persiste les hamacs du draft en N `HamacBooking` (une par plage contiguë et
+  # par type). `total_price_cents` (= `quote.hamac_cents`) est VENTILÉ sur TOUTES
+  # les plages, tous types confondus, au prorata `count × nuits × tarif` : la
+  # somme des `price_cents` égale EXACTEMENT la part hamac du devis.
+  def persist_hamac_ranges!(stay:, draft:, status:, total_price_cents:)
+    flat = hamac_ranges_for(draft).flat_map { |kind, ranges| ranges.map { |r| r.merge(kind: kind) } }
+    return [] if flat.empty?
+
+    # Poids pondérés par le TARIF du type : un hamac double coûte le double d'un
+    # simple, la ventilation doit le refléter (sinon un séjour mixte répartirait
+    # à tort le total à parts égales entre simples et doubles).
+    weights = flat.map { |r| r[:value] * r[:nights] * hamac_rate_for(r[:kind]) }
+    prices  = distribute_cents(total_price_cents, weights)
+
+    flat.each_with_index.map do |r, idx|
+      hamac = HamacBooking.new(
+        firstname:   draft.first_name, lastname: draft.last_name,
+        email:       Customer.normalize_email(draft.email), phone: draft.phone,
+        group_name:  draft.group_name,
+        from_date:   r[:from_date], to_date: r[:to_date],
+        kind:        r[:kind], count: [r[:value], 1].max,
+        status:      status, price_cents: prices[idx]
+      )
+      hamac.save!
+      stay.stay_items.create!(bookable: hamac)
+      hamac
+    end
+  end
+
+  # Tarif unitaire d'un type de hamac, borné à 1 pour ne jamais annuler le poids
+  # d'une plage (un tarif nul rendrait la ventilation dégénérée).
+  def hamac_rate_for(kind)
+    [Pricing::Catalog.hamac_rate(kind).to_i, 1].max
+  end
+
+  # HamacBooking déjà rattachés au séjour (édition).
+  def existing_hamac_bookings(stay)
+    stay.stay_items.where(bookable_type: "HamacBooking").filter_map(&:bookable)
+  end
+
+  # Détache + soft-delete tous les HamacBooking du séjour. L'édition reconstruit
+  # intégralement les plages (comme le camping) plutôt que de réconcilier N↔N.
+  def detach_hamac_bookings!(stay)
+    stay.stay_items.where(bookable_type: "HamacBooking").each do |item|
+      item.bookable&.soft_delete!(validate: false)
+      item.soft_delete!(validate: false)
+    end
+  end
+end

--- a/app/services/payments/pay_service.rb
+++ b/app/services/payments/pay_service.rb
@@ -121,6 +121,7 @@ module Payments
         when SpaceBooking   then "Salles & espaces"
         when CampingBooking then "Camping"
         when VanBooking     then "Emplacement van"
+        when HamacBooking   then "Location de hamacs"
         end
       end.uniq
       activities = stay.experience_bookings.active.count

--- a/app/services/pricing_model.rb
+++ b/app/services/pricing_model.rb
@@ -57,6 +57,9 @@ class PricingModel
     # Terrasse (ADMIN uniquement, décision Michael 2026-07-20) : part datée à la
     # journée, portée par des `CampingBooking` de `kind: "terrasse"`.
     def terrace_cents = category_cents(:terrace)
+    # Hamacs (issue #138) : part extraite du devis pour être portée par les
+    # `HamacBooking` persistés — dans TOUS les canaux, comme camping/van.
+    def hamac_cents   = category_cents(:hamac)
 
     # Base hébergement/camping/repas = total hors activités ET hors espaces.
     # INCHANGÉ pour préserver EXACTEMENT le canal public (funnel) : côté public,
@@ -70,7 +73,7 @@ class PricingModel
     # camping/van/repas vivent sur leurs propres modèles. Invariant admin :
     #   lodging_only + spaces + camping + van + meals == total_excluding_experiences.
     def lodging_only_cents
-      lodging_bundle_cents - camping_cents - van_cents - meals_cents - terrace_cents
+      lodging_bundle_cents - camping_cents - van_cents - meals_cents - terrace_cents - hamac_cents
     end
 
     def category_cents(category)
@@ -356,7 +359,7 @@ class PricingModel
       next if rate.nil?
       label = entry[:kind].to_s == "double" ? "Hamac double" : "Hamac simple"
       Line.new(label: "#{label} × #{count} — #{nights} nuit(s)",
-               amount_cents: rate * count * nights)
+               amount_cents: rate * count * nights, category: :hamac)
     end
   end
 

--- a/app/services/reservations/builder.rb
+++ b/app/services/reservations/builder.rb
@@ -16,6 +16,8 @@ module Reservations
   class Builder < ServiceBase
     include SpaceComposition
     include CampingComposition
+    # Hamacs (issue #138) : persistés dans TOUS les canaux, comme camping/van.
+    include HamacComposition
     include MealComposition
     include TerraceComposition
     # Reservations de chambres de l'hébergement (epic #66, Phase 6) : on réutilise
@@ -29,8 +31,8 @@ module Reservations
     class DraftInvalid < StandardError; end
 
     attr_reader :draft, :stay, :customer, :booking, :space_booking,
-                :camping_booking, :van_booking, :payment, :availability_warning,
-                :space_warning
+                :camping_booking, :van_booking, :hamac_bookings, :payment,
+                :availability_warning, :space_warning
 
     # Mode admin (epic #66, Phase 1) : le CRUD Séjour admin réutilise ce moteur
     # SANS jamais passer par Stripe. Les options `admin`/`status`/`source`/
@@ -146,6 +148,11 @@ module Reservations
         # car ils dérivent du devis (`quote`), inchangé par cette ventilation.
         @camping_booking = build_camping_booking_for!(@stay, quote)
         @van_booking     = build_van_booking_for!(@stay, quote)
+        # Hamacs (issue #138) : jusqu'ici devis-only, donc invisibles du séjour et
+        # sur-louables. Persistés désormais dans TOUS les canaux, une réservation
+        # par plage contiguë ; leur part (`quote.hamac_cents`) est extraite de
+        # `lodging_only_cents` — aucun double-compte, total du séjour inchangé.
+        @hamac_bookings  = build_hamac_bookings_for!(@stay, quote)
         create_meal_orders!(@stay, draft)
         # Terrasse (décision Michael 2026-07-20) : ADMIN UNIQUEMENT. Une occupation
         # `CampingBooking` de `kind: "terrasse"` par JOUR. Ignorée hors admin, même
@@ -242,6 +249,23 @@ module Reservations
       end
       check_space_availability!
       check_outdoor_capacity!
+      check_hamac_stock!
+    end
+
+    # Stock hamacs (issue #138) : vérifié dans TOUS les canaux — contrairement au
+    # camping/van (admin only), le funnel public PERSISTE les hamacs, donc il peut
+    # sur-louer. Stock non renseigné sur le `RentalItem` → aucune limite.
+    def check_hamac_stock!
+      message = hamac_stock_message(draft)
+      return if message.nil?
+
+      if @skip_availability
+        @availability_warning =
+          [@availability_warning,
+           "#{message} — séjour enregistré en forçant la disponibilité."].compact.join(" ")
+      else
+        raise_invalid(message)
+      end
     end
 
     # Dispo de l'hébergement : sur les chambres cochées en mode "rooms" (epic #81,
@@ -383,6 +407,18 @@ module Reservations
           price_cents: quote.van_cents
         )
       end
+    end
+
+    # Hamacs (issue #138) : no-op si le draft n'en porte aucun. Une `HamacBooking`
+    # par plage contiguë et par type ; leur part de prix vient du devis
+    # (`hamac_cents`), ventilée exactement sur les plages.
+    def build_hamac_bookings_for!(stay, quote)
+      return [] unless draft_has_hamacs?(draft)
+
+      persist_hamac_ranges!(
+        stay: stay, draft: draft, status: stay_status,
+        total_price_cents: quote.hamac_cents
+      )
     end
 
     def upsert_customer!

--- a/app/services/stays/admin_updater.rb
+++ b/app/services/stays/admin_updater.rb
@@ -23,6 +23,8 @@ module Stays
   class AdminUpdater < ServiceBase
     include SpaceComposition
     include CampingComposition
+    # Hamacs (issue #138) : persistés et réconciliés comme le camping/van.
+    include HamacComposition
     include MealComposition
     include TerraceComposition
 
@@ -81,6 +83,7 @@ module Stays
         reconcile_spaces!
         reconcile_camping!
         reconcile_van!
+        reconcile_hamacs!
         reconcile_meals!(@stay, @draft)
         # Terrasse (ADMIN uniquement, décision Michael 2026-07-20) : rebuild complet
         # des occupations `CampingBooking` de kind "terrasse", indépendamment du
@@ -109,7 +112,7 @@ module Stays
       unless @draft.lodging.present? || draft_has_spaces?(@draft) ||
              draft_has_camping?(@draft) || draft_has_van?(@draft) ||
              @draft.bookable_experiences? || draft_has_meals?(@draft) ||
-             draft_has_terrace?(@draft)
+             draft_has_terrace?(@draft) || draft_has_hamacs?(@draft)
         raise_invalid("Veuillez sélectionner un hébergement, un espace, un emplacement camping/van, une activité ou un repas.")
       end
       unless Customer.exploitable_email?(@draft.email)
@@ -128,12 +131,29 @@ module Stays
       check_availability!
       check_space_availability!
       check_outdoor_capacity!
+      check_hamac_stock!
+    end
+
+    # Stock hamacs (issue #138), en EXCLUANT les propres réservations du séjour
+    # édité — sinon un séjour déjà confirmé avec hamacs se bloquerait lui-même.
+    def check_hamac_stock!
+      message = hamac_stock_message(@draft, excluding_id: existing_hamac_bookings(@stay).map(&:id).presence)
+      return if message.nil?
+
+      if @skip_availability
+        @availability_warning =
+          [@availability_warning,
+           "#{message} — séjour enregistré en forçant la disponibilité."].compact.join(" ")
+      else
+        raise_invalid(message)
+      end
     end
 
     # Réservables facturés À LA NUIT : ils exigent au moins une nuit. Espaces
     # (forfait date+période), activités et repas n'en exigent pas (issue #80).
     def requires_nights?
-      @draft.lodging.present? || draft_has_camping?(@draft) || draft_has_van?(@draft)
+      @draft.lodging.present? || draft_has_camping?(@draft) || draft_has_van?(@draft) ||
+        draft_has_hamacs?(@draft)
     end
 
     # Camping / van : capacité globale (epic #66, Phase 3), en ignorant les
@@ -445,6 +465,19 @@ module Stays
       else
         persist_van_booking!(stay: @stay, draft: @draft, status: @stay.status, price_cents: price)
       end
+    end
+
+    # Réconcilie les HAMACS du séjour (issue #138) : reconstruction INTÉGRALE des
+    # plages depuis le draft (détacher puis recréer), comme le camping en mode
+    # grille. Plus de hamac au draft → tout est détaché.
+    def reconcile_hamacs!
+      detach_hamac_bookings!(@stay)
+      return unless draft_has_hamacs?(@draft)
+
+      persist_hamac_ranges!(
+        stay: @stay, draft: @draft, status: @stay.status,
+        total_price_cents: @draft.quote.hamac_cents
+      )
     end
 
     def reconcile_experiences!

--- a/app/services/stays/draft_reconstructor.rb
+++ b/app/services/stays/draft_reconstructor.rb
@@ -58,6 +58,10 @@ module Stays
         halls:          halls_from_stay,
         campings:       campings_from_stay,
         vans:           vans_from_stay,
+        # Hamacs (issue #138) : repli pleine-fenêtre quand la grille n'est pas
+        # dérivable (séjour sans dates). La grille, elle, est reconstruite dans
+        # `per_night_resources_from_stay` — c'est elle qui fait foi si présente.
+        hamacs:         hamacs_from_stay,
         meals:          meals_from_stay,
         terrasses:      terrasses_from_stay,
         # Précision libre du besoin d'espace (funnel public) : reconstruite depuis
@@ -85,11 +89,20 @@ module Stays
       campings = @stay.stay_items.select { |i| i.bookable_type == "CampingBooking" }
                       .filter_map(&:bookable).reject { |b| b.kind == "terrasse" }
       vans     = @stay.stay_items.select { |i| i.bookable_type == "VanBooking" }.filter_map(&:bookable)
-      return nil if campings.empty? && vans.empty?
+      hamacs   = @stay.stay_items.select { |i| i.bookable_type == "HamacBooking" }.filter_map(&:bookable)
+      return nil if campings.empty? && vans.empty? && hamacs.empty?
 
       pnr = {}
       pnr["tente"] = spread_nights(campings, arrival, nights, &:people)   if campings.any?
       pnr["van"]   = spread_nights(vans,     arrival, nights, &:vehicles) if vans.any?
+      # Hamacs (issue #138) : une ligne de grille par TYPE, `hamac_simple` /
+      # `hamac_double` — mêmes clés que celles postées par le funnel et le form
+      # admin, donc le round-trip édition ré-affiche fidèlement la sélection.
+      HamacBooking::KINDS.each do |kind|
+        of_kind = hamacs.select { |h| h.kind.to_s == kind }
+        next if of_kind.empty?
+        pnr["hamac_#{kind}"] = spread_nights(of_kind, arrival, nights, &:count)
+      end
       pnr
     end
 
@@ -168,6 +181,19 @@ module Stays
       return [] if van.nil?
       nights = van.from_date && van.to_date ? (van.to_date - van.from_date).to_i : 1
       Array.new([van.vehicles, 1].max) { { nights: [nights, 1].max } }
+    end
+
+    # Reconstruit les entrées hamac {kind, count, nights} depuis les HamacBooking
+    # persistés (une par plage). Sert de repli quand la grille n'est pas
+    # dérivable ; sinon le Draft dérive `hamacs` de `per_night_resources`.
+    def hamacs_from_stay
+      @stay.stay_items.select { |i| i.bookable_type == "HamacBooking" }
+           .filter_map(&:bookable)
+           .sort_by { |h| [h.kind.to_s, h.from_date.to_s] }
+           .map do |h|
+             nights = h.from_date && h.to_date ? (h.to_date - h.from_date).to_i : 1
+             { kind: h.kind, count: h.count, nights: [nights, 1].max }
+           end
     end
 
     # Reconstruit les terrasses {date, people} depuis les CampingBooking terrasse

--- a/app/services/stays/merge_service.rb
+++ b/app/services/stays/merge_service.rb
@@ -233,6 +233,7 @@ module Stays
       when SpaceBooking then bookable.spaces.map(&:name).compact_blank.join(", ").presence || "Espace"
       when CampingBooking then "Camping"
       when VanBooking     then "Van"
+      when HamacBooking   then bookable.label
       else bookable.class.model_name.human
       end
     end

--- a/app/views/pages/calendar/_day_bookings.html.slim
+++ b/app/views/pages/calendar/_day_bookings.html.slim
@@ -5,7 +5,7 @@
 / L'agrégation (pure affichage, aucune logique de dispo/veto) vit dans
 / Calendar::DayStayBlocks. Les occupations SANS séjour gardent leur rendu
 / bloc-par-bloc historique et leurs popovers (fallbacks plus bas).
-- blocks = Calendar::DayStayBlocks.new(date, grouped_reservations: @grouped_reservations, grouped_space_reservations: @grouped_space_reservations, grouped_camping_bookings: @grouped_camping_bookings, grouped_van_bookings: @grouped_van_bookings)
+- blocks = Calendar::DayStayBlocks.new(date, grouped_reservations: @grouped_reservations, grouped_space_reservations: @grouped_space_reservations, grouped_camping_bookings: @grouped_camping_bookings, grouped_van_bookings: @grouped_van_bookings, grouped_hamac_bookings: @grouped_hamac_bookings)
 
 / 1) Blocs SÉJOUR unifiés (un par séjour), couleur stable + câblage modale/fusion.
 - blocks.stay_blocks.each do |stay_block|

--- a/app/views/pages/calendar/_day_stay_block.html.slim
+++ b/app/views/pages/calendar/_day_stay_block.html.slim
@@ -46,6 +46,9 @@ div(class="relative flex mt-2 py-1 px-2 hover:cursor-pointer hover:shadow-xl min
       / Van / camping-car : même logique que le camping.
       - block.van_bookings.each do |van|
         span(class="text-xs text-gray-600 whitespace-nowrap") 🚐 #{van.vehicles} véhicule#{"s" if van.vehicles.to_i > 1}
+      / Hamacs (issue #138) : location par nuit → chip 🛌, et compte dans 💤.
+      - block.hamac_bookings.each do |hamac|
+        span(class="text-xs text-gray-600 whitespace-nowrap") 🛌 #{hamac.label} × #{hamac.count}
       / Terrasse : occupation de JOUR (pas une nuitée) → chip distincte 🪑, pas ⛺️.
       - block.terrace_bookings.each do |terrace|
         span(class="text-xs text-gray-600 whitespace-nowrap") 🪑 Terrasse · #{terrace.people} pers.

--- a/app/views/stays/_compose_grids.html.slim
+++ b/app/views/stays/_compose_grids.html.slim
@@ -68,8 +68,8 @@
         label.block.text-sm.font-medium.text-gray-700 Véhicules
         = number_field_tag "stay[van][vehicles]", (van_vehicles.positive? ? van_vehicles : nil), min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm sm:text-sm"
 
-  / --- Location de hamacs (parité funnel, DEVIS SEUL — aucune persistance ;
-  / la vraie persistance = issue #138). Grille par nuit simple/double, mêmes
+  / --- Location de hamacs (parité funnel). PERSISTÉS depuis l issue #138 :
+  / une HamacBooking par plage contiguë. Grille par nuit simple/double, mêmes
   / `per_night_resources` que le funnel. Toujours visible côté admin (pas de
   / saisonnalité mai-octobre : l'équipe compose hors saison si besoin). Le
   / PricingModel dérive les hamacs de `per_night_resources` → devis live. ------
@@ -81,7 +81,7 @@
     - if @stay_nights.blank?
       p.text-sm.text-gray-500 Choisissez d'abord les dates du séjour pour composer les hamacs nuit par nuit.
     - else
-      p.text-sm.text-gray-500 Hamac fourni et posé sur place — location nuit par nuit. Facturé au devis, non persisté (issue #138).
+      p.text-sm.text-gray-500 Hamac fourni et posé sur place — location nuit par nuit. Le stock disponible est vérifié nuit par nuit.
       .overflow-x-auto
         table.border-collapse style="min-width: #{140 + @stay_nights.size * 88}px"
           thead

--- a/app/views/stays/_details.html.slim
+++ b/app/views/stays/_details.html.slim
@@ -157,6 +157,19 @@ div id="stay-details-#{@stay.id}"
                     .text-gray-500 = nights_label
                 span.text-gray-500.shrink-0 = @stay.formatted_item_amount(van)
 
+      / Hamacs (issue #138) : location par nuit, persistée comme le camping/van.
+      - if @stay.hamac_bookings.any?
+        div
+          h4.text-sm.font-medium.text-gray-700.mb-2 Location de hamacs
+          ul.divide-y.divide-gray-100
+            - @stay.hamac_bookings.each do |hamac|
+              li.py-2.text-sm.flex.items-start.justify-between.gap-3
+                .min-w-0
+                  .text-gray-900.font-medium = "🛌 #{hamac.label} × #{hamac.count}"
+                  - if (nights_label = outdoor_nights_label(hamac))
+                    .text-gray-500 = nights_label
+                span.text-gray-500.shrink-0 = @stay.formatted_item_amount(hamac)
+
       - if @stay.meals.any?
         div
           h4.text-sm.font-medium.text-gray-700.mb-2 Repas

--- a/config/locales/public.en.yml
+++ b/config/locales/public.en.yml
@@ -21,6 +21,7 @@ en:
         camping: "Camping"
         van: "Van / campervan"
         terrace: "Terrace"
+        hamac: "Hammock"
         meal: "Meal"
         other: "Service"
       payment_status:

--- a/config/locales/public.fr.yml
+++ b/config/locales/public.fr.yml
@@ -17,6 +17,7 @@ fr:
         camping: "Camping"
         van: "Van / camping-car"
         terrace: "Terrasse"
+        hamac: "Hamac"
         meal: "Repas"
         other: "Prestation"
       payment_status:

--- a/config/locales/public.nl.yml
+++ b/config/locales/public.nl.yml
@@ -21,6 +21,7 @@ nl:
         camping: "Camping"
         van: "Camper"
         terrace: "Terras"
+        hamac: "Hangmat"
         meal: "Maaltijd"
         other: "Dienst"
       payment_status:

--- a/db/migrate/20260723011804_create_hamac_bookings.rb
+++ b/db/migrate/20260723011804_create_hamac_bookings.rb
@@ -1,0 +1,26 @@
+class CreateHamacBookings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :hamac_bookings do |t|
+      t.string  :firstname
+      t.string  :lastname
+      t.string  :email
+      t.string  :phone
+      t.string  :group_name
+      t.date    :from_date
+      t.date    :to_date
+      t.string  :kind,        null: false, default: "simple"
+      t.integer :count,       null: false, default: 1
+      t.string  :status
+      t.integer :price_cents
+      t.string  :token
+      t.text    :notes
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :hamac_bookings, :token, unique: true
+    add_index :hamac_bookings, [:from_date, :to_date]
+    add_index :hamac_bookings, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_07_22_090000) do
+ActiveRecord::Schema[7.0].define(version: 2026_07_23_011804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -389,6 +389,28 @@ ActiveRecord::Schema[7.0].define(version: 2026_07_22_090000) do
     t.datetime "deleted_at"
     t.index ["gathering_category_id"], name: "index_gatherings_on_gathering_category_id"
     t.index ["starts_at", "ends_at"], name: "index_gatherings_on_starts_at_and_ends_at"
+  end
+
+  create_table "hamac_bookings", force: :cascade do |t|
+    t.string "firstname"
+    t.string "lastname"
+    t.string "email"
+    t.string "phone"
+    t.string "group_name"
+    t.date "from_date"
+    t.date "to_date"
+    t.string "kind", default: "simple", null: false
+    t.integer "count", default: 1, null: false
+    t.string "status"
+    t.integer "price_cents"
+    t.string "token"
+    t.text "notes"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_hamac_bookings_on_deleted_at"
+    t.index ["from_date", "to_date"], name: "index_hamac_bookings_on_from_date_and_to_date"
+    t.index ["token"], name: "index_hamac_bookings_on_token", unique: true
   end
 
   create_table "human_roles", force: :cascade do |t|

--- a/spec/models/hamac_booking_spec.rb
+++ b/spec/models/hamac_booking_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+# HamacBooking (issue #138) — location de hamacs persistée sur le séjour.
+# La capacité n'est PAS une constante du domaine mais le STOCK du `RentalItem`
+# correspondant ; stock non renseigné = aucune limite.
+RSpec.describe HamacBooking do
+  let(:arrival) { Date.today + 30 }
+
+  def hamac(kind: "simple", count: 1, from: arrival, to: arrival + 2, status: "confirmed")
+    described_class.create!(kind: kind, count: count, from_date: from, to_date: to, status: status)
+  end
+
+  describe "validations" do
+    it "refuse un kind inconnu" do
+      record = described_class.new(kind: "triple", count: 1)
+      expect(record).not_to be_valid
+      expect(record.errors[:kind]).to be_present
+    end
+
+    it "refuse un count nul ou négatif" do
+      expect(described_class.new(kind: "simple", count: 0)).not_to be_valid
+      expect(described_class.new(kind: "simple", count: -1)).not_to be_valid
+    end
+
+    it "génère un token à la création" do
+      expect(hamac.token).to be_present
+    end
+  end
+
+  describe ".total_stock" do
+    it "lit le stock du RentalItem correspondant" do
+      RentalItem.create!(name: "Hamac simple", stock: 4, price_cents: 750)
+      expect(described_class.total_stock("simple")).to eq(4)
+    end
+
+    it "vaut nil quand l'article n'existe pas (capacité non bornée)" do
+      expect(described_class.total_stock("double")).to be_nil
+    end
+  end
+
+  describe ".units_reserved_on" do
+    before { RentalItem.create!(name: "Hamac simple", stock: 4, price_cents: 750) }
+
+    it "ne compte que les réservations CONFIRMÉES couvrant la nuit" do
+      hamac(count: 2, status: "confirmed")
+      hamac(count: 3, status: "pending")
+
+      expect(described_class.units_reserved_on("simple", arrival)).to eq(2)
+      # Nuit hors fenêtre [from, to) : rien.
+      expect(described_class.units_reserved_on("simple", arrival + 2)).to eq(0)
+    end
+
+    it "n'agrège jamais les autres types de hamac" do
+      hamac(kind: "double", count: 2)
+      expect(described_class.units_reserved_on("simple", arrival)).to eq(0)
+    end
+
+    it "sait exclure des réservations données (édition)" do
+      own = hamac(count: 2)
+      expect(described_class.units_reserved_on("simple", arrival, excluding_id: [own.id])).to eq(0)
+    end
+  end
+
+  describe ".capacity_conflict_date" do
+    it "renvoie la première nuit en rupture de stock" do
+      RentalItem.create!(name: "Hamac simple", stock: 3, price_cents: 750)
+      hamac(count: 2, from: arrival + 1, to: arrival + 2)
+
+      conflict = described_class.capacity_conflict_date(
+        kind: "simple", units: 2, from: arrival, to: arrival + 3
+      )
+      expect(conflict).to eq(arrival + 1)
+    end
+
+    it "ne bloque jamais quand le stock n'est pas renseigné" do
+      RentalItem.create!(name: "Hamac simple", stock: nil, price_cents: 750)
+      hamac(count: 50)
+
+      expect(described_class.capacity_conflict_date(
+        kind: "simple", units: 50, from: arrival, to: arrival + 2
+      )).to be_nil
+    end
+
+    it "ne signale rien quand le stock suffit" do
+      RentalItem.create!(name: "Hamac simple", stock: 4, price_cents: 750)
+      hamac(count: 2)
+
+      expect(described_class.capacity_conflict_date(
+        kind: "simple", units: 2, from: arrival, to: arrival + 2
+      )).to be_nil
+    end
+  end
+end

--- a/spec/requests/hamacs_display_spec.rb
+++ b/spec/requests/hamacs_display_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+# Issue #138 — un séjour avec hamacs les MONTRE : ligne dédiée dans la modale
+# séjour, chip 🛌 sur le bloc du calendrier, et compte dans la nuitée (💤).
+RSpec.describe "Hamacs — affichage modale + calendrier (issue #138)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(email: "agent-hamacs@les4sources.be", password: "password123") }
+  before { sign_in user }
+
+  let(:arrival)   { Date.today.next_occurring(:friday) }
+  let(:departure) { arrival + 2 }
+
+  # Séjour hamacs SEULS : rien d'autre ne peut expliquer la chip ni la nuitée.
+  let!(:stay) do
+    draft = Reservations::Draft.new(
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille-hamac@example.com", phone: "+32470112233",
+      per_night_resources: { "hamac_double" => %w[1 1] }
+    )
+    builder = Reservations::Builder.new(draft: draft, admin: true, status: "confirmed")
+    builder.run!
+    builder.stay
+  end
+
+  it "affiche la ligne hamacs dans la modale séjour" do
+    get stay_path(stay)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Location de hamacs")
+    expect(response.body).to include("Hamac double × 1")
+  end
+
+  it "affiche la chip 🛌 et la nuitée 💤 sur le bloc du calendrier" do
+    get "/", params: { date: arrival.iso8601 }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("🛌 Hamac double × 1")
+    expect(response.body).to include("Nuitée sur place")
+  end
+
+  it "compte les hamacs dans le résumé de composition du séjour" do
+    expect(stay.decorate.composition_summary).to include("1 hamac")
+  end
+end

--- a/spec/services/reservations/hamac_persistence_spec.rb
+++ b/spec/services/reservations/hamac_persistence_spec.rb
@@ -1,0 +1,181 @@
+require "rails_helper"
+
+# Issue #138 — les hamacs sont désormais PERSISTÉS (avant : devis-only, donc
+# invisibles du séjour et sur-louables). Même pattern que camping/van : une
+# `HamacBooking` par PLAGE CONTIGUË de valeur constante, ventilation EXACTE de la
+# part hamac du devis, et invariant de total du séjour préservé.
+RSpec.describe "Persistance des hamacs sur le séjour (issue #138)" do
+  let!(:hulotte) do
+    lodging = Lodging.create!(name: "La Hulotte", price_night_cents: 48_500)
+    lodging.rooms << Room.create!(name: "Chambre 1", level: 1)
+    lodging
+  end
+
+  let(:arrival)   { Date.today + 30 }
+  let(:departure) { Date.today + 34 } # 4 nuits
+
+  def draft(**overrides)
+    Reservations::Draft.new({
+      arrival_date: arrival.iso8601, departure_date: departure.iso8601,
+      dogs_count: 0, first_name: "Camille", last_name: "Martin",
+      email: "camille@example.com", phone: "+32470112233"
+    }.merge(overrides))
+  end
+
+  describe "Reservations::Builder — grille hamac simple [2,2,0,3]" do
+    let(:grid_draft) { draft(per_night_resources: { "hamac_simple" => %w[2 2 0 3] }) }
+
+    it "crée 2 plages aux bonnes dates/quantités, ∑ prix == quote.hamac_cents" do
+      builder = Reservations::Builder.new(draft: grid_draft)
+      expect(builder.run).to be(true)
+
+      hamacs = builder.stay.stay_items.where(bookable_type: "HamacBooking")
+                      .filter_map(&:bookable).sort_by(&:from_date)
+      expect(hamacs.size).to eq(2)
+
+      expect(hamacs[0].from_date).to eq(arrival)
+      expect(hamacs[0].to_date).to eq(arrival + 2)
+      expect(hamacs[0].kind).to eq("simple")
+      expect(hamacs[0].count).to eq(2)
+      expect(hamacs[0].price_cents).to eq(750 * 2 * 2)
+
+      expect(hamacs[1].from_date).to eq(arrival + 3)
+      expect(hamacs[1].to_date).to eq(arrival + 4)
+      expect(hamacs[1].count).to eq(3)
+      expect(hamacs[1].price_cents).to eq(750 * 3 * 1)
+
+      expect(hamacs.sum(&:price_cents)).to eq(grid_draft.quote.hamac_cents)
+    end
+  end
+
+  describe "grille MIXTE simple + double" do
+    let(:mixed_draft) do
+      draft(per_night_resources: { "hamac_simple" => %w[1 1 0 0], "hamac_double" => %w[0 0 2 2] })
+    end
+
+    it "ventile au prorata du TARIF de chaque type (∑ == quote.hamac_cents)" do
+      builder = Reservations::Builder.new(draft: mixed_draft)
+      expect(builder.run).to be(true)
+
+      hamacs = builder.stay.stay_items.where(bookable_type: "HamacBooking")
+                      .filter_map(&:bookable).index_by(&:kind)
+      expect(hamacs.keys).to match_array(%w[simple double])
+      expect(hamacs["simple"].price_cents).to eq(750 * 1 * 2)
+      expect(hamacs["double"].price_cents).to eq(1_500 * 2 * 2)
+      expect(hamacs.values.sum(&:price_cents)).to eq(mixed_draft.quote.hamac_cents)
+    end
+  end
+
+  describe "invariant de total (re-ventilation, pas de double-compte)" do
+    let(:full_draft) do
+      draft(lodging_id: hulotte.id, per_night_resources: { "hamac_simple" => %w[1 1 1 1] })
+    end
+
+    it "laisse le total du séjour ET l'acompte strictement égaux au devis" do
+      quote   = full_draft.quote
+      builder = Reservations::Builder.new(draft: full_draft) # funnel public
+      expect(builder.run).to be(true)
+      stay = builder.stay
+
+      expect(stay.total_amount_cents).to eq(quote.total_excluding_experiences_cents)
+      expect(builder.payment.amount_cents).to eq(quote.deposit_cents)
+
+      # Le Booking d'hébergement ne porte plus la part hamac.
+      booking = stay.stay_items.where(bookable_type: "Booking").first.bookable
+      expect(booking.price_cents).to eq(quote.lodging_only_cents)
+
+      # Ventilation exhaustive : la somme des parts redonne exactement le total.
+      expect(stay.bookables.sum { |b| b.try(:price_cents).to_i }).to eq(stay.total_amount_cents)
+    end
+  end
+
+  describe "repli pleine-fenêtre (grille absente)" do
+    it "persiste une plage couvrant tout le séjour" do
+      d = draft(hamacs: [{ kind: "double", count: 1 }])
+      builder = Reservations::Builder.new(draft: d)
+      expect(builder.run).to be(true)
+
+      hamac = builder.stay.stay_items.where(bookable_type: "HamacBooking").first.bookable
+      expect(hamac.kind).to eq("double")
+      expect(hamac.count).to eq(1)
+      expect(hamac.from_date).to eq(arrival)
+      expect(hamac.to_date).to eq(departure)
+      expect(hamac.price_cents).to eq(d.quote.hamac_cents)
+    end
+  end
+
+  describe "stock (RentalItem)" do
+    before { RentalItem.create!(name: "Hamac simple", stock: 2, price_cents: 750) }
+
+    it "refuse une demande qui dépasse le stock disponible d'une nuit" do
+      HamacBooking.create!(kind: "simple", count: 2, status: "confirmed",
+                           from_date: arrival + 1, to_date: arrival + 2)
+
+      builder = Reservations::Builder.new(draft: draft(per_night_resources: { "hamac_simple" => %w[1 1 1 1] }))
+      expect(builder.run).to be(false)
+      expect(builder.error_message).to include("stock insuffisant")
+    end
+
+    it "accepte quand le stock suffit" do
+      builder = Reservations::Builder.new(draft: draft(per_night_resources: { "hamac_simple" => %w[2 2 2 2] }))
+      expect(builder.run).to be(true)
+    end
+  end
+
+  describe "round-trip Stays::DraftReconstructor" do
+    it "reconstruit fidèlement la grille hamacs du séjour" do
+      grid = { "hamac_simple" => %w[2 2 0 3], "hamac_double" => %w[0 1 1 0] }
+      builder = Reservations::Builder.new(draft: draft(per_night_resources: grid))
+      expect(builder.run).to be(true)
+
+      rebuilt = Stays::DraftReconstructor.call(builder.stay.reload)
+      # Le Draft normalise la grille en chaînes (même contrat que tente/van).
+      expect(rebuilt.per_night_resources["hamac_simple"]).to eq(%w[2 2 0 3])
+      expect(rebuilt.per_night_resources["hamac_double"]).to eq(%w[0 1 1 0])
+    end
+  end
+
+  describe "Stays::AdminUpdater" do
+    let(:user) { User.create!(email: "admin-hamacs@les4sources.be", password: "password123") }
+
+    it "reconstruit les plages à l'édition (grille modifiée)" do
+      builder = Reservations::Builder.new(draft: draft(per_night_resources: { "hamac_simple" => %w[1 1 1 1] }),
+                                          admin: true, status: "confirmed")
+      expect(builder.run).to be(true)
+      stay = builder.stay
+
+      edited = draft(per_night_resources: { "hamac_simple" => %w[0 2 2 0] })
+      updater = Stays::AdminUpdater.new(stay: stay, draft: edited, user: user)
+      expect(updater.run).to be(true)
+
+      hamacs = stay.reload.stay_items.where(bookable_type: "HamacBooking").filter_map(&:bookable)
+      expect(hamacs.size).to eq(1)
+      expect(hamacs.first.count).to eq(2)
+      expect(hamacs.first.from_date).to eq(arrival + 1)
+      expect(hamacs.first.to_date).to eq(arrival + 3)
+      expect(hamacs.first.price_cents).to eq(edited.quote.hamac_cents)
+    end
+
+    it "détache les hamacs quand ils disparaissent du draft" do
+      builder = Reservations::Builder.new(draft: draft(per_night_resources: { "hamac_simple" => %w[1 1 1 1] }),
+                                          admin: true, status: "confirmed")
+      builder.run
+      stay = builder.stay
+
+      updater = Stays::AdminUpdater.new(stay: stay, draft: draft(lodging_id: hulotte.id), user: user)
+      expect(updater.run).to be(true)
+      expect(stay.reload.stay_items.where(bookable_type: "HamacBooking")).to be_empty
+    end
+
+    it "ne se bloque pas lui-même sur son propre stock à la réédition" do
+      RentalItem.create!(name: "Hamac simple", stock: 2, price_cents: 750)
+      grid = { "hamac_simple" => %w[2 2 2 2] }
+      builder = Reservations::Builder.new(draft: draft(per_night_resources: grid),
+                                          admin: true, status: "confirmed")
+      expect(builder.run).to be(true)
+
+      updater = Stays::AdminUpdater.new(stay: builder.stay, draft: draft(per_night_resources: grid), user: user)
+      expect(updater.run).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
Closes #138

Les hamacs n'existaient que dans le devis (`Draft#hamacs` → lignes `PricingModel`) : un séjour avec hamacs payés ne les montrait ni en modale ni au calendrier, l'édition perdait la sélection, et rien n'empêchait de sur-louer. Ils sont désormais **persistés pour de vrai**, en s'alignant strictement sur le pattern camping/van par nuit.

## Ce qui change

- **`HamacBooking`** (nouvelle table) : `kind` (`simple`|`double`), `count`, fenêtre `[from_date, to_date)`, `price_cents`, `status`, `token`, soft-deletion + PaperTrail, rattaché au séjour par `StayItem` polymorphe (ajouté à la liste blanche `StayItem#bookable_type`).
- **`HamacComposition`** (concern partagé Builder/AdminUpdater, réutilise les primitives de `CampingComposition`) : la grille `per_night_resources[hamac_simple|hamac_double]` est découpée en **plages contiguës** de valeur constante → une `HamacBooking` par plage et par type. Repli pleine-fenêtre quand la grille est absente (form legacy / emails).
- **Ventilation exacte** : `distribute_cents` (largest-remainder) sur des poids `count × nuits × tarif du type` — la somme des `price_cents` égale **exactement** `quote.hamac_cents`. La pondération par le tarif est nécessaire pour un séjour mixte simple + double (sinon répartition à parts égales, donc fausse).
- **`PricingModel`** : les lignes hamac sont taguées `category: :hamac`, `Quote#hamac_cents` apparaît, et `lodging_only_cents` la retranche. C'est une pure **re-ventilation** : total du séjour et acompte strictement inchangés (asserté en spec).
- **Tous les canaux** : le funnel public comme l'admin persistent (`Reservations::Builder`), l'édition admin réconcilie par reconstruction intégrale des plages (`Stays::AdminUpdater#reconcile_hamacs!`).
- **Round-trip** : `Stays::DraftReconstructor` rebâtit `per_night_resources["hamac_simple"|"hamac_double"]` (édition admin **et** demande de modification client) + les entrées pleine-fenêtre en repli.
- **Stock** : `RentalItem#stock` (colonne déjà présente, seedée 4 simples / 2 doubles) vérifié **nuit par nuit**, toutes réservations confirmées vivantes confondues, en excluant les propres réservations du séjour édité. Un stock non renseigné (`nil`) = **aucune limite** — on ne bloque jamais une réservation sur une donnée de catalogue absente, plutôt que d'inventer un plafond.
- **Affichage** : ligne « Location de hamacs » dans la modale séjour, chip `🛌` sur le bloc calendrier, comptage dans `overnight?` (`💤`), icône 🛌 dans `stay_composition_icons`, libellés `Payments::PayService` / `Stays::MergeService`, clé i18n `items.hamac` (fr/en/nl).
- Migration de rattrapage : **néant**, conformément à l'issue (aucune donnée historique — c'est le bug).

## 📸 Aperçu

![Modale séjour — location de hamacs](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260723-032658-modale-sjour--location-de-hamacs.png)

![Calendrier — chip 🛌 et nuitée 💤](https://github.com/les4sources/claudy/raw/agent-screenshots/screenshots/20260723-032703-calendrier--chip--et-nuite-.png)

Séjour hamacs-seuls, 2 nuits, grille `simple: [2,2]` + `double: [0,1]` → 30 € + 15 € = 45 €, soit exactement le total du séjour. Le calendrier montre bien deux plages distinctes et la nuitée `💤`.

## Tests

`bundle exec rspec` : **1209 exemples, 0 échec** (16 pending préexistants, squelettes `rails g`). Aucun linter Ruby/JS n'est configuré sur le repo (pas de `.rubocop.yml`, pas de `bin/rubocop`, pas de script `lint` — le seul workflow CI est `agent-ready-gate.yml`), donc rien à faire passer au vert de ce côté.

Specs ajoutées : `spec/models/hamac_booking_spec.rb` (validations, stock, conflits nuit par nuit), `spec/services/reservations/hamac_persistence_spec.rb` (plages contiguës, ventilation exacte, mixte simple/double, invariant de total, repli pleine-fenêtre, stock, round-trip reconstructor, édition + détachement admin), `spec/requests/hamacs_display_spec.rb` (modale, chip calendrier, nuitée, résumé de composition).

## Ce qui n'a PAS été testé / à valider

- **Le funnel public de bout en bout n'a pas été parcouru en navigateur.** La persistance côté public est couverte par un spec de service (`Reservations::Builder` avec `admin: false`, le chemin exact du contrôleur public), mais pas par une soumission réelle du formulaire multi-étapes.
- **Le stock en production.** `RentalItem#stock` n'est seedé qu'en dev (4 simples / 2 doubles). Si la prod a des stocks vides, la vérification ne bloquera rien (comportement volontaire, non-régressif) — à renseigner dans l'admin pour que le garde-fou serve.
- **Comportement du stock vis-à-vis des séjours `pending`.** Comme pour camping/van, seules les réservations **confirmées** consomment le stock : deux demandes en attente peuvent viser le même hamac. Cohérent avec l'existant, mais c'est un choix à confirmer.
- **La saisonnalité mai-octobre** n'est pas appliquée à la persistance : le funnel public masque déjà les hamacs hors saison, l'admin les propose toute l'année (comportement existant, inchangé).
- **Pas de migration de données** ni de backfill : les séjours passés avec hamacs payés restent sans `HamacBooking` (il n'y a rien à reprendre, la donnée n'a jamais existé).
