### PR TITLE
Refs #144 — Phase 1 : filet CI et déminage du Gemfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+# Lance la suite RSpec sur chaque pull request et sur chaque push vers la branche par défaut.
+# C'est le gate de la migration Rails 8.1 / Ruby 3.4 (epic #144) : aucune phase ne se ferme
+# sans cette CI au vert.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rspec:
+    name: RSpec
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: claudy_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      PGHOST: localhost
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: postgres
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installer Ruby et les gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Installer Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+          cache: yarn
+
+      # Le layout admin appelle `vite_client_tag` / `vite_javascript_tag` : les specs request
+      # qui rendent une page authentifiée déclenchent un build Vite (`autoBuild: true` en test),
+      # d'où les dépendances JS et le build explicite ci-dessous.
+      - name: Installer les dépendances JS
+        run: yarn install --frozen-lockfile
+
+      - name: Construire les assets Vite
+        run: bin/vite build
+
+      - name: Préparer la base de test
+        run: bin/rails db:test:prepare
+
+      - name: RSpec
+        run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
       PGPORT: 5432
       PGUSER: postgres
       PGPASSWORD: postgres
+      # En local ces variables viennent de `.env` (dotenv, non versionné). Plusieurs sont
+      # lues par `ENV.fetch` sans valeur par défaut — `POSTMARK_API_TOKEN` dans
+      # config/application.rb, `STRIPE_API_KEY` dans config/initializers/stripe.rb,
+      # `PHONE_NUMBER` dans deux vues publiques — donc sans elles Rails ne boote pas.
+      # Valeurs factices : rien n'est appelé pour de vrai en test (delivery_method = :test).
+      DEFAULT_FROM_EMAIL: ci@example.com
+      DEFAULT_BCC_EMAIL: ci-bcc@example.com
+      PHONE_NUMBER: "+32(0)81/12.34.56"
+      POSTMARK_API_TOKEN: POSTMARK_API_TEST
+      STRIPE_API_KEY: sk_test_ci_placeholder
+      REPORTS_FIRST_YEAR: "2022"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `ruby-vips` est requis dès config/application.rb : sans la bibliothèque système,
+      # Rails ne boote pas du tout (LoadError sur libvips.so.42). Le nom du paquet a changé
+      # avec la transition time_t 64 bits d'Ubuntu 24.04 (libvips42 -> libvips42t64), d'où
+      # le repli sur l'ancien nom.
+      - name: Installer libvips
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libvips42t64 \
+            || sudo apt-get install -y --no-install-recommends libvips42
+
       - name: Installer Ruby et les gems
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,9 @@ gem "simple_calendar", "~> 2.4"
 gem "simple_form"
 gem "slim"
 gem "soft_deletion"
-gem "stripe"
+# Pinnée volontairement : la montée 10.x -> 19.x touche le chemin des paiements et se fait
+# dans un chantier séparé, pas au fil des `bundle update` de la migration Rails.
+gem "stripe", "~> 10.13"
 gem "validates_email_format_of"
 gem "will_paginate", "~> 3.3"
 # gem "tailwindcss-rails"
@@ -91,7 +93,6 @@ group :development, :test do
   gem "byebug"
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails", "~> 6.0.0"
-  gem "sqlite3"
 end
 
 group :development do
@@ -110,6 +111,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  # Selenium Manager (intégré depuis selenium-webdriver 4.11) remplace la gem `webdrivers`,
+  # dépréciée et qui plafonnait selenium-webdriver sous la 4.11.
   gem "selenium-webdriver"
-  gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,9 +309,6 @@ GEM
       tilt (>= 2.0.6, < 2.1)
     soft_deletion (1.8.0)
       activerecord (>= 5.0.0, < 7.1)
-    sqlite3 (1.6.3-arm64-darwin)
-    sqlite3 (1.6.3-x86_64-darwin)
-    sqlite3 (1.6.3-x86_64-linux)
     ssrf_filter (1.1.1)
     stimulus-rails (1.1.0)
       railties (>= 6.0.0)
@@ -346,10 +343,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webrick (1.7.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
@@ -405,16 +398,14 @@ DEPENDENCIES
   simple_form
   slim
   soft_deletion
-  sqlite3
   stimulus-rails
-  stripe
+  stripe (~> 10.13)
   turbo-rails
   tzinfo-data
   validates_email_format_of
   view_component
   vite_rails
   web-console
-  webdrivers
   will_paginate (~> 3.3)
 
 RUBY VERSION

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,4 +1,0 @@
-# Rails.application.config.dartsass.builds = {
-#   "application.sass.scss"  => "application.css",
-#   "public.sass.scss"       => "public.css"
-# }


### PR DESCRIPTION
**Phase 1 de l'epic #144** — Migration Rails 7.0.4 → 8.1.3 et Ruby 3.1.2 → 3.4.10.

Cette phase ne monte **aucune** version de Rails ni de Ruby. Elle pose le filet qui rendra les 7 phases suivantes vérifiables, et retire du `Gemfile` les gems qui saboteraient silencieusement la résolution plus loin.

## Ce que fait la PR

**Le CI qui manquait.** `.github/workflows/ci.yml` lance `bundle exec rspec` sur chaque `pull_request` et sur chaque `push` vers `main`, avec un service PostgreSQL 15. Jusqu'ici `.github/workflows/` ne contenait que `agent-ready-gate.yml` : **aucun workflow ne lançait les tests**.

Trois choses que le premier run a apprises, et qui sont dans le workflow parce qu'elles sont nécessaires — pas par précaution :

- **Assets Vite.** Le layout admin appelle `vite_client_tag` / `vite_javascript_tag`, donc les specs request qui rendent une page authentifiée déclenchent un build. D'où Node + `yarn install --frozen-lockfile` + `bin/vite build`.
- **libvips.** `ruby-vips` est requis dès `config/application.rb:19` : sans la bibliothèque système, Rails ne boote pas du tout (`LoadError: Could not open library 'libvips.so.42'`). Le paquet est installé avec un repli sur l'ancien nom, la transition `time_t` 64 bits d'Ubuntu 24.04 ayant renommé `libvips42` en `libvips42t64`.
- **Les variables d'environnement du boot.** En local elles viennent de `.env` (dotenv, non versionné), et trois d'entre elles sont lues par `ENV.fetch` **sans valeur par défaut** : `POSTMARK_API_TOKEN` (`config/application.rb:44`), `STRIPE_API_KEY` (`config/initializers/stripe.rb:1`) et `PHONE_NUMBER` (deux vues publiques). Sans elles : `KeyError` au boot. Le workflow fournit des valeurs factices — rien n'est appelé pour de vrai, `delivery_method` est à `:test`. Aucun `ENV.fetch` applicatif n'a été assoupli : le garde-fou qui fait planter la production sans token reste intact.

Les versions de Ruby et de Node sont lues depuis `.ruby-version` et `.tool-versions` plutôt que codées en dur dans le workflow — comme ça les phases 4 et 7 (montées de Ruby) n'auront pas à penser à modifier le CI en plus des fichiers de version.

**Trois déminages du `Gemfile`**, chacun correspondant à un piège vérifié en bac à sable avant l'écriture du plan :

- `gem "stripe"` → `gem "stripe", "~> 10.13"`. Sans ce pin, chaque `bundle update` des phases suivantes propulsait la gem de 10.13 à 19.3.1 — neuf versions majeures sur le chemin des paiements, à l'insu de tout le monde. La montée Stripe est un chantier séparé, hors périmètre de l'epic.
- Suppression de `gem "webdrivers"` (groupe `:test`). Gem dépréciée, remplacée par Selenium Manager intégré à `selenium-webdriver` depuis la 4.11 — et c'est elle qui plafonnait `selenium-webdriver` sous 4.11 (rétrogradation observée de 4.5.0 à 4.1.0 lors de la résolution vers Rails 8.1). Zéro référence dans `spec/`, et il n'existe aucun `spec/system`.
- Suppression de `gem "sqlite3"` (groupe `:development, :test`). Zéro référence dans le code, `config/database.yml` est en PostgreSQL sur les trois environnements.

**Et un peu de ménage :** suppression de `config/initializers/dartsass.rb`, fichier entièrement commenté dont la gem (`dartsass-rails`) est elle-même commentée dans le `Gemfile`.

## Vérification

**Sur le runner GitHub** (run [30505637223](https://github.com/les4sources/claudy/actions/runs/30505637223), vert) : `1423 examples, 0 failures, 16 pending` en 56,6 s.

**En local**, deux passages : d'abord avec `CI=1` (donc `config.eager_load = true`, comme sur le runner), puis une seconde fois avec les valeurs d'environnement exactes du workflow plutôt que celles du `.env` de la machine. Les deux : `1423 examples, 0 failures, 16 pending`. Exactement le socle annoncé dans l'epic, aucun spec supprimé ni skippé.

Critères de la phase, un par un :

- [x] le workflow CI existe **et passe au vert sur cette PR**
- [x] `bundle exec rspec` reste à 0 échec
- [x] `Gemfile.lock` ne contient plus `webdrivers` ni `sqlite3`
- [x] `selenium-webdriver` n'a pas été rétrogradé — toujours en `4.5.0`
- [x] `stripe` toujours en `10.13.0`, `rails` toujours en `7.0.4`, Ruby toujours en 3.1.2

## Ce qui n'a pas pu être testé

- **Aucune capture d'écran** : cette phase ne touche à aucun rendu visible — un workflow CI, trois lignes de `Gemfile` et un initializer entièrement commenté. Rien à montrer en pixels.
- **Le repli `libvips42`** (le `||` du second `apt-get`) n'a jamais été emprunté : `libvips42t64` existe sur l'image `ubuntu-latest` actuelle, donc la branche de secours reste non exercée. Elle ne servira que si GitHub revient à une image plus ancienne.
- **Le déclencheur `push` vers `main`** n'a pas été éprouvé : seul le déclencheur `pull_request` a tourné jusqu'ici. Il ne sera exercé qu'au merge de cette PR.
- **La montée de `stripe`** reste volontairement non testée puisqu'elle est explicitement hors périmètre : le pin la gèle, il ne la valide pas.
- **Aucune vérification navigateur** dans cette phase — l'epic la réserve aux phases 3 et 6, celles qui touchent au rendu.

## Point à valider

Le CI est posé mais **il ne bloque pas encore la fusion** : il faut le déclarer comme *required status check* dans les réglages de branche de `main` (Settings → Branches → règle de protection). La *Definition of Done* de l'epic l'exige (« le workflow CI existe et bloque la fusion en cas d'échec ») — c'est un réglage GitHub, pas du code, donc il reste à faire à la main.

Refs #144
