### PR TITLE
Refs #144 — ruby-vips en transitif : déblocage du deploy production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,16 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # `ruby-vips` est requis dès config/application.rb : sans la bibliothèque système,
-      # Rails ne boote pas du tout (LoadError sur libvips.so.42). Le nom du paquet a changé
-      # avec la transition time_t 64 bits d'Ubuntu 24.04 (libvips42 -> libvips42t64), d'où
-      # le repli sur l'ancien nom.
-      - name: Installer libvips
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libvips42t64 \
-            || sudo apt-get install -y --no-install-recommends libvips42
-
+      # Pas de libvips : comme en production (Ubuntu 22.04, libvips 8.12 retiré — trop
+      # vieux pour la garde de sécurité d'Active Storage 8.1.3.1). ruby-vips n'est plus
+      # qu'une dépendance transitive de image_processing, jamais requise par Bundler ;
+      # Active Storage rescue son LoadError et analyse via ImageMagick, présent sur les
+      # runners comme sur le serveur.
       - name: Installer Ruby et les gems
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,11 @@ gem "bootsnap", require: false
 # gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
+# NB : image_processing tire ruby-vips en dépendance transitive — c'est voulu qu'il ne soit
+# PAS listé ici en direct. Une entrée directe le ferait charger par Bundler.require, qui
+# enveloppe tout échec en GemRequireError fatale ; en transitif, seul Active Storage le
+# require, et il rescue proprement l'absence de libvips (retiré du serveur : 8.12 < 8.13
+# exigé par la garde de sécurité de Rails 8.1.3.1 ; les uploaders sont MiniMagick).
 gem "image_processing", "~> 1.2"
 
 gem "dotenv-rails", groups: [:development, :test]
@@ -71,7 +76,6 @@ gem "money-rails", "~>1.12"
 gem "paper_trail"
 gem "postmark-rails"
 gem "public_activity"
-gem "ruby-vips"
 gem "sentry-ruby"
 gem "sentry-rails"
 gem "simple_calendar", "~> 2.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,6 @@ GEM
     dry-cli (1.4.1)
     erb (6.0.6)
     erubi (1.13.1)
-    ffi (1.17.4)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -446,7 +445,6 @@ DEPENDENCIES
   rails (~> 8.1.0)
   redis (~> 5.0)
   rspec-rails (~> 8.0)
-  ruby-vips
   selenium-webdriver
   sentry-rails
   sentry-ruby


### PR DESCRIPTION
Suivi du premier deploy échoué de l'epic #144 — la garde libvips d'Active Storage 8.1.3.1. Diagnostic, preuve du mécanisme (Bundler.require vs rescue d'Active Storage, vérifié dans le release échoué sur le serveur), retrait de l'entrée directe ruby-vips, CI alignée sur la prod (sans libvips). Détail complet dans le message de commit. Suite : 1428/0.