### PR TITLE
Agenda iCal des gardes, abonnable depuis Google Agenda (#142)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ STRIPE_API_KEY=12341234
 # Jeton(s) d'accès à l'API privée pour agents IA (header Authorization: Bearer ...).
 # Plusieurs jetons possibles, séparés par des virgules (rotation).
 AGENT_API_TOKEN=changeme-generate-a-long-random-token
+# Jeton du flux iCal des gardes : GET /watchman.ics?token=... (issue #142).
+# Non configuré ou vide → la route renvoie 404, jamais un flux ouvert.
+# Sur Hatchbox, un ajout/changement exige un VRAI redémarrage de l'app (cf. README).
+WATCHMAN_ICS_TOKEN=changeme-generate-a-long-random-token

--- a/README.md
+++ b/README.md
@@ -61,3 +61,37 @@ Use `rails db:seed` to add lodgings, rooms and spaces to the database.
 ### Sending emails
 
 Emails are delivered using Postmark. Please ask Michael (it@les4sources.be) for credentials.
+
+### Flux iCal des gardes (Google Agenda)
+
+Les gardes (rôle « Veilleur·euse ») sont publiées sous forme de flux iCalendar
+abonnable, pour qu'elles apparaissent dans l'agenda personnel de chacun·e sans
+avoir à ouvrir Claudy.
+
+**S'abonner depuis Google Agenda**
+
+1. Dans Google Agenda : *Autres agendas* → **+** → **Ajouter à partir de l'URL**.
+2. Coller `https://app.les4sources.be/watchman.ics?token=LE_JETON`.
+3. Valider. Google re-synchronise le flux tout seul (comptez plusieurs heures
+   entre deux rafraîchissements — c'est Google qui décide, pas nous).
+
+Le flux est en **lecture seule** et **collectif** : un seul événement journée
+entière par jour, titré `Garde : Ana & Bruno` quand plusieurs personnes sont de
+garde le même jour. Seuls les **titulaires** y figurent (les `backup` non), et
+tout l'historique est exporté. Chaque événement renvoie vers le calendrier
+Claudy du mois concerné.
+
+**Le jeton**
+
+L'URL n'est protégée que par le jeton `?token=…`, comparé en temps constant à la
+variable d'environnement `WATCHMAN_ICS_TOKEN`. Toute requête sans jeton, avec un
+mauvais jeton, ou lorsque la variable n'est pas configurée reçoit un **404** : le
+flux n'est jamais ouvert par défaut. Le jeton vaut donc accès en lecture aux noms
+et aux dates de garde — il se transmet à la main, pas en clair sur le web.
+
+Générer un jeton : `ruby -rsecurerandom -e 'puts SecureRandom.urlsafe_base64(32)'`.
+
+> ⚠️ **Déploiement Hatchbox.** Après avoir ajouté ou changé `WATCHMAN_ICS_TOKEN`,
+> il faut un **vrai redémarrage** de l'app, pas un simple déploiement : le
+> hot-reload (SIGUSR2) ne recharge pas l'environnement, et la route continuerait
+> de renvoyer 404 alors que la variable semble bien configurée.

--- a/app/controllers/watchman_ics_controller.rb
+++ b/app/controllers/watchman_ics_controller.rb
@@ -1,0 +1,30 @@
+# Flux iCal des gardes, abonnable depuis Google Agenda (issue #142).
+#
+# Hérite de `ActionController::Base` et NON de `BaseController` : Google Agenda
+# récupère l'URL anonymement, sans cookie ni session Devise. Un `authenticate_user!`
+# rendrait le flux inabonnable.
+#
+# Le seul garde-fou est donc le jeton `?token=` :
+#   - comparé en temps constant à `ENV["WATCHMAN_ICS_TOKEN"]` ;
+#   - absent, faux, ou variable d'environnement non configurée → **404**, jamais
+#     401/403 : on ne confirme même pas l'existence du flux.
+class WatchmanIcsController < ActionController::Base
+  layout false
+
+  def show
+    return head :not_found unless authorized?
+
+    render plain: Watchmen::IcalFeed.new.to_ics, content_type: "text/calendar"
+  end
+
+  private
+
+  def authorized?
+    expected = ENV["WATCHMAN_ICS_TOKEN"].to_s
+    provided = params[:token].to_s
+    # Pas de jeton configuré → le flux n'est PAS ouvert par défaut.
+    return false if expected.blank? || provided.blank?
+
+    ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+  end
+end

--- a/app/services/watchmen/ical_feed.rb
+++ b/app/services/watchmen/ical_feed.rb
@@ -1,0 +1,199 @@
+module Watchmen
+  # Flux iCalendar (RFC 5545) des gardes — rôle « Veilleur·euse » (issue #142).
+  #
+  # Abonnable depuis Google Agenda (« Ajouter depuis l'URL ») : Google refait la
+  # requête tout seul, à son rythme. D'où deux exigences structurantes :
+  #
+  #   - un `UID` STABLE par jour, dérivé de la date : une re-synchronisation doit
+  #     METTRE À JOUR l'événement existant, jamais en créer un doublon ;
+  #   - un rendu DÉTERMINISTE (noms triés, événements triés par date) : deux
+  #     générations sur les mêmes données donnent le même flux à l'octet près.
+  #
+  # Strictement en LECTURE : rien n'est écrit, rien n'est modifié.
+  class IcalFeed
+    # Il n'existe qu'un seul rôle dans Claudy : #1 « Veilleur·euse » — la garde.
+    # Même convention que `HumanRole#has_watchman_note?` et `PagesController`.
+    WATCHMAN_ROLE_ID = 1
+
+    PRODID = "-//Les 4 Sources//Claudy Gardes//FR".freeze
+    CALENDAR_NAME = "Gardes — Les 4 Sources".freeze
+
+    # Domaine des UID : une CONSTANTE, jamais l'hôte configuré. Si l'hôte de
+    # l'app changeait, des UID dérivés de l'hôte changeraient aussi et Google
+    # recréerait tous les événements en double.
+    UID_DOMAIN = "claudy.les4sources.be".freeze
+
+    # Plusieurs personnes le même jour → un seul événement, noms joints.
+    NAME_SEPARATOR = " & ".freeze
+
+    # La RFC 5545 exige des fins de ligne CRLF et des lignes de 75 octets max
+    # (au-delà : pliage sur une ligne de continuation commençant par une espace).
+    CRLF = "\r\n".freeze
+    MAX_LINE_OCTETS = 75
+
+    # `DTSTAMP` est obligatoire dans un VEVENT. On le dérive du `updated_at` des
+    # gardes du jour pour qu'il reste stable tant que la garde ne bouge pas.
+    FALLBACK_DTSTAMP = Time.utc(2000, 1, 1).freeze
+
+    MissingHostError = Class.new(StandardError)
+
+    Day = Struct.new(:date, :names, :updated_at)
+
+    def to_ics
+      lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:#{escape_text(PRODID)}",
+        "CALSCALE:GREGORIAN",
+        "X-WR-CALNAME:#{escape_text(CALENDAR_NAME)}"
+      ]
+      days.each { |day| lines.concat(vevent_lines(day)) }
+      lines << "END:VCALENDAR"
+
+      lines.flat_map { |line| fold(line) }.join(CRLF) + CRLF
+    end
+
+    # Un élément par JOUR ayant au moins une garde titulaire, trié par date.
+    def days
+      @days ||= begin
+        names = names_by_human_id(assignments.map { |row| row[1] }.uniq)
+
+        assignments.group_by { |row| row[0] }.sort_by(&:first).filter_map do |date, rows|
+          day_names = sort_names(rows.filter_map { |row| names[row[1]] }.uniq)
+          next if day_names.empty?
+
+          Day.new(date, day_names, rows.filter_map { |row| row[2] }.max)
+        end
+      end
+    end
+
+    private
+
+    # Toutes les gardes connues — pas de fenêtre glissante : le volume est faible
+    # (~1150 événements) et l'historique est utile. Seuls les TITULAIRES
+    # (`status: selected`) sortent ; les `backup` ne produisent aucun événement.
+    # UNE seule requête pour l'ensemble du flux.
+    def assignments
+      @assignments ||= HumanRole
+        .where(role_id: WATCHMAN_ROLE_ID, status: :selected)
+        .where.not(date: nil)
+        .pluck(:date, :human_id, :updated_at)
+    end
+
+    # `Human` porte un `default_scope` (`status: "active"` + soft-deletion). Un
+    # `includes(:human)` ferait donc DISPARAÎTRE les gardes des membres devenus
+    # inactifs : sur les données de production, 52 jours sont concernés, dont 37
+    # où la personne est seule — autant d'événements sans nom. Le flux est un
+    # historique de qui était de garde : on lit les noms hors `default_scope`, en
+    # UNE requête (aucun N+1).
+    def names_by_human_id(human_ids)
+      return {} if human_ids.empty?
+
+      Human.unscoped.where(id: human_ids).pluck(:id, :name).to_h
+    end
+
+    # Ordre alphabétique insensible aux accents (« Émile » avant « Fred », et non
+    # après « Zoé »), avec le nom brut en second critère : le tri est total, donc
+    # le rendu est stable d'une génération à l'autre.
+    def sort_names(names)
+      names.sort_by { |name| [I18n.transliterate(name).downcase, name] }
+    end
+
+    def vevent_lines(day)
+      [
+        "BEGIN:VEVENT",
+        "UID:#{uid_for(day.date)}",
+        "DTSTAMP:#{ical_timestamp(day.updated_at)}",
+        # Événement all-day. Le `DTEND` d'un all-day iCal est EXCLUSIF : sans le
+        # +1 jour, Google affiche une durée nulle ou décale l'événement.
+        "DTSTART;VALUE=DATE:#{ical_date(day.date)}",
+        "DTEND;VALUE=DATE:#{ical_date(day.date + 1)}",
+        "SUMMARY:#{escape_text(summary_for(day))}",
+        # `URL` est de type URI, pas TEXT : la RFC ne lui applique pas
+        # l'échappement `\;` / `\,`. La valeur vient des url_helpers Rails.
+        "URL:#{calendar_url_for(day.date)}",
+        # Google Agenda n'affiche pas toujours la propriété `URL` seule : on
+        # rappelle le lien dans la DESCRIPTION, elle-même de type TEXT.
+        "DESCRIPTION:#{escape_text(description_for(day))}",
+        "END:VEVENT"
+      ]
+    end
+
+    def summary_for(day)
+      "Garde : #{day.names.join(NAME_SEPARATOR)}"
+    end
+
+    def description_for(day)
+      [summary_for(day), "Calendrier Claudy : #{calendar_url_for(day.date)}"].join("\n")
+    end
+
+    def uid_for(date)
+      "garde-#{date.strftime('%Y%m%d')}@#{UID_DOMAIN}"
+    end
+
+    def ical_date(date)
+      date.strftime("%Y%m%d")
+    end
+
+    def ical_timestamp(time)
+      (time || FALLBACK_DTSTAMP).utc.strftime("%Y%m%dT%H%M%SZ")
+    end
+
+    # Lien vers le calendrier Claudy AU MOIS de la garde : la page racine accepte
+    # `?date=AAAA-MM-JJ` (cf. `PagesController#set_dates`).
+    def calendar_url_for(date)
+      Rails.application.routes.url_helpers.root_url(
+        **url_options, date: date.beginning_of_month.iso8601
+      )
+    end
+
+    # L'hôte vient de la configuration de l'app (celle des emails), jamais d'une
+    # valeur codée en dur.
+    def url_options
+      @url_options ||= begin
+        options = (Rails.application.config.action_mailer.default_url_options || {}).symbolize_keys
+
+        if options[:host].blank?
+          raise MissingHostError,
+                "config.action_mailer.default_url_options[:host] est requis pour générer le flux iCal des gardes."
+        end
+
+        options.slice(:host, :port, :protocol).compact
+      end
+    end
+
+    # Échappement RFC 5545 des valeurs TEXT. L'antislash PASSE EN PREMIER, sinon
+    # on ré-échapperait les antislashs qu'on vient d'introduire. La forme à bloc
+    # de `gsub` est volontaire : elle n'interprète pas les `\\` du remplacement.
+    def escape_text(text)
+      text.to_s
+          .gsub(/[\\;,]/) { |char| "\\#{char}" }
+          .gsub(/\r\n|\r|\n/) { "\\n" }
+    end
+
+    # Pliage RFC 5545 : 75 octets max par ligne, continuation préfixée d'une
+    # espace. On découpe par CARACTÈRE en comptant les octets, pour ne jamais
+    # couper une séquence UTF-8 en deux (« — », « é »…).
+    def fold(line)
+      return [line] if line.bytesize <= MAX_LINE_OCTETS
+
+      chunks = []
+      current = +""
+      limit = MAX_LINE_OCTETS
+
+      line.each_char do |char|
+        if current.bytesize + char.bytesize > limit
+          chunks << current
+          current = +""
+          # Les lignes de continuation commencent par une espace, qui compte
+          # dans les 75 octets : il reste 74 octets de contenu.
+          limit = MAX_LINE_OCTETS - 1
+        end
+        current << char
+      end
+      chunks << current
+
+      chunks.each_with_index.map { |chunk, index| index.zero? ? chunk : " #{chunk}" }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,6 +192,12 @@ Rails.application.routes.draw do
   get  "mon-sejour/:token/activites", to: "public/activity_selections#show",   as: :public_activity_selection
   post "mon-sejour/:token/activites", to: "public/activity_selections#create",  as: :public_activity_selection_create
 
+  # Canal jeton — flux iCal des gardes, abonnable depuis Google Agenda
+  # (issue #142). Le jeton passe en paramètre (`?token=…`) et non dans le chemin :
+  # Google Agenda ne veut qu'une URL, et un jeton en query se recopie tel quel.
+  # Lecture seule, sans Devise (Google récupère l'URL sans cookie).
+  get "watchman.ics", to: "watchman_ics#show", as: :watchman_ics
+
   # Facturation — poste de travail du Pôle Admin (Michael 2026-07-26). Remplace
   # « Comptabilité / Tableau de bord » (`/comptabilite`, retiré). URL admin en
   # ANGLAIS, comme le reste de l'admin.

--- a/spec/requests/watchman_ics_spec.rb
+++ b/spec/requests/watchman_ics_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+# issue #142 — le flux iCal des gardes doit être récupérable par Google Agenda :
+# anonymement (aucun cookie, aucune session Devise) et scellé par un seul jeton.
+RSpec.describe "GET /watchman.ics", type: :request do
+  let(:token) { "jeton-de-test-tres-long-et-aleatoire" }
+  let!(:role) do
+    Role.find_or_create_by!(id: Watchmen::IcalFeed::WATCHMAN_ROLE_ID) { |r| r.name = "Veilleur·euse" }
+  end
+
+  def with_token(value)
+    original = ENV["WATCHMAN_ICS_TOKEN"]
+    ENV["WATCHMAN_ICS_TOKEN"] = value
+    yield
+  ensure
+    ENV["WATCHMAN_ICS_TOKEN"] = original
+  end
+
+  describe "protection par jeton" do
+    it "renvoie 404 sans jeton" do
+      with_token(token) { get "/watchman.ics" }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "renvoie 404 avec un jeton faux" do
+      with_token(token) { get "/watchman.ics", params: { token: "pas-le-bon" } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "renvoie 404 avec un jeton de la bonne longueur mais faux" do
+      with_token(token) { get "/watchman.ics", params: { token: token.sub(/.\z/, "X") } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "renvoie 404 quand ENV[\"WATCHMAN_ICS_TOKEN\"] est vide — jamais de flux ouvert par défaut" do
+      with_token("") { get "/watchman.ics", params: { token: "" } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "renvoie 404 quand ENV[\"WATCHMAN_ICS_TOKEN\"] est absent" do
+      with_token(nil) { get "/watchman.ics", params: { token: token } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "ne renvoie ni 401 ni 403 : on ne confirme pas l'existence du flux" do
+      with_token(token) { get "/watchman.ics", params: { token: "pas-le-bon" } }
+
+      expect(response).not_to have_http_status(:unauthorized)
+      expect(response).not_to have_http_status(:forbidden)
+      expect(response.body).to be_blank
+    end
+  end
+
+  describe "avec le bon jeton" do
+    let!(:garde) do
+      HumanRole.create!(human: Human.create!(name: "Ana"), role: role,
+                        date: Date.new(2026, 8, 12), status: :selected)
+    end
+
+    it "renvoie 200 et un Content-Type text/calendar en UTF-8" do
+      with_token(token) { get "/watchman.ics", params: { token: token } }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Type"]).to eq("text/calendar; charset=utf-8")
+    end
+
+    it "est accessible SANS être connecté — aucune redirection vers Devise" do
+      # Aucun `sign_in` ici : c'est exactement le besoin (Google Agenda est anonyme).
+      with_token(token) { get "/watchman.ics", params: { token: token } }
+
+      expect(response).to have_http_status(:ok)
+      expect(response).not_to be_redirect
+      expect(response.body).to include("BEGIN:VCALENDAR")
+    end
+
+    it "sert le flux des gardes" do
+      with_token(token) { get "/watchman.ics", params: { token: token } }
+
+      body = response.body.gsub("\r\n ", "")
+
+      expect(body).to include("SUMMARY:Garde : Ana")
+      expect(body).to include("UID:garde-20260812@claudy.les4sources.be")
+      expect(body).to include("DTSTART;VALUE=DATE:20260812")
+      expect(body).to include("DTEND;VALUE=DATE:20260813")
+      expect(body).to end_with("END:VCALENDAR\r\n")
+    end
+
+    it "ne modifie aucune donnée — le flux est strictement en lecture" do
+      empreinte = -> { [HumanRole.count, Human.unscoped.count, HumanRole.pluck(:updated_at)] }
+      avant = empreinte.call
+
+      with_token(token) { get "/watchman.ics", params: { token: token } }
+
+      expect(empreinte.call).to eq(avant)
+    end
+  end
+end

--- a/spec/services/watchmen/ical_feed_spec.rb
+++ b/spec/services/watchmen/ical_feed_spec.rb
@@ -1,0 +1,298 @@
+require "rails_helper"
+
+# issue #142 — flux iCal des gardes, abonnable depuis Google Agenda.
+RSpec.describe Watchmen::IcalFeed do
+  let!(:role) { Role.find_or_create_by!(id: described_class::WATCHMAN_ROLE_ID) { |r| r.name = "Veilleur·euse" } }
+
+  def human(name)
+    Human.create!(name: name)
+  end
+
+  def garde(human, date, status: :selected)
+    HumanRole.create!(human: human, role: role, date: date, status: status)
+  end
+
+  # Le flux est plié à 75 octets (RFC 5545) : on déplie avant d'inspecter, sinon
+  # une longue `DESCRIPTION` casserait les assertions.
+  def unfolded(ics = subject.to_ics)
+    ics.gsub("\r\n ", "")
+  end
+
+  def vevents(ics = subject.to_ics)
+    unfolded(ics).scan(/BEGIN:VEVENT.*?END:VEVENT/m)
+  end
+
+  def count_queries
+    count = 0
+    counter = ->(*, payload) { count += 1 unless payload[:name].in?(%w[CACHE SCHEMA TRANSACTION]) }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { yield }
+    count
+  end
+
+  describe "en-tête du calendrier" do
+    it "porte PRODID, VERSION, CALSCALE et un X-WR-CALNAME lisible" do
+      ics = unfolded
+
+      expect(ics).to include("BEGIN:VCALENDAR")
+      expect(ics).to include("VERSION:2.0")
+      expect(ics).to include("CALSCALE:GREGORIAN")
+      expect(ics).to include("PRODID:-//Les 4 Sources//Claudy Gardes//FR")
+      expect(ics).to include("X-WR-CALNAME:Gardes — Les 4 Sources")
+      expect(ics).to end_with("END:VCALENDAR\r\n")
+    end
+
+    it "termine TOUTES ses lignes par CRLF, comme l'exige la RFC" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      ics = subject.to_ics
+
+      expect(ics).not_to match(/(?<!\r)\n/)
+      expect(ics.split("\r\n")).to all(satisfy { |line| line.bytesize <= 75 })
+    end
+  end
+
+  describe "un événement par jour" do
+    it "rend un VEVENT avec le nom de la personne de garde" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      events = vevents
+
+      expect(events.size).to eq(1)
+      expect(events.first).to include("SUMMARY:Garde : Ana")
+    end
+
+    it "regroupe plusieurs personnes du même jour dans UN SEUL événement, noms triés" do
+      date = Date.new(2026, 8, 12)
+      garde(human("Bruno"), date)
+      garde(human("Ana"), date)
+
+      events = vevents
+
+      expect(events.size).to eq(1)
+      expect(events.first).to include("SUMMARY:Garde : Ana & Bruno")
+    end
+
+    it "trie les noms sans se laisser piéger par les accents" do
+      date = Date.new(2026, 8, 12)
+      garde(human("Fred"), date)
+      garde(human("Émile"), date)
+
+      expect(vevents.first).to include("SUMMARY:Garde : Émile & Fred")
+    end
+
+    it "rend les jours dans l'ordre chronologique" do
+      ana = human("Ana")
+      garde(ana, Date.new(2026, 8, 20))
+      garde(ana, Date.new(2026, 8, 12))
+
+      expect(subject.days.map(&:date)).to eq([Date.new(2026, 8, 12), Date.new(2026, 8, 20)])
+    end
+
+    it "ignore les backup : un backup seul sur une date ne produit AUCUN événement" do
+      garde(human("Suppléante"), Date.new(2026, 8, 12), status: :backup)
+
+      expect(vevents).to be_empty
+    end
+
+    it "n'exporte que les titulaires d'un jour mixte titulaire + backup" do
+      date = Date.new(2026, 8, 12)
+      garde(human("Ana"), date)
+      garde(human("Suppléant"), date, status: :backup)
+
+      events = vevents
+
+      expect(events.size).to eq(1)
+      expect(events.first).to include("SUMMARY:Garde : Ana")
+      expect(events.first).not_to include("Suppléant")
+    end
+  end
+
+  describe "événement all-day" do
+    it "pose un DTSTART date et un DTEND au LENDEMAIN (borne exclusive iCal)" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      event = vevents.first
+
+      expect(event).to include("DTSTART;VALUE=DATE:20260812")
+      expect(event).to include("DTEND;VALUE=DATE:20260813")
+    end
+
+    it "passe correctement une fin de mois" do
+      garde(human("Ana"), Date.new(2026, 8, 31))
+
+      event = vevents.first
+
+      expect(event).to include("DTSTART;VALUE=DATE:20260831")
+      expect(event).to include("DTEND;VALUE=DATE:20260901")
+    end
+  end
+
+  describe "UID stable" do
+    it "dérive l'UID de la date, à l'identique entre deux générations" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      first = described_class.new.to_ics
+      second = described_class.new.to_ics
+
+      expect(unfolded(first)).to include("UID:garde-20260812@claudy.les4sources.be")
+      expect(first).to eq(second)
+    end
+
+    it "garde le même UID quand la composition du jour change (mise à jour, pas doublon)" do
+      date = Date.new(2026, 8, 12)
+      garde(human("Ana"), date)
+      before_ics = described_class.new.to_ics
+
+      garde(human("Bruno"), date)
+      after_ics = described_class.new.to_ics
+
+      expect(unfolded(after_ics)).to include("UID:garde-20260812@claudy.les4sources.be")
+      expect(vevents(after_ics).size).to eq(1)
+      expect(unfolded(before_ics)).to include("SUMMARY:Garde : Ana")
+      expect(unfolded(after_ics)).to include("SUMMARY:Garde : Ana & Bruno")
+    end
+
+    it "porte un DTSTAMP UTC" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      expect(vevents.first).to match(/DTSTAMP:\d{8}T\d{6}Z/)
+    end
+  end
+
+  describe "lien vers le calendrier Claudy du mois" do
+    it "pointe vers le 1er du mois de la garde, en URL et en DESCRIPTION" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      event = vevents.first
+
+      expect(event).to include("URL:http://localhost:3000/?date=2026-08-01")
+      expect(event).to include("Calendrier Claudy : http://localhost:3000/?date=2026-08-01")
+    end
+
+    it "construit l'hôte depuis la configuration de l'app, pas en dur" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      allow(Rails.application.config.action_mailer)
+        .to receive(:default_url_options).and_return(host: "app.les4sources.be")
+
+      expect(vevents.first).to include("URL:http://app.les4sources.be/?date=2026-08-01")
+    end
+
+    it "refuse de générer un flux si aucun hôte n'est configuré" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      allow(Rails.application.config.action_mailer).to receive(:default_url_options).and_return({})
+
+      expect { subject.to_ics }.to raise_error(described_class::MissingHostError)
+    end
+  end
+
+  describe "échappement RFC 5545" do
+    it "échappe virgule et point-virgule dans un nom sans casser le flux" do
+      garde(human("Dupont, Ana; dite Nana"), Date.new(2026, 8, 12))
+
+      event = vevents.first
+
+      expect(event).to include('SUMMARY:Garde : Dupont\, Ana\; dite Nana')
+      expect(vevents.size).to eq(1)
+    end
+
+    it "échappe l'antislash une seule fois" do
+      garde(human('Ana \\ Bruno'), Date.new(2026, 8, 12))
+
+      expect(vevents.first).to include('SUMMARY:Garde : Ana \\\\ Bruno')
+    end
+
+    it "rend la DESCRIPTION multi-ligne avec un \\n littéral, pas un vrai saut de ligne" do
+      garde(human("Ana"), Date.new(2026, 8, 12))
+
+      description = unfolded[/^DESCRIPTION:.*$/]
+
+      expect(description).to include('Garde : Ana\nCalendrier Claudy :')
+    end
+  end
+
+  describe "pliage des lignes longues" do
+    it "plie à 75 octets et se déplie sans perte" do
+      # Assez de noms pour dépasser largement 75 octets sur le SUMMARY.
+      date = Date.new(2026, 8, 12)
+      %w[Anastasia Bartholomew Clementine Dieudonné Ermengarde].each { |n| garde(human(n), date) }
+
+      ics = subject.to_ics
+      expected = "SUMMARY:Garde : Anastasia & Bartholomew & Clementine & Dieudonné & Ermengarde"
+
+      expect(ics).not_to include(expected)              # la ligne brute est pliée
+      expect(unfolded(ics)).to include(expected)        # dépliée, elle est intacte
+      expect(ics.split("\r\n")).to all(satisfy { |line| line.bytesize <= 75 })
+    end
+
+    it "ne coupe jamais un caractère multi-octets en deux" do
+      date = Date.new(2026, 8, 12)
+      6.times { |i| garde(human("Éléonore#{i}Ç"), date) }
+
+      ics = subject.to_ics
+
+      expect(ics.valid_encoding?).to be(true)
+      expect(unfolded(ics)).to include("Éléonore0Ç & Éléonore1Ç")
+    end
+  end
+
+  describe "membres devenus inactifs" do
+    # `Human` porte un `default_scope` (status "active" + soft-deletion) : un
+    # `includes(:human)` viderait le titre de ces journées historiques.
+    it "conserve le nom d'un membre passé inactif" do
+      ancienne = human("Claire")
+      garde(ancienne, Date.new(2024, 3, 4))
+      ancienne.update_columns(status: "inactive")
+
+      expect(vevents.first).to include("SUMMARY:Garde : Claire")
+    end
+
+    it "conserve le nom d'un membre soft-deleted" do
+      partie = human("Zoé")
+      garde(partie, Date.new(2024, 3, 4))
+      partie.update_columns(deleted_at: Time.current)
+
+      expect(vevents.first).to include("SUMMARY:Garde : Zoé")
+    end
+  end
+
+  describe "performance" do
+    it "ne fait aucun N+1 : le nombre de requêtes ne dépend pas du nombre de jours" do
+      ana = human("Ana")
+      bruno = human("Bruno")
+
+      garde(ana, Date.new(2026, 8, 1))
+      garde(bruno, Date.new(2026, 8, 1))
+      few = count_queries { described_class.new.to_ics }
+
+      (2..30).each do |day|
+        garde(ana, Date.new(2026, 8, day))
+        garde(bruno, Date.new(2026, 8, day))
+      end
+      many = count_queries { described_class.new.to_ics }
+
+      expect(described_class.new.days.size).to eq(30)
+      expect(many).to eq(few)
+      expect(many).to be <= 2
+    end
+  end
+
+  describe "couverture" do
+    it "couvre tout l'historique, sans fenêtre glissante" do
+      ana = human("Ana")
+      garde(ana, Date.new(2023, 11, 9))
+      garde(ana, Date.today)
+      garde(ana, Date.new(2026, 8, 30))
+
+      expect(vevents.size).to eq(3)
+      expect(unfolded).to include("DTSTART;VALUE=DATE:20231109")
+      expect(unfolded).to include("DTSTART;VALUE=DATE:20260830")
+    end
+
+    it "ne rend aucun VEVENT quand il n'y a aucune garde" do
+      expect(vevents).to be_empty
+      expect(unfolded).to include("BEGIN:VCALENDAR")
+    end
+  end
+end


### PR DESCRIPTION
Closes #142

Publie les gardes (rôle **Veilleur·euse**) en flux iCalendar abonnable, pour qu'elles apparaissent dans l'agenda personnel de chacun·e sans avoir à ouvrir Claudy.

## Ce que ça fait

`GET /watchman.ics?token=…` renvoie un flux RFC 5545 :

- **un seul événement journée entière par jour**, noms regroupés dans le titre (`Garde : Ana & Bruno`), triés — pas un événement par personne ;
- **seuls les titulaires** (`status: selected`) ; les `backup` ne produisent aucun événement ;
- **tout l'historique**, sans fenêtre glissante (986 jours, 1149 gardes en prod aujourd'hui) ;
- chaque événement renvoie vers le **calendrier Claudy du mois concerné** (`URL` + rappel dans `DESCRIPTION`, parce que Google n'affiche pas toujours `URL` seule).

## Sécurité de la route

- Jeton en query, comparé en **temps constant** à `ENV["WATCHMAN_ICS_TOKEN"]` (`ActiveSupport::SecurityUtils.secure_compare`).
- Jeton absent, faux, **ou variable non configurée → 404** (pas 401/403 : on ne confirme même pas l'existence du flux). Jamais de flux ouvert par défaut.
- `WatchmanIcsController` hérite d'`ActionController::Base`, **pas** de `BaseController` : Google Agenda récupère l'URL anonymement, un `authenticate_user!` rendrait le flux inabonnable.

## Deux points de conception qui méritent un mot

**UID déterministe.** `garde-AAAAMMJJ@claudy.les4sources.be`, dérivé de la date et d'un domaine **constant** (pas de l'hôte configuré : si l'hôte changeait, des UID dérivés de l'hôte changeraient aussi et Google recréerait tout en double). `DTSTAMP` vient du `updated_at` des gardes du jour, donc il ne bouge que si la garde bouge vraiment.

**Les noms sont lus hors `default_scope`.** `Human` porte `default_scope { where(status: "active") }` + soft-deletion. Le `includes(:human)` suggéré dans l'issue ferait donc **disparaître les noms des membres devenus inactifs** : sur les données de prod, **52 jours** sont concernés, dont **37 où la personne est seule** — autant d'événements au titre vide. Le flux est un historique de qui était de garde, donc `Human.unscoped` en une requête dédiée. Toujours **2 requêtes au total**, aucun N+1 (couvert par un test qui compte les requêtes).

## Vérifications faites

- `bundle exec rspec` **vert en entier** : **1341 exemples, 0 échec**, 16 pending (les 16 pending préexistent — la base était à 1305/0/16 avant cette branche). 36 nouveaux tests.
- **Flux réel parsé par un parseur tiers.** Le `.ics` généré sur les données de dev (301 206 octets, 986 VEVENT) a été parsé avec **ical.js**, puis re-parsé sur **les octets exacts servis par HTTP** : 986 événements, tous *all-day*, `DTEND` = lendemain pour tous (vérifié en composantes de date, y compris les 5 jours de changement d'heure), aucun UID en doublon, échappement correctement décodé, génération déterministe (deux passes identiques à l'octet près).
- **Bout en bout sur un vrai serveur** (`bin/rails server`, sans cookie) : sans jeton → 404 · mauvais jeton → 404 · bon jeton → **200** avec `Content-Type: text/calendar; charset=utf-8`.
- Lecture stricte : un test vérifie qu'aucune donnée n'est touchée par la requête.

### Extrait de sortie réelle

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Les 4 Sources//Claudy Gardes//FR
CALSCALE:GREGORIAN
X-WR-CALNAME:Gardes — Les 4 Sources
BEGIN:VEVENT
UID:garde-20231215@claudy.les4sources.be
DTSTAMP:20231130T193553Z
DTSTART;VALUE=DATE:20231215
DTEND;VALUE=DATE:20231216
SUMMARY:Garde : Magali & Seb
URL:http://claudy.test/?date=2023-12-01
DESCRIPTION:Garde : Magali & Seb\nCalendrier Claudy : http://claudy.test/?d
 ate=2023-12-01
END:VEVENT
```

(La dernière ligne est *pliée* : la RFC 5545 impose 75 octets max, continuation préfixée d'une espace. Le pliage découpe par caractère pour ne jamais couper une séquence UTF-8 en deux.)

## 📸 Aperçu

Pas de capture : la feature n'a **aucun rendu visible** (c'est un flux texte `text/calendar`, pas une vue). L'extrait ci-dessus est la sortie réelle.

## Ce qui n'a PAS pu être testé / à valider

1. **L'abonnement réel dans Google Agenda n'a pas été testé.** Il faut une URL publique et un compte Google — impossible depuis le run nocturne. Le flux est validé RFC + parseur tiers, mais le comportement final de Google (délai de rafraîchissement, mise à jour vs doublon) ne se confirme qu'en vrai. **C'est le point à valider en premier après déploiement.**
2. **`WATCHMAN_ICS_TOKEN` est une variable NOUVELLE.** Sur Hatchbox, un déploiement standard fait un hot-reload (SIGUSR2) qui **ne recharge pas l'environnement** : après l'avoir ajoutée, il faut un **vrai redémarrage** de l'app, sinon la route renverra 404 alors que la variable semble configurée. Générer le jeton avec `ruby -rsecurerandom -e 'puts SecureRandom.urlsafe_base64(32)'`.
3. **Le lien des événements sera en `http://`, pas `https://`.** Il est construit depuis `config.action_mailer.default_url_options` (comme le veut l'issue : hôte de l'app, rien en dur), et la prod n'y déclare ni `protocol` ni `force_ssl` — les emails ont déjà ce comportement. Ça fonctionne (redirection), mais si tu veux du `https` dans les agendas, il faut ajouter `protocol: "https"` à la config d'URL de l'app : c'est un changement **global** (emails inclus), donc hors périmètre de cette issue. À trancher.
4. **Décision de rendu que j'ai prise seule, à confirmer :** les noms des membres **inactifs / soft-deleted** restent affichés dans l'historique (sinon 37 journées perdaient leur titre). Si tu préfères les anonymiser sur le passé, dis-le et je change.
5. Le tri des noms est alphabétique **insensible aux accents** (« Émile » avant « Fred », pas après « Zoé »).

## Note d'environnement (hors périmètre, pour info)

Dans le clone nocturne, `bundle exec rspec` ne démarrait pas : `.env` fournit `STRIPE_SECRET_KEY` alors que `config/initializers/stripe.rb` fait `ENV.fetch('STRIPE_API_KEY')` (et `.env.example` liste bien `STRIPE_API_KEY`). J'ai ajouté la clé **en local seulement** (`.env` est gitignoré, rien de commité) pour pouvoir lancer les tests. Le `.env` de `~/code/claudy` a le même écart — ça vaut peut-être un alignement.
