### PR TITLE
Ajoute la catégorie de séjour « Couple »

### DIFF
--- a/app/models/stay.rb
+++ b/app/models/stay.rb
@@ -48,6 +48,7 @@ class Stay < ApplicationRecord
     "training"         => "Formation/Initiation",
     "friends"          => "Groupe d'amis",
     "family"           => "Famille",
+    "couple"           => "Couple",
     "team_building"    => "Team building",
     "collective"       => "Collectif",
     "retreat"          => "Mise au vert",

--- a/spec/models/stay_category_spec.rb
+++ b/spec/models/stay_category_spec.rb
@@ -35,11 +35,12 @@ RSpec.describe Stay, type: :model do
       expect(Stay.public_categories.keys).to match_array(Stay::CATEGORIES.keys - ["les4sources"])
     end
 
-    it "inclut l'amendement (collective, workshop_retreat) et les 12 clés au total" do
-      expect(Stay::CATEGORIES.keys).to include("collective", "workshop_retreat")
-      expect(Stay::CATEGORIES.size).to eq(12)
+    it "inclut l'amendement (collective, workshop_retreat, couple) et les 13 clés au total" do
+      expect(Stay::CATEGORIES.keys).to include("collective", "workshop_retreat", "couple")
+      expect(Stay::CATEGORIES.size).to eq(13)
       expect(Stay::CATEGORIES["collective"]).to eq("Collectif")
       expect(Stay::CATEGORIES["workshop_retreat"]).to eq("Retraite/Stage")
+      expect(Stay::CATEGORIES["couple"]).to eq("Couple")
     end
   end
 


### PR DESCRIPTION
## Contexte

Michael : « Dans les catégories de séjour, ajoute "Couple" ».

## Changement

Une seule ligne de fond : la clé stable `couple` → libellé FR **« Couple »** dans `Stay::CATEGORIES` (`app/models/stay.rb`), placée juste après **Famille**.

Tout le reste se dérive de cette constante, donc rien d'autre à toucher :
- `<select>` du CRUD admin **et** du funnel public (`Stay.public_categories` n'exclut que `les4sources`) ;
- validation d'inclusion `validates :category, inclusion: { in: CATEGORIES.keys }` ;
- libellé `Stay#category_label` et badge `StayDecorator#category_badge`.

Pas de migration : `stays.category` est une colonne `string` libre côté base, bornée au niveau modèle.

## Tests

Le spec de comptage `spec/models/stay_category_spec.rb` passe de 12 à 13 clés et vérifie explicitement `couple` → « Couple ». La boucle `CATEGORIES.each_key` couvre automatiquement la validation de la nouvelle clé.

```
bundle exec rspec spec/models
279 examples, 0 failures, 16 pending
```
(les 16 *pending* sont des specs placeholder préexistantes)

## Non vérifié

Pas de passage navigateur : le changement est une entrée de hash rendue par des `<select>` déjà en place, sans nouvelle vue ni nouvelle classe Tailwind.